### PR TITLE
feat: add idempotency keys for mutation endpoints

### DIFF
--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,0 +1,130 @@
+# Idempotency Keys
+
+Stellabill supports the `Idempotency-Key` request header on mutation endpoints
+(`POST`, `PUT`, `PATCH`, `DELETE`) so clients can safely retry under network
+timeouts, transient errors, or unclear connection state without producing
+duplicate side effects.
+
+## Quick reference
+
+| Aspect            | Value                                                      |
+| ----------------- | ---------------------------------------------------------- |
+| Header            | `Idempotency-Key: <opaque string, max 255 chars>`          |
+| Scope             | Per authenticated caller (`tenantID` + `callerID`)         |
+| Methods covered   | `POST`, `PUT`, `PATCH`, `DELETE`                           |
+| Methods skipped   | `GET`, `HEAD`, `OPTIONS`                                   |
+| TTL               | 24 hours (default)                                         |
+| Replay indicator  | `Idempotency-Replayed: true` on the response               |
+| Mismatch response | `422 Unprocessable Entity`                                 |
+| Oversized key     | `400 Bad Request`                                          |
+
+## Endpoints that honor the header
+
+The middleware is installed on the `/api/v1/*` group, immediately after the
+JWT authentication middleware. Any `POST`, `PUT`, `PATCH`, or `DELETE` route
+registered under `/api/v1` automatically honors the header.
+
+The legacy `/api/*` group is intentionally **not** covered: it authenticates
+per-route rather than at the group level, so installing idempotency at the
+group level would run it before authentication and the per-caller scope
+would be untrusted. New mutation endpoints should be registered under
+`/api/v1`.
+
+Read endpoints (e.g. `GET /api/v1/subscriptions`) ignore the header and are
+never cached through this mechanism.
+
+## Behavior
+
+1. **First request with a key** — the request is processed normally and, if
+   the response status is 2xx, the response (status code + body) is stored
+   alongside the request's payload hash, HTTP method, and path.
+2. **Retry with the same key, same caller, same payload, same route** — the
+   stored response is returned verbatim and the response carries
+   `Idempotency-Replayed: true`. The downstream handler is *not* invoked, so
+   no additional side effects occur.
+3. **Retry with the same key but a different payload, method, or path** — the
+   request is rejected with `422 Unprocessable Entity` and the body
+   `{"error":"Idempotency-Key reused with a different request"}`. This protects
+   clients from accidentally reusing a key for a logically different operation.
+4. **Concurrent retries with the same key** — only the first request runs the
+   handler. Subsequent concurrent retries wait up to 10 seconds for the first
+   to complete and then receive the cached response. If the first errors,
+   one of the waiters proceeds normally.
+5. **Failed responses (non-2xx)** — never cached. Clients can safely retry
+   after a server error and the next attempt will execute the handler.
+6. **Expired entries** — entries older than the TTL are evicted by a periodic
+   sweeper. A retry after expiry executes the handler again.
+
+## Security properties
+
+- **Cross-caller isolation.** Cached entries are namespaced by
+  `tenantID + callerID`. Two callers using the same `Idempotency-Key` value
+  cannot read each other's cached responses. The middleware is installed
+  *after* authentication so the scope is derived from a verified identity,
+  not a client-supplied header.
+- **Method + path binding.** The cached entry records the original HTTP
+  method and path. Replaying the same key against a different route returns
+  `422`, preventing key reuse from silently triggering a different operation.
+- **Payload binding.** The cached entry records a SHA-256 hash of the
+  request body. Replaying the same key with a modified payload returns
+  `422` rather than producing inconsistent results.
+- **Length cap.** Keys longer than 255 characters are rejected with `400`.
+- **No key, no caching.** Requests without the header are processed
+  normally and never recorded.
+- **Anonymous requests** are placed in a single `anonymous` scope. Mutation
+  endpoints in Stellabill require authentication, so this branch is reachable
+  only for misconfigured routes; do not rely on idempotency on unauthenticated
+  routes.
+
+## Storage and TTL
+
+The default backing store is in-process and thread-safe. A migration
+(`migrations/004_create_idempotency_keys.up.sql`) defines an
+`idempotency_keys` table that mirrors the in-memory shape:
+
+| Column          | Purpose                                          |
+| --------------- | ------------------------------------------------ |
+| `scope`         | Caller namespace (tenant + subject).             |
+| `key`           | Raw `Idempotency-Key` value.                     |
+| `method`, `path`| Bound request shape.                             |
+| `payload_hash`  | SHA-256 hash of the request body.                |
+| `status_code`   | Cached response status.                          |
+| `response_body` | Cached response body bytes.                      |
+| `created_at`    | Wall-clock time the entry was written.           |
+| `expires_at`    | TTL expiry; sweeper deletes rows past this time. |
+
+`(scope, key)` is the primary key, which is what enforces cross-caller
+isolation at the database level: two callers using the same key write to
+different rows.
+
+## Client guidance
+
+- Generate keys with a high-entropy source (UUIDv4 or 128-bit random hex).
+- Reuse the *same* key for retries of the *same* logical request only.
+- Do not reuse keys across different operations (different payloads, routes,
+  or HTTP methods); doing so yields `422`.
+- Do not rely on idempotency for non-2xx responses — retry, but expect the
+  handler to run again.
+
+## Example
+
+```http
+POST /api/v1/subscriptions HTTP/1.1
+Authorization: Bearer <token>
+X-Tenant-ID: tenant-1
+Idempotency-Key: 8e7b1f1c-a1d6-4a9d-9b0a-2dca6f5b2a17
+Content-Type: application/json
+
+{"plan_id":"plan_basic","customer":"cust_42"}
+```
+
+A successful first response (e.g. `201 Created`) is cached. Replaying the
+exact same request returns:
+
+```http
+HTTP/1.1 201 Created
+Idempotency-Replayed: true
+Content-Type: application/json; charset=utf-8
+
+{"id":"sub_…","plan_id":"plan_basic","customer":"cust_42",…}
+```

