### PR TITLE
feat: serve real subscription detail from GetSubscriptionHandler

### DIFF
--- a/internal/handlers/subscriptions.go
+++ b/internal/handlers/subscriptions.go
@@ -130,10 +130,13 @@ func NewGetSubscriptionHandler(svc service.SubscriptionService) gin.HandlerFunc 
 			return
 		}
 
-		// Minimal, safe handler that validates caller and path, then delegates to the service.
-		callerID, exists := c.Get("callerID")
-		if !exists {
-			RespondWithAuthError(c, "unauthorized")
+		callerID, ok := getRequiredStringContextValue(c, "callerID", "unauthorized")
+		if !ok {
+			return
+		}
+
+		tenantID, ok := getRequiredStringContextValue(c, "tenantID", "missing tenant")
+		if !ok {
 			return
 		}
 
@@ -148,26 +151,17 @@ func NewGetSubscriptionHandler(svc service.SubscriptionService) gin.HandlerFunc 
 			return
 		}
 
-		tenantID := c.GetString("tenantID")
-		// Delegate to service (note: real implementation may include ownership checks)
-		detail, _, err := svc.GetDetail(c.Request.Context(), tenantID, callerID.(string), id)
+		detail, warnings, err := svc.GetDetail(c.Request.Context(), tenantID, callerID, id)
 		if err != nil {
 			code, errCode, msg := MapServiceErrorToResponse(err)
 			RespondWithError(c, code, errCode, msg)
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{
-			"api_version": "1",
-			"data": gin.H{
-				"id":              detail.ID,
-				"plan_id":         detail.PlanID,
-				"customer":        detail.Customer,
-				"status":          detail.Status,
-				"interval":        detail.Interval,
-				"plan":            detail.Plan,
-				"billing_summary": detail.BillingSummary,
-			},
+		c.JSON(http.StatusOK, service.ResponseEnvelope{
+			APIVersion: "v1",
+			Data:       detail,
+			Warnings:   warnings,
 		})
 	}
 }

--- a/internal/handlers/subscriptions_integration_test.go
+++ b/internal/handlers/subscriptions_integration_test.go
@@ -98,9 +98,9 @@ func TestIntegration_GetSubscription_HappyPath(t *testing.T) {
 		t.Fatalf("failed to decode response body: %v", err)
 	}
 
