### PR TITLE
test: add pagination and scoped-cursor edge-case coverage

### DIFF
--- a/internal/handlers/reconciliation_test.go
+++ b/internal/handlers/reconciliation_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"stellarbill-backend/internal/auth"
+	"stellarbill-backend/internal/pagination"
 	"stellarbill-backend/internal/reconciliation"
 )
 
@@ -574,6 +575,31 @@ func TestListReportsHandler_InvalidCursor(t *testing.T) {
 	}
 	if response.Code != "VALIDATION_FAILED" {
 		t.Fatalf("expected VALIDATION_FAILED, got %s", response.Code)
+	}
+}
+
+func TestListReportsHandler_RejectsScopedCursorFromDifferentTenant(t *testing.T) {
+	store := reconciliation.NewMemoryStore()
+	r := setupReconcileRouter(nil, store, "tenant-b", string(auth.RoleMerchant))
+
+	cursor := pagination.EncodeScopedCursor("sub-1", "sub-1", "tenant-a")
+	req := httptest.NewRequest(http.MethodGet, "/reports?cursor="+cursor, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for cross-tenant cursor, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	var response ErrorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if response.Code != "VALIDATION_FAILED" {
+		t.Fatalf("expected VALIDATION_FAILED, got %s", response.Code)
+	}
+	if response.Details["reason"] != "cursor does not belong to this tenant" {
+		t.Fatalf("expected tenant mismatch reason, got %#v", response.Details["reason"])
 	}
 }
 

--- a/internal/pagination/cursor_test.go
+++ b/internal/pagination/cursor_test.go
@@ -1,6 +1,7 @@
 package pagination
 
 import (
+	"encoding/base64"
 	"testing"
 )
 
@@ -39,18 +40,31 @@ func TestDecodeEmpty(t *testing.T) {
 	}
 }
 
-func TestDecodeInvalid(t *testing.T) {
-	// Invalid base64
-	_, err := Decode("invalid-base64-!@#")
-	if err == nil {
-		t.Error("expected error for invalid base64")
+func TestDecodeRejectsMalformedCursors(t *testing.T) {
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{
+			name:   "non-base64",
+			cursor: "invalid-base64-!@#",
+		},
+		{
+			name:   "truncated-json-payload",
+			cursor: base64.URLEncoding.EncodeToString([]byte(`{"id":"usr_123"`)),
+		},
+		{
+			name:   "tampered-json-types",
+			cursor: base64.URLEncoding.EncodeToString([]byte(`{"id":123,"sort_value":true}`)),
+		},
 	}
 
-	// Valid base64 but invalid json
-	encodedInvalidJson := "bm90LWpzb24=" // "not-json" base64
-	_, err = Decode(encodedInvalidJson)
-	if err == nil {
-		t.Error("expected error for invalid json")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Decode(tc.cursor); err == nil {
+				t.Fatal("expected malformed cursor to be rejected")
+			}
+		})
 	}
 }
 
@@ -77,6 +91,79 @@ func TestPaginateSlice_Empty(t *testing.T) {
 	}
 }
 
+func TestPaginateSlice_LimitAtOrBeyondLength(t *testing.T) {
+	items := []dummyItem{
+		{"a", "10"},
+		{"b", "20"},
+		{"c", "30"},
+	}
+
+	tests := []struct {
+		name  string
+		limit int
+	}{
+		{
+			name:  "limit equals length",
+			limit: len(items),
+		},
+		{
+			name:  "limit exceeds length",
+			limit: len(items) + 5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			page := PaginateSlice(items, Cursor{}, tc.limit)
+			if len(page.Items) != len(items) {
+				t.Fatalf("expected %d items, got %d", len(items), len(page.Items))
+			}
+			if page.HasMore {
+				t.Fatal("expected hasMore false on final page")
+			}
+			if page.NextCursor != "" {
+				t.Fatalf("expected empty next cursor on final page, got %q", page.NextCursor)
+			}
+		})
+	}
+}
+
+func TestPaginateSlice_ExactPageBoundary(t *testing.T) {
+	items := []dummyItem{
+		{"a", "10"},
+		{"b", "20"},
+		{"c", "30"},
+		{"d", "40"},
+	}
+
+	page1 := PaginateSlice(items, Cursor{}, 2)
+	if len(page1.Items) != 2 {
+		t.Fatalf("expected 2 items on page1, got %d", len(page1.Items))
+	}
+	if !page1.HasMore {
+		t.Fatal("expected hasMore true on page1")
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("expected next cursor on page1")
+	}
+
+	next, err := Decode(page1.NextCursor)
+	if err != nil {
+		t.Fatalf("expected next cursor to decode: %v", err)
+	}
+
+	page2 := PaginateSlice(items, next, 2)
+	if len(page2.Items) != 2 {
+		t.Fatalf("expected 2 items on page2, got %d", len(page2.Items))
+	}
+	if page2.HasMore {
+		t.Fatal("expected hasMore false at exact boundary")
+	}
+	if page2.NextCursor != "" {
+		t.Fatalf("expected empty next cursor at exact boundary, got %q", page2.NextCursor)
+	}
+}
+
 func TestPaginateSlice_ContinuityAndDuplicates(t *testing.T) {
 	// Items are sorted by val ASC, id ASC
 	items := []dummyItem{
@@ -97,7 +184,7 @@ func TestPaginateSlice_ContinuityAndDuplicates(t *testing.T) {
 	if !page1.HasMore {
 		t.Error("expected hasMore true")
 	}
-	
+
 	next1, _ := Decode(page1.NextCursor)
 	if next1.ID != "b" || next1.SortValue != "10" {
 		t.Errorf("expected next1 to be b:10, got %v", next1)
@@ -111,7 +198,7 @@ func TestPaginateSlice_ContinuityAndDuplicates(t *testing.T) {
 	if !page2.HasMore {
 		t.Error("expected hasMore true")
 	}
-	
+
 	next2, _ := Decode(page2.NextCursor)
 	if next2.ID != "d" || next2.SortValue != "30" {
 		t.Errorf("expected next2 to be d:30, got %v", next2)

--- a/internal/pagination/scoped_cursor_test.go
+++ b/internal/pagination/scoped_cursor_test.go
@@ -31,9 +31,21 @@ func TestScopedCursor_EmptyString(t *testing.T) {
 
 func TestScopedCursor_WrongTenantRejected(t *testing.T) {
 	encoded := EncodeScopedCursor("id-1", "sort-val", "tenant-abc")
-	_, err := DecodeScopedCursor(encoded, "tenant-xyz")
+
+	cursor, err := DecodeScopedCursor(encoded, "tenant-abc")
+	if err != nil {
+		t.Fatalf("expected round-trip decode to succeed for source tenant: %v", err)
+	}
+	if cursor.ID != "id-1" || cursor.SortValue != "sort-val" {
+		t.Fatalf("unexpected cursor after round-trip: %+v", cursor)
+	}
+
+	_, err = DecodeScopedCursor(encoded, "tenant-xyz")
 	if err == nil {
 		t.Fatal("expected error for wrong tenant")
+	}
+	if err.Error() != "cursor does not belong to this tenant" {
+		t.Fatalf("expected tenant mismatch error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #229

---

Added test-only coverage for the pagination edge cases on test/pagination-edges.

In internal/pagination/cursor_test.go:1, Decode now has dedicated malformed-cursor cases for non-base64 input, truncated JSON payloads, and tampered payload types. The same file also adds page-boundary assertions for PaginateSlice: limit == len, limit > len, and an exact two-page boundary where the last page must return HasMore == false and an empty NextCursor.