### PR TITLE
feat: enforce reconciliation scoping and cursor validation

### DIFF
--- a/docs/reconciliation.md
+++ b/docs/reconciliation.md
@@ -1,27 +1,46 @@
 # Backend ↔ Contract Reconciliation
 
-This document describes the new reconciliation helpers and report model added under `internal/reconciliation`.
+This document describes the reconciliation helpers, report model, and RBAC-scoped endpoints under `internal/reconciliation` and `internal/handlers`.
 
-What it does
-- Defines models for contract snapshots (`Snapshot`) and backend subscriptions (`BackendSubscription`).
+## What it does
+- Defines models for contract snapshots (`Snapshot`) and backend subscriptions (`BackendSubscription`), both carrying a `TenantID` for isolation.
 - Implements a `Reconciler` that compares the two and returns a `Report` with actionable `FieldMismatch` entries.
 - Includes unit tests for matching, mismatch, missing snapshot, and stale snapshot scenarios.
 
-Key comparison points
+## Key comparison points
 - status
 - amount + currency
 - billing interval
 - balances (per-key comparison)
 - snapshot staleness (contract export older than backend by >24h)
 
-Security notes
+## RBAC & tenant scoping
+
+### Permissions
+| Permission | Admin | Merchant | Customer |
+|---|---|---|---|
+| `manage:reconciliation` | ✓ | — | — |
+| `read:reconciliation` | ✓ | ✓ | — |
+
+### Endpoint access
+- `POST /api/admin/reconcile` — requires `manage:reconciliation`. Admins can reconcile any subscription. Merchants are restricted to their own tenant's subscriptions; any cross-tenant submission is rejected with 403.
+- `GET /api/admin/reports` — requires `read:reconciliation`. Admins see all reports. Merchants see only their tenant's reports.
+
+### Tenant isolation
+- All models (`Snapshot`, `BackendSubscription`, `Report`) carry a `TenantID` field.
+- Non-admin callers have `TenantID` stamped onto every submitted subscription automatically; the adapter snapshot list is filtered to exclude other tenants' data.
+- The `Store.ListReportsByTenant(tenantID)` method enforces server-side filtering.
+
+### Cursor security
+Pagination cursors are HMAC-signed and embed the `TenantID`. On decode, the handler validates:
+1. The HMAC signature is intact (prevents tampering).
+2. The embedded tenant matches the caller's tenant (prevents IDOR via cursor replay).
+
+Set the `CURSOR_HMAC_SECRET` environment variable in production. A default key is used in development.
+
+## Security notes
 - This package is purely local and does not make network calls. When integrating with a live contract adapter:
   - Ensure adapter communication is authenticated and encrypted.
   - Sanitize or redact any PII before persisting or logging reports.
   - Limit access to reconciliation endpoints to privileged roles and audit usage.
-
-Next steps
-- Implement an HTTP endpoint in `internal/handlers` that:
-  - Accepts a time range / filter and triggers reconciliation by fetching snapshots from the integration adapter.
-  - Returns aggregated reports and a summary (counts matched / mismatched).
-- Add integration tests that run against a real adapter or a recorded fixture.
+- Predictable IDs are not directly exposed; reports are listed via tenant-scoped queries, not by guessable identifiers.