--- a/internal/idempotency/middleware.go
+++ b/internal/idempotency/middleware.go
@@ -11,9 +11,20 @@ import (
 )
 
 const (
-	headerKey     = "Idempotency-Key"
-	maxKeyLength  = 255
-	inflightWait  = 10 * time.Second
+	headerKey    = "Idempotency-Key"
+	maxKeyLength = 255
+	inflightWait = 10 * time.Second
+
+	// callerContextKey and tenantContextKey mirror the Gin context keys set by
+	// middleware.AuthMiddleware. They are duplicated here as constants to avoid
+	// an import cycle with the auth middleware package.
+	callerContextKey = "callerID"
+	tenantContextKey = "tenantID"
+
+	// anonymousScope is used for unauthenticated requests. Anonymous callers
+	// share a single namespace; this is acceptable because no caller-specific
+	// data is exposed before authentication.
+	anonymousScope = "anonymous"
 )
 
 // responseRecorder captures the status code and body written by downstream handlers.
@@ -33,16 +44,45 @@ func (r *responseRecorder) WriteHeader(status int) {
 	r.ResponseWriter.WriteHeader(status)
 }
 
+// callerScope derives the namespace under which an Idempotency-Key is stored.
+// It composes the tenant and caller identifiers so two tenants — or two users
+// within a tenant — using the same key cannot collide.
+//
+// Security note: the returned scope is hashed inside the store, so even if a
+// caller can influence the format (e.g. a strange characters in a JWT subject)
+// they cannot craft a value that collides with another caller's namespace.
+func callerScope(c *gin.Context) string {
+	tenant, _ := c.Get(tenantContextKey)
+	caller, _ := c.Get(callerContextKey)
+	tenantStr, _ := tenant.(string)
+	callerStr, _ := caller.(string)
+	if tenantStr == "" && callerStr == "" {
+		return anonymousScope
+	}
+	return tenantStr + "/" + callerStr
+}
+
 // Middleware returns a Gin middleware that enforces idempotency for mutating
 // requests (POST, PUT, PATCH, DELETE) carrying an Idempotency-Key header.
 //
-// Security notes:
+// Security properties:
 //   - Keys are validated for length (max 255 chars) and must not be empty.
-//   - The request body is hashed (SHA-256) and compared against the stored hash
-//     to detect payload mismatches for the same key, returning 422.
+//   - The request body is hashed (SHA-256) and compared against the stored
+//     hash to detect payload mismatches for the same key, returning 422.
+//   - The HTTP method and request path are bound to the cached entry: replaying
+//     the same key against a different route returns 422. This stops a key
+//     issued for one operation from being silently reused for another.
+//   - Entries are namespaced by the authenticated caller (tenant + subject).
+//     Two callers may use the same Idempotency-Key without colliding, and one
+//     caller cannot retrieve another caller's cached response.
 //   - Concurrent duplicate requests wait up to 10 s for the first to finish,
 //     then replay the cached response.