-	// api_version = "1"
-	if envelope["api_version"] != "1" {
-		t.Errorf("expected api_version=1, got %v", envelope["api_version"])
+	// api_version = "v1"
+	if envelope["api_version"] != "v1" {
+		t.Errorf("expected api_version=v1, got %v", envelope["api_version"])
 	}
 
 	data, ok := envelope["data"].(map[string]interface{})
@@ -117,8 +117,8 @@ func TestIntegration_GetSubscription_HappyPath(t *testing.T) {
 		t.Errorf("expected data.plan_id=%q, got %v", planID, data["plan_id"])
 	}
 	// data.customer
-	if data["customer"] != customerID {
-		t.Errorf("expected data.customer=%q, got %v", customerID, data["customer"])
+	if data["customer"] != "cust_***" {
+		t.Errorf("expected data.customer to be redacted, got %v", data["customer"])
 	}
 	// data.status
 	if data["status"] != "active" {
@@ -151,6 +151,97 @@ func TestIntegration_GetSubscription_HappyPath(t *testing.T) {
 	}
 	if billing["currency"] != "USD" {
 		t.Errorf("expected billing_summary.currency=USD, got %v", billing["currency"])
+	}
+}
+
+func TestIntegration_GetSubscription_NotFound_Returns404(t *testing.T) {
+	subRepo := repository.NewMockSubscriptionRepo()
+	planRepo := repository.NewMockPlanRepo()
+	r := buildIntegrationRouter(subRepo, planRepo)
+
+	tokenStr := makeTestJWT("cust-1", "tenant-1")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/subscriptions/550e8400-e29b-41d4-a716-446655440001", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	req.Header.Set("X-Tenant-ID", "tenant-1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestIntegration_GetSubscription_WrongTenant_Returns404(t *testing.T) {
+	const customerID = "cust-abc"
+	const subID = "550e8400-e29b-41d4-a716-446655440001"
+
+	subRepo := repository.NewMockSubscriptionRepo(&repository.SubscriptionRow{
+		ID:         subID,
+		PlanID:     "550e8400-e29b-41d4-a716-446655440002",
+		TenantID:   "tenant-1",
+		CustomerID: customerID,
+		Status:     "active",
+		Amount:     "999",
+		Currency:   "USD",
+		Interval:   "monthly",
+	})
+	planRepo := repository.NewMockPlanRepo()
+	r := buildIntegrationRouter(subRepo, planRepo)
+
+	tokenStr := makeTestJWT(customerID, "tenant-2")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/subscriptions/"+subID, nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	req.Header.Set("X-Tenant-ID", "tenant-2")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestIntegration_GetSubscription_MissingPlan_ReturnsWarning(t *testing.T) {
+	const customerID = "cust-abc"
+	const subID = "550e8400-e29b-41d4-a716-446655440001"
+
+	subRepo := repository.NewMockSubscriptionRepo(&repository.SubscriptionRow{
+		ID:         subID,
+		PlanID:     "550e8400-e29b-41d4-a716-446655440002",
+		TenantID:   "tenant-1",
+		CustomerID: customerID,
+		Status:     "active",
+		Amount:     "999",
+		Currency:   "USD",
+		Interval:   "monthly",
+	})
+	planRepo := repository.NewMockPlanRepo()
+	r := buildIntegrationRouter(subRepo, planRepo)
+
+	tokenStr := makeTestJWT(customerID, "tenant-1")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/subscriptions/"+subID, nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	req.Header.Set("X-Tenant-ID", "tenant-1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	var envelope map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&envelope); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	warnings, ok := envelope["warnings"].([]interface{})
+	if !ok || len(warnings) != 1 || warnings[0] != "plan not found" {
+		t.Fatalf("expected plan warning, got %#v", envelope["warnings"])
+	}
+	data := envelope["data"].(map[string]interface{})
+	if _, ok := data["plan"]; ok {
+		t.Fatalf("expected omitted plan when plan lookup misses, got %#v", data["plan"])
 	}
 }
 

--- a/internal/handlers/subscriptions_test.go
+++ b/internal/handlers/subscriptions_test.go
@@ -22,10 +22,12 @@ type mockSubscriptionService struct {
 	warnings []string
 	err      error
 	callerID string
+	tenantID string
 	id       string
 }
 
 func (m *mockSubscriptionService) GetDetail(_ context.Context, tenantID, callerID, id string) (*service.SubscriptionDetail, []string, error) {
+	m.tenantID = tenantID
 	m.callerID = callerID
 	m.id = id
 	return m.detail, m.warnings, m.err
@@ -57,6 +59,107 @@ func setupRouter(svc *mockSubscriptionService, setCallerID bool) *gin.Engine {
 	}
 	r.GET("/api/subscriptions/:id", NewGetSubscriptionHandler(svc))
 	return r
+}
+
+func TestNewGetSubscriptionHandler_ReturnsServiceDetailAndWarnings(t *testing.T) {
+	detail := &service.SubscriptionDetail{
+		ID:       "sub-123",
+		PlanID:   "plan-123",
+		Customer: "cust-123",
+		Status:   "active",
+		Interval: "monthly",
+		Plan: &service.PlanMetadata{
+			PlanID:   "plan-123",
+			Name:     "Pro",
+			Amount:   "2999",
+			Currency: "USD",
+			Interval: "monthly",
+		},
+		BillingSummary: service.BillingSummary{
+			AmountCents: 2999,
+			Currency:    "USD",
+		},
+	}
+	svc := &mockSubscriptionService{
+		detail:   detail,
+		warnings: []string{"plan not found"},
+	}
+	r := setupRouter(svc, true)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/subscriptions/sub-123", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "tenant-1", svc.tenantID)
+	assert.Equal(t, "caller-123", svc.callerID)
+	assert.Equal(t, "sub-123", svc.id)
+
+	var response service.ResponseEnvelope
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "v1", response.APIVersion)
+	assert.Equal(t, []string{"plan not found"}, response.Warnings)
+
+	var body map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &body)
+	assert.NoError(t, err)
+	data := body["data"].(map[string]interface{})
+	assert.Equal(t, "sub-123", data["id"])
+	assert.Equal(t, "plan-123", data["plan_id"])
+	assert.Equal(t, "cust_***", data["customer"])
+	assert.Equal(t, "active", data["status"])
+	assert.NotNil(t, data["plan"])
+	assert.NotNil(t, data["billing_summary"])
+}
+
+func TestNewGetSubscriptionHandler_ServiceErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{"not found", service.ErrNotFound, http.StatusNotFound, string(ErrorCodeNotFound)},
+		{"forbidden", service.ErrForbidden, http.StatusForbidden, string(ErrorCodeForbidden)},
+		{"deleted", service.ErrDeleted, http.StatusGone, string(ErrorCodeNotFound)},
+		{"billing parse", service.ErrBillingParse, http.StatusInternalServerError, string(ErrorCodeInternalError)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &mockSubscriptionService{err: tt.err}
+			r := setupRouter(svc, true)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/subscriptions/sub-123", nil)
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			var response ErrorEnvelope
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCode, response.Code)
+		})
+	}
+}
+
+func TestNewGetSubscriptionHandler_MissingTenantReturns401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &mockSubscriptionService{}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("callerID", "caller-123")
+		c.Next()
+	})
+	r.GET("/api/subscriptions/:id", NewGetSubscriptionHandler(svc))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/subscriptions/sub-123", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Empty(t, svc.id)
 }
 
 func TestHandler_ListSubscriptions(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wire `NewGetSubscriptionHandler` to read `tenantID` and `callerID` from Gin context and call `SubscriptionService.GetDetail`.
- Return the real `SubscriptionDetail` response, including `Plan`, `BillingSummary`, and service warnings.
- Add handler and integration coverage for not found, wrong tenant, non-owner caller, soft-deleted row, billing parse error, and missing-plan warning behavior.

## Security / Correctness
- Tenant scoping, ownership checks, soft-delete handling, plan lookup, and billing normalization stay delegated to `SubscriptionService.GetDetail`.
- Service sentinel errors are mapped to the required HTTP statuses: 404, 403, 410, and 500.
- Customer data continues to serialize through the existing `SubscriptionDetail.MarshalJSON` redaction behavior.

## Validation
- `git diff --check` passed.
- `go test ./...` could not be run locally because this workspace does not have the Go toolchain (`go`/`gofmt`) installed on PATH.
closes #205