--- a/internal/auth/roles.go
+++ b/internal/auth/roles.go
@@ -17,7 +17,9 @@ const (
 	PermManagePlans        Permission = "manage:plans"
 	PermManageSubscriptions Permission = "manage:subscriptions"
 	PermReadStatements     Permission = "read:statements"
-	PermManageStatements   Permission = "manage:statements"
+	PermManageStatements       Permission = "manage:statements"
+	PermManageReconciliation   Permission = "manage:reconciliation"
+	PermReadReconciliation     Permission = "read:reconciliation"
 )
 
 var rolePermissions = map[Role][]Permission{
@@ -28,12 +30,15 @@ var rolePermissions = map[Role][]Permission{
 		PermManageSubscriptions,
 		PermReadStatements,
 		PermManageStatements,
+		PermManageReconciliation,
+		PermReadReconciliation,
 	},
 	RoleMerchant: {
 		PermReadPlans,
 		PermReadSubscriptions,
 		PermReadStatements,
 		PermManageStatements,
+		PermReadReconciliation,
 	},
 	RoleCustomer: {
 		PermReadPlans,

--- a/internal/handlers/reconciliation.go
+++ b/internal/handlers/reconciliation.go
@@ -1,64 +1,193 @@
 package handlers
 
 import (
-    "net/http"
+	"net/http"
+	"strconv"
 
-    "github.com/gin-gonic/gin"
-    "stellarbill-backend/internal/reconciliation"
+	"github.com/gin-gonic/gin"
+	"stellarbill-backend/internal/auth"
+	"stellarbill-backend/internal/pagination"
+	"stellarbill-backend/internal/reconciliation"
 )
 
 // NewReconcileHandler returns a handler that accepts a list of backend subscriptions
 // (JSON array) and compares them against snapshots fetched from the provided Adapter.
-// If a non-nil store is provided, reports will be persisted.
-// Request body: [{subscription_id,...}, ...]
+// Only admin and merchant roles with manage:reconciliation permission may trigger reconciliation.
+// Merchant callers can only reconcile subscriptions belonging to their tenant.
 func NewReconcileHandler(adapter reconciliation.Adapter, store reconciliation.Store) gin.HandlerFunc {
-    return func(c *gin.Context) {
-        var backendSubs []reconciliation.BackendSubscription
-        if err := c.ShouldBindJSON(&backendSubs); err != nil {
-            RespondWithValidationError(c, "Invalid request body", map[string]interface{}{
-                "reason": err.Error(),
-            })
-            return
-        }
+	return func(c *gin.Context) {
+		callerID, exists := c.Get("callerID")
+		if !exists {
+			RespondWithAuthError(c, "Missing authentication credentials")
+			return
+		}
 
-        snaps, err := adapter.FetchSnapshots(c.Request.Context())
-        if err != nil {
-            RespondWithInternalError(c, "Failed to fetch reconciliation snapshots")
-            return
-        }
+		tenantID, exists := c.Get("tenantID")
+		if !exists {
+			RespondWithAuthError(c, "Missing tenant context")
+			return
+		}
+		tid := tenantID.(string)
 
-        snapMap := make(map[string]*reconciliation.Snapshot, len(snaps))
-        for i := range snaps {
-            s := snaps[i]
-            snapMap[s.SubscriptionID] = &s
-        }
+		roles := auth.ExtractRoles(c)
+		if !hasAnyPermission(roles, auth.PermManageReconciliation) {
+			RespondWithError(c, http.StatusForbidden, ErrorCodeForbidden, "Insufficient permissions for reconciliation")
+			return
+		}
 
-        reconciler := reconciliation.New()
-        reports := make([]reconciliation.Report, 0, len(backendSubs))
-        for _, b := range backendSubs {
-            rep := reconciler.Compare(b, snapMap[b.SubscriptionID])
-            reports = append(reports, rep)
-        }
+		isAdmin := hasRole(roles, auth.RoleAdmin)
+		_ = callerID
 
-        // summary
-        matched := 0
-        for _, r := range reports {
-            if r.Matched {
-                matched++
-            }
-        }
+		var backendSubs []reconciliation.BackendSubscription
+		if err := c.ShouldBindJSON(&backendSubs); err != nil {
+			RespondWithValidationError(c, "Invalid request body", map[string]interface{}{
+				"reason": err.Error(),
+			})
+			return
+		}
 
-        // persist if store configured
-        if store != nil {
-            // best-effort save; don't fail the request on save error but log via header
-            if err := store.SaveReports(reports); err != nil {
-                c.Header("X-Reconcile-Save-Error", err.Error())
-            }
-        }
+		// Merchant callers can only reconcile their own tenant's subscriptions.
+		if !isAdmin {
+			for _, b := range backendSubs {
+				if b.TenantID != "" && b.TenantID != tid {
+					RespondWithError(c, http.StatusForbidden, ErrorCodeForbidden,
+						"Cannot reconcile subscriptions belonging to another tenant")
+					return
+				}
+			}
+			// Stamp tenant on all submissions so downstream logic is scoped.
+			for i := range backendSubs {
+				backendSubs[i].TenantID = tid
+			}
+		}
 
-        c.JSON(http.StatusOK, gin.H{
-            "summary": gin.H{"total": len(reports), "matched": matched, "mismatched": len(reports) - matched},
-            "reports": reports,
-        })
-    }
+		snaps, err := adapter.FetchSnapshots(c.Request.Context())
+		if err != nil {
+			RespondWithInternalError(c, "Failed to fetch reconciliation snapshots")
+			return
+		}
+
+		// Build snapshot map scoped to the caller's tenant for non-admin.
+		snapMap := make(map[string]*reconciliation.Snapshot, len(snaps))
+		for i := range snaps {
+			s := snaps[i]
+			if !isAdmin && s.TenantID != tid {
+				continue
+			}
+			snapMap[s.SubscriptionID] = &s
+		}
+
+		reconciler := reconciliation.New()
+		reports := make([]reconciliation.Report, 0, len(backendSubs))
+		for _, b := range backendSubs {
+			rep := reconciler.Compare(b, snapMap[b.SubscriptionID])
+			reports = append(reports, rep)
+		}
+
+		matched := 0
+		for _, r := range reports {
+			if r.Matched {
+				matched++
+			}
+		}
+
+		if store != nil {
+			if err := store.SaveReports(reports); err != nil {
+				c.Header("X-Reconcile-Save-Error", err.Error())
+			}
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"summary": gin.H{"total": len(reports), "matched": matched, "mismatched": len(reports) - matched},
+			"reports": reports,
+		})
+	}
+}
+
+// NewListReportsHandler returns a handler that lists reconciliation reports.
+// Admin sees all reports; merchants see only their tenant's reports.
+// Supports cursor-based pagination with tenant-scoped cursors.
+func NewListReportsHandler(store reconciliation.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, exists := c.Get("callerID")
+		if !exists {
+			RespondWithAuthError(c, "Missing authentication credentials")
+			return
+		}
+
+		tenantID, exists := c.Get("tenantID")
+		if !exists {
+			RespondWithAuthError(c, "Missing tenant context")
+			return
+		}
+		tid := tenantID.(string)
+
+		roles := auth.ExtractRoles(c)
+		if !hasAnyPermission(roles, auth.PermReadReconciliation) {
+			RespondWithError(c, http.StatusForbidden, ErrorCodeForbidden, "Insufficient permissions to view reports")
+			return
+		}
+
+		isAdmin := hasRole(roles, auth.RoleAdmin)
+
+		// Validate scoped cursor
+		cursorStr := c.Query("cursor")
+		cursor, err := pagination.DecodeScopedCursor(cursorStr, tid)
+		if err != nil {
+			RespondWithValidationError(c, "Invalid pagination cursor", map[string]interface{}{
+				"reason": err.Error(),
+			})
+			return
+		}
+
+		limitStr := c.DefaultQuery("limit", "20")
+		limit, _ := strconv.Atoi(limitStr)
+		if limit <= 0 || limit > 100 {
+			limit = 20
+		}
+
+		var reports []reconciliation.Report
+		if isAdmin {
+			reports, err = store.ListReports()
+		} else {
+			reports, err = store.ListReportsByTenant(tid)
+		}
+		if err != nil {
+			RespondWithInternalError(c, "Failed to load reports")
+			return
+		}
+
+		page := pagination.PaginateSlice(reports, cursor, limit)
+
+		// Re-encode the next cursor with tenant scope.
+		nextCursor := ""
+		if page.HasMore && len(page.Items) > 0 {
+			last := page.Items[len(page.Items)-1]
+			nextCursor = pagination.EncodeScopedCursor(last.GetID(), last.GetSortValue(), tid)
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"reports":     page.Items,
+			"next_cursor": nextCursor,
+			"has_more":    page.HasMore,
+		})
+	}
+}
+
+func hasAnyPermission(roles []auth.Role, perm auth.Permission) bool {
+	for _, r := range roles {
+		if auth.HasPermission(r, perm) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRole(roles []auth.Role, target auth.Role) bool {
+	for _, r := range roles {
+		if r == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/handlers/reconciliation_test.go
+++ b/internal/handlers/reconciliation_test.go
@@ -1,83 +1,322 @@
 package handlers
 
 import (
-    "bytes"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
-    "time"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 
-    "github.com/gin-gonic/gin"
-    "stellarbill-backend/internal/reconciliation"
+	"github.com/gin-gonic/gin"
+	"stellarbill-backend/internal/auth"
+	"stellarbill-backend/internal/pagination"
+	"stellarbill-backend/internal/reconciliation"
 )
 
+func setupReconcileRouter(adapter reconciliation.Adapter, store reconciliation.Store, tenantID, role string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("callerID", "caller-123")
+		if tenantID != "" {
+			c.Set("tenantID", tenantID)
+		}
+		if role != "" {
+			c.Set(auth.RolesContextKey, []auth.Role{auth.Role(role)})
+		}
+		c.Next()
+	})
+	r.POST("/admin/reconcile", NewReconcileHandler(adapter, store))
+	r.GET("/admin/reports", NewListReportsHandler(store))
+	return r
+}
+
 func TestReconcileHandler(t *testing.T) {
-    now := time.Now().UTC()
+	now := time.Now().UTC()
 
-    // prepare adapter with a snapshot that will mismatch status and balances
-    snap := reconciliation.Snapshot{
-        SubscriptionID: "sub-1",
-        Status: "cancelled",
-        Amount: 1000,
-        Currency: "USD",
-        Interval: "monthly",
-        Balances: map[string]int64{"due": 0},
-        ExportedAt: now,
-    }
-    adapter := reconciliation.NewMemoryAdapter(snap)
+	snap := reconciliation.Snapshot{
+		SubscriptionID: "sub-1",
+		TenantID:       "tenant-1",
+		Status:         "cancelled",
+		Amount:         1000,
+		Currency:       "USD",
+		Interval:       "monthly",
+		Balances:       map[string]int64{"due": 0},
+		ExportedAt:     now,
+	}
+	adapter := reconciliation.NewMemoryAdapter(snap)
 
-    // backend submission with differing status and due balance
-    backend := reconciliation.BackendSubscription{
-        SubscriptionID: "sub-1",
-        Status: "active",
-        Amount: 1000,
-        Currency: "USD",
-        Interval: "monthly",
-        Balances: map[string]int64{"due": 100},
-        UpdatedAt: now,
-    }
+	backend := reconciliation.BackendSubscription{
+		SubscriptionID: "sub-1",
+		TenantID:       "tenant-1",
+		Status:         "active",
+		Amount:         1000,
+		Currency:       "USD",
+		Interval:       "monthly",
+		Balances:       map[string]int64{"due": 100},
+		UpdatedAt:      now,
+	}
 
-    payload, _ := json.Marshal([]reconciliation.BackendSubscription{backend})
+	payload, _ := json.Marshal([]reconciliation.BackendSubscription{backend})
 
-    store := reconciliation.NewMemoryStore()
-    r := gin.New()
-    r.POST("/admin/reconcile", NewReconcileHandler(adapter, store))
+	store := reconciliation.NewMemoryStore()
+	r := setupReconcileRouter(adapter, store, "tenant-1", "admin")
 
-    req := httptest.NewRequest(http.MethodPost, "/admin/reconcile", bytes.NewReader(payload))
-    req.Header.Set("Content-Type", "application/json")
-    w := httptest.NewRecorder()
-    r.ServeHTTP(w, req)
+	req := httptest.NewRequest(http.MethodPost, "/admin/reconcile", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
 
-    if w.Code != http.StatusOK {
-        t.Fatalf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
-    }
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", w.Code, w.Body.String())
+	}
 
-    var resp struct {
-        Summary struct{
-            Total int `json:"total"`
-            Matched int `json:"matched"`
-            Mismatched int `json:"mismatched"`
-        } `json:"summary"`
-        Reports []reconciliation.Report `json:"reports"`
-    }
-    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-        t.Fatalf("failed to parse response: %v", err)
-    }
+	var resp struct {
+		Summary struct {
+			Total      int `json:"total"`
+			Matched    int `json:"matched"`
+			Mismatched int `json:"mismatched"`
+		} `json:"summary"`
+		Reports []reconciliation.Report `json:"reports"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
 
-    if resp.Summary.Total != 1 || resp.Summary.Mismatched != 1 || len(resp.Reports) != 1 {
-        t.Fatalf("unexpected summary/reports: %+v", resp)
-    }
-    if resp.Reports[0].Matched {
-        t.Fatalf("expected report to show mismatches")
-    }
+	if resp.Summary.Total != 1 || resp.Summary.Mismatched != 1 || len(resp.Reports) != 1 {
+		t.Fatalf("unexpected summary/reports: %+v", resp)
+	}
+	if resp.Reports[0].Matched {
+		t.Fatalf("expected report to show mismatches")
+	}
 
-    // ensure reports were persisted
-    saved, err := store.ListReports()
-    if err != nil {
-        t.Fatalf("store.ListReports error: %v", err)
-    }
-    if len(saved) != 1 || saved[0].SubscriptionID != "sub-1" {
-        t.Fatalf("unexpected saved reports: %#v", saved)
-    }
+	saved, err := store.ListReports()
+	if err != nil {
+		t.Fatalf("store.ListReports error: %v", err)
+	}
+	if len(saved) != 1 || saved[0].SubscriptionID != "sub-1" {
+		t.Fatalf("unexpected saved reports: %#v", saved)
+	}
+}
+
+func TestReconcileHandler_NoAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	// No callerID set
+	r.POST("/admin/reconcile", NewReconcileHandler(reconciliation.NewMemoryAdapter(), reconciliation.NewMemoryStore()))
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/reconcile", bytes.NewReader([]byte("[]")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestReconcileHandler_CustomerForbidden(t *testing.T) {
+	store := reconciliation.NewMemoryStore()
+	r := setupReconcileRouter(reconciliation.NewMemoryAdapter(), store, "tenant-1", "customer")
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/reconcile", bytes.NewReader([]byte("[]")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestReconcileHandler_MerchantCrossTenantBlocked(t *testing.T) {
+	adapter := reconciliation.NewMemoryAdapter()
+	store := reconciliation.NewMemoryStore()
+	r := setupReconcileRouter(adapter, store, "tenant-1", "merchant")
+
+	backend := reconciliation.BackendSubscription{
+		SubscriptionID: "sub-other",
+		TenantID:       "tenant-2",
+		Status:         "active",
+		Amount:         500,
+		Currency:       "USD",
+		Interval:       "monthly",
+		UpdatedAt:      time.Now().UTC(),
+	}
+	payload, _ := json.Marshal([]reconciliation.BackendSubscription{backend})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/reconcile", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-tenant attempt, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestReconcileHandler_MerchantScopedSnapshots(t *testing.T) {
+	now := time.Now().UTC()
+
+	snap1 := reconciliation.Snapshot{
+		SubscriptionID: "sub-mine",
+		TenantID:       "tenant-1",
+		Status:         "active",
+		Amount:         1000,
+		Currency:       "USD",
+		Interval:       "monthly",
+		Balances:       map[string]int64{},
+		ExportedAt:     now,
+	}
+	snap2 := reconciliation.Snapshot{
+		SubscriptionID: "sub-other",
+		TenantID:       "tenant-2",
+		Status:         "active",
+		Amount:         2000,
+		Currency:       "USD",
+		Interval:       "monthly",
+		Balances:       map[string]int64{},
+		ExportedAt:     now,
+	}
+	adapter := reconciliation.NewMemoryAdapter(snap1, snap2)
+	store := reconciliation.NewMemoryStore()
+	r := setupReconcileRouter(adapter, store, "tenant-1", "merchant")
+
+	backend := reconciliation.BackendSubscription{
+		SubscriptionID: "sub-mine",
+		TenantID:       "tenant-1",
+		Status:         "active",
+		Amount:         1000,
+		Currency:       "USD",
+		Interval:       "monthly",
+		Balances:       map[string]int64{},
+		UpdatedAt:      now,
+	}
+	payload, _ := json.Marshal([]reconciliation.BackendSubscription{backend})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/reconcile", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Reports []reconciliation.Report `json:"reports"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Reports) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(resp.Reports))
+	}
+	if resp.Reports[0].TenantID != "tenant-1" {
+		t.Fatalf("report tenant should be tenant-1, got %s", resp.Reports[0].TenantID)
+	}
+}
+
+func TestListReportsHandler_TenantIsolation(t *testing.T) {
+	store := reconciliation.NewMemoryStore()
+	_ = store.SaveReports([]reconciliation.Report{
+		{SubscriptionID: "sub-1", TenantID: "tenant-1", Matched: true},
+		{SubscriptionID: "sub-2", TenantID: "tenant-2", Matched: false},
+		{SubscriptionID: "sub-3", TenantID: "tenant-1", Matched: true},
+	})
+
+	// Merchant for tenant-1 should only see their reports
+	r := setupReconcileRouter(nil, store, "tenant-1", "merchant")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/reports", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Reports []reconciliation.Report `json:"reports"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Reports) != 2 {
+		t.Fatalf("expected 2 tenant-1 reports, got %d", len(resp.Reports))
+	}
+	for _, rpt := range resp.Reports {
+		if rpt.TenantID != "tenant-1" {
+			t.Fatalf("leaked report from tenant %s to tenant-1", rpt.TenantID)
+		}
+	}
+}
+
+func TestListReportsHandler_AdminSeesAll(t *testing.T) {
+	store := reconciliation.NewMemoryStore()
+	_ = store.SaveReports([]reconciliation.Report{
+		{SubscriptionID: "sub-1", TenantID: "tenant-1", Matched: true},
+		{SubscriptionID: "sub-2", TenantID: "tenant-2", Matched: false},
+	})
+
+	r := setupReconcileRouter(nil, store, "tenant-1", "admin")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/reports", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Reports []reconciliation.Report `json:"reports"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Reports) != 2 {
+		t.Fatalf("admin should see all 2 reports, got %d", len(resp.Reports))
+	}
+}
+
+func TestListReportsHandler_CustomerForbidden(t *testing.T) {
+	r := setupReconcileRouter(nil, reconciliation.NewMemoryStore(), "tenant-1", "customer")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/reports", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for customer, got %d", w.Code)
+	}
+}
+
+func TestListReportsHandler_CrossTenantCursorRejected(t *testing.T) {
+	store := reconciliation.NewMemoryStore()
+	_ = store.SaveReports([]reconciliation.Report{
+		{SubscriptionID: "sub-1", TenantID: "tenant-1", Matched: true},
+	})
+
+	// Create a cursor scoped to tenant-2
+	cursorForTenant2 := pagination.EncodeScopedCursor("sub-1", "sub-1", "tenant-2")
+
+	r := setupReconcileRouter(nil, store, "tenant-1", "merchant")
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/reports?cursor="+cursorForTenant2, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for cross-tenant cursor, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListReportsHandler_TamperedCursorRejected(t *testing.T) {
+	store := reconciliation.NewMemoryStore()
+	r := setupReconcileRouter(nil, store, "tenant-1", "merchant")
+
+	// Hand-craft a tampered cursor (not properly signed)
+	req := httptest.NewRequest(http.MethodGet, "/admin/reports?cursor=dGFtcGVyZWQ=", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for tampered cursor, got %d: %s", w.Code, w.Body.String())
+	}
 }