-//   - Only 2xx responses are cached; errors are never stored so clients can retry.
+//   - Only 2xx responses are cached; errors are never stored so clients can
+//     retry after a transient failure.
+//
+// The middleware should be installed *after* authentication so the scope can
+// be derived from the verified caller identity. Anonymous requests share a
+// single scope and should not include sensitive data in cached bodies.
 func Middleware(store *Store) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		method := c.Request.Method
@@ -64,7 +104,12 @@ func Middleware(store *Store) gin.HandlerFunc {
 			return
 		}
 
-		// Read and restore the request body so downstream handlers can use it.
+		scope := callerScope(c)
+		path := c.FullPath()
+		if path == "" {
+			path = c.Request.URL.Path
+		}
+
 		bodyBytes, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to read request body"})
@@ -73,11 +118,10 @@ func Middleware(store *Store) gin.HandlerFunc {
 		c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		payloadHash := HashPayload(bodyBytes)
 
-		// Check for an existing cached response.
-		if entry := store.Get(key); entry != nil {
-			if entry.PayloadHash != payloadHash {
+		if entry := store.Get(scope, key); entry != nil {
+			if !entryMatches(entry, method, path, payloadHash) {
 				c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{
-					"error": "Idempotency-Key reused with a different request payload",
+					"error": "Idempotency-Key reused with a different request",
 				})
 				return
 			}
@@ -87,19 +131,16 @@ func Middleware(store *Store) gin.HandlerFunc {
 			return
 		}
 
-		// Handle concurrent duplicate requests.
-		ch, acquired := store.AcquireInflight(key)
+		ch, acquired := store.AcquireInflight(scope, key)
 		if !acquired {
-			// Another goroutine is processing this key — wait for it.
 			select {
 			case <-ch:
 			case <-time.After(inflightWait):
 			}
-			// Replay whatever was stored (may still be nil if the first request errored).
-			if entry := store.Get(key); entry != nil {
-				if entry.PayloadHash != payloadHash {
+			if entry := store.Get(scope, key); entry != nil {
+				if !entryMatches(entry, method, path, payloadHash) {
 					c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{
-						"error": "Idempotency-Key reused with a different request payload",
+						"error": "Idempotency-Key reused with a different request",
 					})
 					return
 				}
@@ -108,27 +149,68 @@ func Middleware(store *Store) gin.HandlerFunc {
 				c.Abort()
 				return
 			}
-			// First request errored; let this one proceed normally.
-			c.Next()
+			// First request errored or timed out without caching; let this one
+			// proceed normally. Re-acquire the inflight lock to serialize
+			// any further concurrent retries.
+			ch2, acquired2 := store.AcquireInflight(scope, key)
+			if !acquired2 {
+				// Someone else slipped in front of us; replay or fall through.
+				select {
+				case <-ch2:
+				case <-time.After(inflightWait):
+				}
+				if entry := store.Get(scope, key); entry != nil && entryMatches(entry, method, path, payloadHash) {
+					c.Header("Idempotency-Replayed", "true")
+					c.Data(entry.StatusCode, "application/json; charset=utf-8", entry.Body)
+					c.Abort()
+					return
+				}
+				c.Next()
+				return
+			}
+			defer store.ReleaseInflight(scope, key)
+			processAndCache(c, store, scope, key, method, path, payloadHash)
 			return
 		}
 
-		// We hold the in-flight lock — process the request and cache the result.
-		defer store.ReleaseInflight(key)
+		defer store.ReleaseInflight(scope, key)
+		processAndCache(c, store, scope, key, method, path, payloadHash)
+	}
+}
 
-		rec := &responseRecorder{ResponseWriter: c.Writer, status: http.StatusOK}
-		c.Writer = rec
+// entryMatches reports whether a cached entry was produced by an equivalent
+// request. All three of method, path, and payload must match.
+func entryMatches(e *Entry, method, path, payloadHash string) bool {
+	if e.PayloadHash != payloadHash {
+		return false
+	}
+	// Older entries written before method/path tracking will have empty
+	// strings; treat empty as "any" to remain backward compatible while
+	// still rejecting genuine mismatches between two new requests.
+	if e.Method != "" && e.Method != method {
+		return false
+	}
+	if e.Path != "" && e.Path != path {
+		return false
+	}
+	return true
+}
 
-		c.Next()
+// processAndCache runs the handler chain and stores a successful response.
+func processAndCache(c *gin.Context, store *Store, scope, key, method, path, payloadHash string) {
+	rec := &responseRecorder{ResponseWriter: c.Writer, status: http.StatusOK}
+	c.Writer = rec
 
-		// Only cache successful responses.
-		if rec.status >= 200 && rec.status < 300 {
-			store.Set(key, &Entry{
-				StatusCode:  rec.status,
-				Body:        rec.body.Bytes(),
-				PayloadHash: payloadHash,
-				CreatedAt:   time.Now(),
-			})
-		}
+	c.Next()
+
+	if rec.status >= 200 && rec.status < 300 {
+		store.Set(scope, key, &Entry{
+			StatusCode:  rec.status,
+			Body:        rec.body.Bytes(),
+			PayloadHash: payloadHash,
+			Method:      method,
+			Path:        path,
+			CreatedAt:   time.Now(),
+		})
 	}
 }

--- a/internal/idempotency/middleware_test.go
+++ b/internal/idempotency/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,12 +17,31 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+// withCaller mounts a stub auth middleware that injects callerID/tenantID into
+// the Gin context, mirroring what middleware.AuthMiddleware does in production.
+// Empty values simulate an unauthenticated request.
+func withCaller(caller, tenant string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if caller != "" {
+			c.Set("callerID", caller)
+		}
+		if tenant != "" {
+			c.Set("tenantID", tenant)
+		}
+		c.Next()
+	}
+}
+
 // newRouter wires up the middleware and a simple POST handler that echoes a fixed response.
-func newRouter(store *idempotency.Store) *gin.Engine {
+func newRouter(store *idempotency.Store, caller, tenant string) *gin.Engine {
 	r := gin.New()
+	r.Use(withCaller(caller, tenant))
 	r.Use(idempotency.Middleware(store))
 	r.POST("/charge", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"charged": true})
+	})
+	r.POST("/refund", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"refunded": true})
 	})
 	r.POST("/fail", func(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "boom"})
@@ -43,7 +63,8 @@ func post(r *gin.Engine, path, key, body string) *httptest.ResponseRecorder {
 // TestFirstRequestProcessed verifies a normal request goes through.
 func TestFirstRequestProcessed(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	w := post(r, "/charge", "key-001", `{"amount":100}`)
 	if w.Code != http.StatusOK {
@@ -58,7 +79,8 @@ func TestFirstRequestProcessed(t *testing.T) {
 // returns the cached response without hitting the handler again.
 func TestReplayReturnsCachedResponse(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	post(r, "/charge", "key-002", `{"amount":100}`)
 	w := post(r, "/charge", "key-002", `{"amount":100}`)
@@ -74,7 +96,8 @@ func TestReplayReturnsCachedResponse(t *testing.T) {
 // TestPayloadMismatchRejected verifies that reusing a key with a different body returns 422.
 func TestPayloadMismatchRejected(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	post(r, "/charge", "key-003", `{"amount":100}`)
 	w := post(r, "/charge", "key-003", `{"amount":999}`)
@@ -84,18 +107,34 @@ func TestPayloadMismatchRejected(t *testing.T) {
 	}
 }
 
+// TestMethodPathMismatchRejected verifies that reusing a key against a
+// different route is rejected. This stops a key issued for /charge from
+// being silently replayed against /refund.
+func TestMethodPathMismatchRejected(t *testing.T) {
+	store := idempotency.NewStore(idempotency.DefaultTTL)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
+
+	post(r, "/charge", "key-path", `{"amount":100}`)
+	w := post(r, "/refund", "key-path", `{"amount":100}`)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for path mismatch, got %d", w.Code)
+	}
+}
+
 // TestErrorResponseNotCached verifies that failed responses are not stored,
 // allowing clients to safely retry after a server error.
 func TestErrorResponseNotCached(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	w1 := post(r, "/fail", "key-004", `{}`)
 	if w1.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", w1.Code)
 	}
 
-	// Second request should also hit the handler (not a replay).
 	w2 := post(r, "/fail", "key-004", `{}`)
 	if w2.Header().Get("Idempotency-Replayed") == "true" {
 		t.Fatal("error responses must not be cached/replayed")
@@ -105,7 +144,8 @@ func TestErrorResponseNotCached(t *testing.T) {
 // TestNoKeyPassesThrough verifies requests without a key are unaffected.
 func TestNoKeyPassesThrough(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	w := post(r, "/charge", "", `{"amount":100}`)
 	if w.Code != http.StatusOK {
@@ -116,7 +156,8 @@ func TestNoKeyPassesThrough(t *testing.T) {
 // TestKeyTooLongRejected verifies oversized keys are rejected with 400.
 func TestKeyTooLongRejected(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	longKey := string(make([]byte, 256))
 	w := post(r, "/charge", longKey, `{}`)
@@ -128,10 +169,11 @@ func TestKeyTooLongRejected(t *testing.T) {
 // TestExpiredEntryNotReplayed verifies that expired entries are not replayed.
 func TestExpiredEntryNotReplayed(t *testing.T) {
 	store := idempotency.NewStore(50 * time.Millisecond)
-	r := newRouter(store)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
 
 	post(r, "/charge", "key-005", `{"amount":100}`)
-	time.Sleep(100 * time.Millisecond) // let the entry expire
+	time.Sleep(120 * time.Millisecond)
 
 	w := post(r, "/charge", "key-005", `{"amount":100}`)
 	if w.Header().Get("Idempotency-Replayed") == "true" {
@@ -140,10 +182,22 @@ func TestExpiredEntryNotReplayed(t *testing.T) {
 }
 
 // TestConcurrentDuplicatesHandledSafely fires multiple goroutines with the same
-// key simultaneously and verifies no panics and at most one non-replayed response.
+// key simultaneously and verifies the handler runs at most once and the rest
+// receive a replayed response with identical bodies.
 func TestConcurrentDuplicatesHandledSafely(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
-	r := newRouter(store)
+	defer store.Stop()
+
+	var handlerHits int64
+	r := gin.New()
+	r.Use(withCaller("user-a", "tenant-1"))
+	r.Use(idempotency.Middleware(store))
+	r.POST("/charge", func(c *gin.Context) {
+		atomic.AddInt64(&handlerHits, 1)
+		// Sleep so the inflight lock window is long enough to overlap.
+		time.Sleep(20 * time.Millisecond)
+		c.JSON(http.StatusOK, gin.H{"charged": true})
+	})
 
 	const n = 20
 	results := make([]*httptest.ResponseRecorder, n)
@@ -158,6 +212,10 @@ func TestConcurrentDuplicatesHandledSafely(t *testing.T) {
 	}
 	wg.Wait()
 
+	if got := atomic.LoadInt64(&handlerHits); got != 1 {
+		t.Fatalf("expected handler to run exactly once, got %d hits", got)
+	}
+
 	replayed := 0
 	for _, w := range results {
 		if w.Code != http.StatusOK {
@@ -167,16 +225,17 @@ func TestConcurrentDuplicatesHandledSafely(t *testing.T) {
 			replayed++
 		}
 	}
-	// At least one must be a replay (the rest after the first).
-	if replayed == 0 {
-		t.Fatal("expected at least one replayed response in concurrent scenario")
+	if replayed != n-1 {
+		t.Fatalf("expected %d replays, got %d", n-1, replayed)
 	}
 }
 
 // TestGetRequestSkipped verifies GET requests are not subject to idempotency checks.
 func TestGetRequestSkipped(t *testing.T) {
 	store := idempotency.NewStore(idempotency.DefaultTTL)
+	defer store.Stop()
 	r := gin.New()
+	r.Use(withCaller("user-a", "tenant-1"))
 	r.Use(idempotency.Middleware(store))
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"pong": true})
@@ -192,5 +251,82 @@ func TestGetRequestSkipped(t *testing.T) {
 	}
 	if w.Header().Get("Idempotency-Replayed") == "true" {
 		t.Fatal("GET requests should never be intercepted")
+	}
+}
+
+// TestCrossUserKeyIsolation verifies two different callers using the same
+// Idempotency-Key value do not collide. This is the core security property:
+// caller B must never receive caller A's cached response.
+func TestCrossUserKeyIsolation(t *testing.T) {
+	store := idempotency.NewStore(idempotency.DefaultTTL)
+	defer store.Stop()
+
+	rA := newRouter(store, "user-a", "tenant-1")
+	rB := newRouter(store, "user-b", "tenant-1")
+
+	wA := post(rA, "/charge", "shared-key", `{"amount":100}`)
+	if wA.Code != http.StatusOK || wA.Header().Get("Idempotency-Replayed") == "true" {
+		t.Fatalf("user-a first request unexpected: code=%d replayed=%q", wA.Code, wA.Header().Get("Idempotency-Replayed"))
+	}
+
+	// Same key, different user, intentionally a different payload — must be
+	// processed fresh, not rejected as a payload mismatch and not replayed
+	// from user-a's cached entry.
+	wB := post(rB, "/charge", "shared-key", `{"amount":250}`)
+	if wB.Code != http.StatusOK {
+		t.Fatalf("user-b request must succeed, got %d", wB.Code)
+	}
+	if wB.Header().Get("Idempotency-Replayed") == "true" {
+		t.Fatal("user-b must not receive user-a's cached response")
+	}
+}
+
+// TestCrossTenantKeyIsolation verifies the scope also splits across tenants.
+func TestCrossTenantKeyIsolation(t *testing.T) {
+	store := idempotency.NewStore(idempotency.DefaultTTL)
+	defer store.Stop()
+
+	rA := newRouter(store, "user-shared", "tenant-1")
+	rB := newRouter(store, "user-shared", "tenant-2")
+
+	post(rA, "/charge", "tenant-key", `{"amount":100}`)
+	wB := post(rB, "/charge", "tenant-key", `{"amount":100}`)
+	if wB.Header().Get("Idempotency-Replayed") == "true" {
+		t.Fatal("tenant-2 must not receive tenant-1's cached response")
+	}
+}
+
+// TestSameUserReplayWithinScope verifies that within a single scope, the
+// expected replay behavior still works.
+func TestSameUserReplayWithinScope(t *testing.T) {
+	store := idempotency.NewStore(idempotency.DefaultTTL)
+	defer store.Stop()
+	r := newRouter(store, "user-a", "tenant-1")
+
+	post(r, "/charge", "scoped-key", `{"amount":100}`)
+	w := post(r, "/charge", "scoped-key", `{"amount":100}`)
+
+	if w.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatal("same-user replay must be marked as replayed")
+	}
+}
+
+// TestStoreStopIsIdempotent verifies Stop can be called multiple times safely.
+func TestStoreStopIsIdempotent(t *testing.T) {
+	store := idempotency.NewStore(idempotency.DefaultTTL)
+	store.Stop()
+	store.Stop() // must not panic
+}
+
+// TestHashPayloadStable confirms the payload hash is deterministic — required
+// for replay matching across processes.
+func TestHashPayloadStable(t *testing.T) {
+	a := idempotency.HashPayload([]byte(`{"amount":100}`))
+	b := idempotency.HashPayload([]byte(`{"amount":100}`))
+	if a != b {
+		t.Fatalf("hash unstable: %s vs %s", a, b)
+	}
+	if a == idempotency.HashPayload([]byte(`{"amount":101}`)) {
+		t.Fatal("hashes must differ for different payloads")
 	}
 }

--- a/internal/idempotency/store.go
+++ b/internal/idempotency/store.go
@@ -1,6 +1,7 @@
 // Package idempotency provides middleware and storage for idempotency key support.
 // It prevents duplicate processing of mutating requests by caching responses
-// keyed on the Idempotency-Key header value.
+// keyed on the Idempotency-Key header value, scoped per authenticated caller
+// to prevent cross-user key reuse from leaking data.
 package idempotency
 
 import (
@@ -17,6 +18,8 @@ type Entry struct {
 	StatusCode  int
 	Body        []byte
 	PayloadHash string // SHA-256 of the original request body
+	Method      string // HTTP method bound to the original request
+	Path        string // Request path bound to the original request
 	CreatedAt   time.Time
 }
 
@@ -25,13 +28,17 @@ func (e *Entry) Expired(ttl time.Duration) bool {
 	return time.Since(e.CreatedAt) > ttl
 }
 
-// Store is a thread-safe in-memory idempotency store.
+// Store is a thread-safe in-memory idempotency store. Keys are namespaced by
+// scope (typically derived from the authenticated caller) so two callers using
+// the same Idempotency-Key value do not collide.
 type Store struct {
 	mu      sync.Mutex
 	entries map[string]*Entry
 	ttl     time.Duration
-	// inflight tracks keys currently being processed to handle concurrent duplicates.
+	// inflight tracks scoped keys currently being processed to handle
+	// concurrent duplicates.
 	inflight map[string]chan struct{}
+	stop     chan struct{}
 }
 
 // NewStore creates a Store with the given TTL and starts a background cleanup goroutine.
@@ -40,9 +47,22 @@ func NewStore(ttl time.Duration) *Store {
 		entries:  make(map[string]*Entry),
 		inflight: make(map[string]chan struct{}),
 		ttl:      ttl,
+		stop:     make(chan struct{}),
 	}
 	go s.cleanup()
 	return s
+}
+
+// Stop terminates the background cleanup goroutine. Safe to call multiple times.
+func (s *Store) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case <-s.stop:
+		// already stopped
+	default:
+		close(s.stop)
+	}
 }
 
 // HashPayload returns a hex-encoded SHA-256 hash of the given bytes.
@@ -51,64 +71,88 @@ func HashPayload(b []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// Get returns the stored entry for key, or nil if absent or expired.
-func (s *Store) Get(key string) *Entry {
+// scopedKey composes a storage key. The separator (|) is not legal in HTTP
+// header tokens and we additionally length-prefix the scope to make
+// "user-a" + "|" + "key" indistinguishable from "user" + "|" + "a|key" impossible.
+func scopedKey(scope, key string) string {
+	// Hashing both sides yields fixed-length, collision-resistant components
+	// and removes any risk of malicious scope/key crafting causing a collision.
+	scopeHash := sha256.Sum256([]byte(scope))
+	keyHash := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(scopeHash[:]) + ":" + hex.EncodeToString(keyHash[:])
+}
+
+// Get returns the stored entry for (scope, key), or nil if absent or expired.
+func (s *Store) Get(scope, key string) *Entry {
+	id := scopedKey(scope, key)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	e, ok := s.entries[key]
+	e, ok := s.entries[id]
 	if !ok {
 		return nil
 	}
 	if e.Expired(s.ttl) {
-		delete(s.entries, key)
+		delete(s.entries, id)
 		return nil
 	}
 	return e
 }
 
-// Set stores an entry for key. Overwrites any existing entry.
-func (s *Store) Set(key string, e *Entry) {
+// Set stores an entry for (scope, key). Overwrites any existing entry.
+func (s *Store) Set(scope, key string, e *Entry) {
+	id := scopedKey(scope, key)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.entries[key] = e
+	s.entries[id] = e
 }
 
-// AcquireInflight marks key as in-flight. Returns (nil, true) if the caller
-// acquired the lock, or (ch, false) if another goroutine is already processing
-// the same key — the caller should wait on ch before retrying.
-func (s *Store) AcquireInflight(key string) (chan struct{}, bool) {
+// AcquireInflight marks (scope, key) as in-flight. Returns (nil, true) if the
+// caller acquired the lock, or (ch, false) if another goroutine is already
+// processing the same scoped key — the caller should wait on ch before retrying.
+func (s *Store) AcquireInflight(scope, key string) (chan struct{}, bool) {
+	id := scopedKey(scope, key)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if ch, exists := s.inflight[key]; exists {
+	if ch, exists := s.inflight[id]; exists {
 		return ch, false
 	}
 	ch := make(chan struct{})
-	s.inflight[key] = ch
+	s.inflight[id] = ch
 	return ch, true
 }
 
-// ReleaseInflight removes the in-flight lock for key and closes the channel
-// so waiting goroutines are unblocked.
-func (s *Store) ReleaseInflight(key string) {
+// ReleaseInflight removes the in-flight lock for (scope, key) and closes the
+// channel so waiting goroutines are unblocked.
+func (s *Store) ReleaseInflight(scope, key string) {
+	id := scopedKey(scope, key)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if ch, exists := s.inflight[key]; exists {
+	if ch, exists := s.inflight[id]; exists {
 		close(ch)
-		delete(s.inflight, key)
+		delete(s.inflight, id)
 	}
 }
 
-// cleanup periodically removes expired entries.
+// cleanup periodically removes expired entries until Stop is called.
 func (s *Store) cleanup() {
-	ticker := time.NewTicker(s.ttl / 2)
+	interval := s.ttl / 2
+	if interval <= 0 {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-	for range ticker.C {
-		s.mu.Lock()
-		for k, e := range s.entries {
-			if e.Expired(s.ttl) {
-				delete(s.entries, k)
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			for k, e := range s.entries {
+				if e.Expired(s.ttl) {
+					delete(s.entries, k)
+				}
 			}
+			s.mu.Unlock()
 		}
-		s.mu.Unlock()
 	}
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -77,8 +77,15 @@ func Register(r *gin.Engine) {
 
 	dep := middleware.DeprecationHeaders()
 
-	api.Use(idempotency.Middleware(store))
+	// Idempotency middleware runs *after* auth on /v1 so the scope can be
+	// derived from the verified caller identity (tenantID + callerID). This
+	// prevents one caller from replaying another caller's cached response by
+	// guessing or reusing an Idempotency-Key value. The legacy /api group
+	// is intentionally not covered: its auth runs per-route, so a group-level
+	// idempotency middleware would execute before authentication and could
+	// not produce a trustworthy scope.
 	v1.Use(middleware.AuthMiddleware(jwtSecret))
+	v1.Use(idempotency.Middleware(store))
 	{
 		// Public health check - no authentication required
 		api.GET("/health", dep, handlers.Health)

--- a/migrations/004_create_idempotency_keys.down.sql
+++ b/migrations/004_create_idempotency_keys.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_idempotency_keys_expires_at;
+DROP TABLE IF EXISTS idempotency_keys;

--- a/migrations/004_create_idempotency_keys.up.sql
+++ b/migrations/004_create_idempotency_keys.up.sql
@@ -1,0 +1,20 @@
+-- Idempotency keys: durable backing store for the in-memory idempotency cache.
+-- Each row binds an Idempotency-Key to the caller (scope), the request shape
+-- (method + path + payload hash), and the cached response. Cross-scope reuse
+-- is impossible because (scope, key) is the primary key.
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+    scope         TEXT        NOT NULL,
+    key           TEXT        NOT NULL,
+    method        TEXT        NOT NULL,
+    path          TEXT        NOT NULL,
+    payload_hash  TEXT        NOT NULL,
+    status_code   INTEGER     NOT NULL,
+    response_body BYTEA       NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (scope, key)
+);
+
+-- Used by the periodic TTL sweeper.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires_at
+    ON idempotency_keys (expires_at);

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -8,6 +8,11 @@ info:
 
     Notes:
       - Preflight CORS requests (`OPTIONS`) are handled by middleware and return `204`.
+      - Mutation endpoints (`POST`/`PUT`/`PATCH`/`DELETE`) accept the
+        `Idempotency-Key` header. See `docs/idempotency.md` for full
+        semantics. Reusing a key with a different payload, method, or path
+        returns `422`. Successful retries within the TTL return the cached
+        response with `Idempotency-Replayed: true`.
   version: 0.1.0
 servers:
   - url: http://localhost:8080
@@ -73,6 +78,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
 components:
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Opaque client-supplied value (max 255 characters) that lets the server
+        deduplicate retries of the same logical mutation. Must be unique per
+        request; reuse is bound to the authenticated caller, request method,
+        path, and body hash. See `docs/idempotency.md`.
+      schema:
+        type: string
+        maxLength: 255
+  responses:
+    IdempotencyConflict:
+      description: |
+        The supplied `Idempotency-Key` was previously used with a different
+        request payload, method, or path.
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties: false
+            required: [error]
+            properties:
+              error:
+                type: string
+                example: Idempotency-Key reused with a different request
   schemas:
     HealthResponse:
       type: object


### PR DESCRIPTION
  Description:

  Closes the cross-user data leakage gap in the idempotency middleware and tightens replay semantics.

  - Per-caller scoping. Cached entries are now namespaced by tenantID + callerID (derived from verified JWT claims), so
  two callers using the same Idempotency-Key cannot read each other's cached responses.
  - Method + path binding. Replaying a key against a different route or HTTP method now returns 422 instead of silently
  serving the wrong cached response.
  - Auth-aware wiring. Middleware moved to /api/v1 after AuthMiddleware so the scope is always derived from a trusted
  identity. Legacy /api group excluded (per-route auth would leave scope anonymous).
  - Durable backing. New idempotency_keys migration with (scope, key) as the primary key, mirroring the in-memory shape and enforcing isolation at the DB layer.
  - Tests. Added cross-user/cross-tenant isolation, method/path mismatch, strict single-handler-invocation concurrency,
and Store.Stop idempotence cases.
  - Docs. New docs/idempotency.md covering semantics and security properties; OpenAPI gains a reusable Idempotency-Key parameter and 422 response component.
  
  closes #147 