--- a/internal/pagination/scoped_cursor.go
+++ b/internal/pagination/scoped_cursor.go
@@ -1,0 +1,81 @@
+package pagination
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+// ScopedCursor extends Cursor with a TenantID so that cursors cannot be reused
+// across tenants. The encoded form includes an HMAC signature to prevent
+// tampering with the tenant scope.
+type ScopedCursor struct {
+	ID        string `json:"id"`
+	SortValue string `json:"sort_value,omitempty"`
+	TenantID  string `json:"tenant_id"`
+	Sig       string `json:"sig"`
+}
+
+func cursorSecret() []byte {
+	if s := os.Getenv("CURSOR_HMAC_SECRET"); s != "" {
+		return []byte(s)
+	}
+	return []byte("stellabill-cursor-hmac-default")
+}
+
+func signCursor(id, sortValue, tenantID string) string {
+	mac := hmac.New(sha256.New, cursorSecret())
+	mac.Write([]byte(id + "|" + sortValue + "|" + tenantID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func EncodeScopedCursor(id, sortValue, tenantID string) string {
+	if id == "" && sortValue == "" {
+		return ""
+	}
+	sc := ScopedCursor{
+		ID:        id,
+		SortValue: sortValue,
+		TenantID:  tenantID,
+		Sig:       signCursor(id, sortValue, tenantID),
+	}
+	b, err := json.Marshal(sc)
+	if err != nil {
+		return ""
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// DecodeScopedCursor decodes a cursor and validates that it belongs to the
+// expected tenant. Returns an error if the cursor was issued for a different
+// tenant or has been tampered with.
+func DecodeScopedCursor(encoded string, expectedTenantID string) (Cursor, error) {
+	if encoded == "" {
+		return Cursor{}, nil
+	}
+
+	b, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return Cursor{}, errors.New("invalid cursor format")
+	}
+
+	var sc ScopedCursor
+	if err := json.Unmarshal(b, &sc); err != nil {
+		return Cursor{}, errors.New("invalid cursor format")
+	}
+
+	expected := signCursor(sc.ID, sc.SortValue, sc.TenantID)
+	if !hmac.Equal([]byte(sc.Sig), []byte(expected)) {
+		return Cursor{}, errors.New("cursor signature invalid")
+	}
+
+	if sc.TenantID != expectedTenantID {
+		return Cursor{}, errors.New("cursor does not belong to this tenant")
+	}
+
+	return Cursor{ID: sc.ID, SortValue: sc.SortValue}, nil
+}

--- a/internal/pagination/scoped_cursor_test.go
+++ b/internal/pagination/scoped_cursor_test.go
@@ -1,0 +1,53 @@
+package pagination
+
+import (
+	"testing"
+)
+
+func TestScopedCursor_RoundTrip(t *testing.T) {
+	encoded := EncodeScopedCursor("id-1", "sort-val", "tenant-abc")
+	if encoded == "" {
+		t.Fatal("expected non-empty encoded cursor")
+	}
+
+	cursor, err := DecodeScopedCursor(encoded, "tenant-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cursor.ID != "id-1" || cursor.SortValue != "sort-val" {
+		t.Fatalf("unexpected cursor: %+v", cursor)
+	}
+}
+
+func TestScopedCursor_EmptyString(t *testing.T) {
+	cursor, err := DecodeScopedCursor("", "tenant-abc")
+	if err != nil {
+		t.Fatalf("unexpected error for empty cursor: %v", err)
+	}
+	if cursor.ID != "" || cursor.SortValue != "" {
+		t.Fatalf("expected empty cursor, got: %+v", cursor)
+	}
+}
+
+func TestScopedCursor_WrongTenantRejected(t *testing.T) {
+	encoded := EncodeScopedCursor("id-1", "sort-val", "tenant-abc")
+	_, err := DecodeScopedCursor(encoded, "tenant-xyz")
+	if err == nil {
+		t.Fatal("expected error for wrong tenant")
+	}
+}
+
+func TestScopedCursor_TamperedSignatureRejected(t *testing.T) {
+	// Garbage base64 that decodes to valid JSON but with wrong sig
+	_, err := DecodeScopedCursor("eyJpZCI6ImlkLTEiLCJ0ZW5hbnRfaWQiOiJ0ZW5hbnQtYWJjIiwic2lnIjoiZmFrZSJ9", "tenant-abc")
+	if err == nil {
+		t.Fatal("expected error for tampered signature")
+	}
+}
+
+func TestScopedCursor_InvalidBase64(t *testing.T) {
+	_, err := DecodeScopedCursor("not-valid-base64!!!", "tenant-abc")
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -9,6 +9,7 @@ import (
 // Snapshot represents a single subscription state exported from the contract/ledger.
 type Snapshot struct {
 	SubscriptionID string            `json:"subscription_id"`
+	TenantID       string            `json:"tenant_id"`
 	Status         string            `json:"status"`
 	Amount         int64             `json:"amount"`
 	Currency       string            `json:"currency"`
@@ -20,6 +21,7 @@ type Snapshot struct {
 // BackendSubscription represents the subscription as stored in the backend DB.
 type BackendSubscription struct {
 	SubscriptionID string           `json:"subscription_id"`
+	TenantID       string           `json:"tenant_id"`
 	Status         string           `json:"status"`
 	Amount         int64            `json:"amount"`
 	Currency       string           `json:"currency"`
@@ -37,12 +39,13 @@ type FieldMismatch struct {
 
 // Report contains the reconciliation result for a subscription.
 type Report struct {
-	JobID       string          `json:"job_id,omitempty"`
-	SubscriptionID string          `json:"subscription_id"`
-	Matched     bool            `json:"matched"`
-	Mismatches  []FieldMismatch `json:"mismatches"`
-	Backend     BackendSubscription `json:"backend"`
-	Contract    Snapshot            `json:"contract"`
+	JobID          string              `json:"job_id,omitempty"`
+	SubscriptionID string              `json:"subscription_id"`
+	TenantID       string              `json:"tenant_id"`
+	Matched        bool                `json:"matched"`
+	Mismatches     []FieldMismatch     `json:"mismatches"`
+	Backend        BackendSubscription `json:"backend"`
+	Contract       Snapshot            `json:"contract"`
 }
 
 func (r Report) GetID() string        { return r.SubscriptionID }
@@ -60,6 +63,7 @@ type Adapter interface {
 type Store interface {
 	SaveReports(reports []Report) error
 	ListReports() ([]Report, error)
+	ListReportsByTenant(tenantID string) ([]Report, error)
 	DeleteReportsByJobID(jobID string) error
 	GetReportsByJobID(jobID string) ([]Report, error)
 }
@@ -80,6 +84,7 @@ func New() *Reconciler {
 func (r *Reconciler) Compare(backend BackendSubscription, contract *Snapshot) Report {
 	var rep Report
 	rep.SubscriptionID = backend.SubscriptionID
+	rep.TenantID = backend.TenantID
 	rep.Backend = backend
 	if contract == nil {
 		rep.Matched = false

--- a/internal/reconciliation/store_memory.go
+++ b/internal/reconciliation/store_memory.go
@@ -30,6 +30,20 @@ func (m *MemoryStore) ListReports() ([]Report, error) {
 	return out, nil
 }
 
+// ListReportsByTenant returns reports scoped to a specific tenant.
+func (m *MemoryStore) ListReportsByTenant(tenantID string) ([]Report, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var out []Report
+	for _, r := range m.reports {
+		if r.TenantID == tenantID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 // DeleteReportsByJobID removes all reports associated with a job ID.
 func (m *MemoryStore) DeleteReportsByJobID(jobID string) error {
 	m.mu.Lock()

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"fmt"
-	"net/http"
 
+	"stellarbill-backend/internal/auth"
 	"stellarbill-backend/internal/config"
 	"stellarbill-backend/internal/handlers"
 	"stellarbill-backend/internal/middleware"
@@ -97,17 +97,10 @@ func Register(r *gin.Engine) {
 		adminHandler := handlers.NewAdminHandler(cfg.AdminToken)
 		admin.POST("/purge", adminHandler.PurgeCache)
 		
-		// Reconciliation
+		// Reconciliation — scoped by RBAC and tenant
 		adapter := reconciliation.NewMemoryAdapter()
 		reconStore := reconciliation.NewMemoryStore()
-		admin.POST("/reconcile", handlers.NewReconcileHandler(adapter, reconStore))
-		admin.GET("/reports", func(c *gin.Context) {
-			reports, err := reconStore.ListReports()
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load reports"})
-				return
-			}
-			c.JSON(http.StatusOK, gin.H{"reports": reports})
-		})
+		admin.POST("/reconcile", auth.RequirePermission(auth.PermManageReconciliation), handlers.NewReconcileHandler(adapter, reconStore))
+		admin.GET("/reports", auth.RequirePermission(auth.PermReadReconciliation), handlers.NewListReportsHandler(reconStore))
 	}
 }


### PR DESCRIPTION
This adds RBAC and tenant isolation to the reconciliation endpoints:

  - New permissions (manage:reconciliation, read:reconciliation) gate access — admin gets full access, merchants get read-only, customers are blocked.
  - Tenant scoping — TenantID added to all reconciliation models. Merchants can only reconcile/view their own tenant's data; cross-tenant attempts return 403.
  - HMAC-signed cursors — Pagination cursors embed the tenant ID and are cryptographically signed, preventing IDOR via cursor tampering or replay across tenants.
  - 10 test cases cover auth, cross-tenant rejection, cursor validation, and role-based filtering.
  
  closes #125 