### PR TITLE
feat: graceful HTTP server shutdown on SIGINT/SIGTERM

### DIFF
--- a/GRACEFUL_SHUTDOWN.md
+++ b/GRACEFUL_SHUTDOWN.md
@@ -1,247 +1,36 @@
-# Graceful Shutdown Implementation Summary
+# Graceful HTTP Server Shutdown
 
-## Overview
-This document provides a comprehensive summary of the graceful shutdown feature implementation for the Stella Bill backend service. The feature enables safe, coordinated shutdown of the HTTP server while ensuring all in-flight requests are properly drained and cleanup callbacks execute successfully.
+The HTTP server in `cmd/server/main.go` handles `SIGINT` and `SIGTERM` with a bounded graceful shutdown path.
 
-## Architecture
+## Runtime Behavior
 
-### Three-Phase Shutdown Process
+1. The server starts `ListenAndServe` in a goroutine.
+2. The main goroutine waits for either a startup/server error or a shutdown signal.
+3. On the first `SIGINT` or `SIGTERM`, the server calls `http.Server.Shutdown` with a 30 second timeout.
+4. In-flight requests are allowed to drain until the timeout expires.
+5. Route-level cleanup runs with the same bounded context:
+   - database pool close
+   - OpenTelemetry tracer shutdown/flush
+6. If graceful shutdown fails or times out, the server forces `Close` and exits non-zero.
+7. A second signal during graceful shutdown forces an immediate close and exits non-zero.
 
-1. **Phase 1: Request Draining** (configurable timeout)
-   - Server stops accepting new requests
-   - Waits for in-flight requests to complete naturally
-   - If timeout exceeded, forces close of remaining connections
-   - Ensures no new work starts during shutdown
+## Cleanup Ownership
 
-2. **Phase 2: Callback Execution** (configurable timeout)
-   - Executes all registered shutdown callbacks in order
-   - Callbacks receive context with deadline for their own cleanup
-   - Each callback runs concurrently but errors are logged
-   - Timeout ensures callbacks don't block the shutdown process
+`internal/routes.RegisterWithCleanup` configures routes and returns a cleanup callback for resources created during route wiring. The existing `routes.Register` remains available for tests and tools that do not own process shutdown.
 
-3. **Phase 3: Server Close**
-   - Closes HTTP server listener
-   - Completes graceful shutdown sequence
+The current server wiring does not start an outbox worker from `cmd/server/main.go`; when that worker is wired into the HTTP process, its `Stop` method should be added to the cleanup callback so it participates in the same bounded shutdown path.
 
-## Components
+## Validation Notes
 
-### Core Implementation
-- **File**: [internal/shutdown/shutdown.go](../../internal/shutdown/shutdown.go)
-- **Package**: `shutdown`
-- **Main Type**: `GracefulShutdown`
+The server lifecycle is covered by `cmd/server/main_test.go` for:
 
-### Key Methods
+- signal received before any request
+- in-flight request draining
+- shutdown timeout exceeded
+- second signal forcing immediate close
 
-#### `NewGracefulShutdown(server *http.Server, shutdownTimeout, drainTimeout time.Duration) *GracefulShutdown`
-- Initializes graceful shutdown with configured timeouts
-- `shutdownTimeout`: Total time for shutdown/callbacks
-- `drainTimeout`: Time to wait for in-flight requests
+Run verification with:
 
-#### `Shutdown()`
-- Initiates graceful shutdown sequence
-- Starts the three-phase shutdown process
-- Can be called multiple times safely (idempotent)
-
-#### `Wait() <-chan struct{}`
-- Blocks until shutdown is complete
-- Allows caller to synchronize shutdown completion
-
-#### `OnShutdown(fn func(context.Context) error)`
-- Registers callback to execute during Phase 2
-- Callbacks execute in registration order (sequentially)
-- Each callback receives shutdown context with deadline
-
-#### `IsShuttingDown() bool`
-- Returns true if shutdown is in progress
-
-### Context Management
-- Each callback receives a context with deadline set to `shutdownTimeout`
-- Allows callbacks to respect overall shutdown deadline
-- Context cancellation signals other callbacks to stop
-- Enables cooperative shutdown behavior
-
-## Features
-
-### Safety & Correctness
-✅ **Request Draining**: All in-flight requests complete or are forcibly closed
-✅ **Callback Execution**: User callbacks run in known order
-✅ **Timeout Protection**: No phase can block indefinitely
-✅ **Error Resilience**: Callback errors don't prevent shutdown
-✅ **Concurrency Safe**: Multiple goroutines can safely call Shutdown()
-✅ **Idempotent**: Calling Shutdown() multiple times is safe
-
-### Logging
-- Detailed logging at each phase
-- Callback execution tracking
-- Timeout warnings
-- Error reporting for failed callbacks
-
-## Testing
-
-### Test Coverage
-- **Unit Tests**: 15+ tests covering all core functionality
-- **Integration Tests**: 5+ tests with real HTTP servers and concurrent requests
-- **Total Runtime**: ~2.4 seconds
-
-### Test Categories
-
-#### Core Functionality Tests (shutdown_test.go)
-1. **TestNewGracefulShutdown**: Initialization
-2. **TestGracefulShutdown_OnShutdown**: Callback registration
-3. **TestGracefulShutdown_MultipleCallbacks**: Multiple callback support
-4. **TestGracefulShutdown_ShutdownCallbacks**: Callback execution order
-5. **TestGracefulShutdown_CallbackError**: Error handling
-6. **TestGracefulShutdown_CallbackTimeout**: Timeout behavior
-7. **TestGracefulShutdown_IsShuttingDown**: Status checking
-8. **TestGracefulShutdown_Wait**: Synchronization
-9. **TestGracefulShutdown_ShutdownOnlyOnce**: Idempotency
-10. **TestGracefulShutdown_WithPendingRequests**: Request draining
-11. **TestGracefulShutdown_ContextCancellation**: Context handling
-12. **TestGracefulShutdown_ConcurrentShutdown**: Concurrent calls
-
-#### Integration Tests (shutdown_integration_test.go)
-1. **TestGracefulShutdown_Integration_SimpleServer**: Basic HTTP server shutdown
-2. **TestGracefulShutdown_Integration_MultipleRequests**: Multiple concurrent requests
-3. **TestGracefulShutdown_Integration_CallbacksAndDraining**: Request/callback ordering
-4. **TestGracefulShutdown_Integration_RequestTimeout**: Timeout enforcement
-5. **TestGracefulShutdown_Integration_CallbackWithContext**: Context propagation
-
-## Usage Example
-
-```go
-package main
-
-import (
-	"context"
-	"net/http"
-	"time"
-	"internal/shutdown"
-)
-
-func main() {
-	server := &http.Server{
-		Addr: ":8080",
-		Handler: http.DefaultServeMux,
-	}
-
-	// Initialize graceful shutdown
-	gs := shutdown.NewGracefulShutdown(
-		server,
-		10*time.Second, // Total shutdown timeout
-		5*time.Second,  // Request drain timeout
-	)
-
-	// Register cleanup callbacks
-	gs.OnShutdown(func(ctx context.Context) error {
-		// Perform cleanup operations
-		// Context has deadline for cleanup to complete
-		return cleanupResources(ctx)
-	})
-
-	// Start server in background
-	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Server error: %v", err)
-		}
-	}()
-
-	// Wait for shutdown signal (e.g., from signal handler)
-	<-shutdownSignal
-
-	// Start graceful shutdown
-	gs.Shutdown()
-	gs.Wait()
-	
-	log.Println("Server shutdown complete")
-}
+```sh
+go test ./...
 ```
-
-## Integration with Main Server
-
-### In cmd/server/main.go
-```go
-// Initialize graceful shutdown
-gs := shutdown.NewGracefulShutdown(
-	server,
-	30*time.Second, // 30s total shutdown timeout
-	15*time.Second, // 15s request drain timeout
-)
-
-// Implement shutdown logic
-go func() {
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
-	
-	gs.Shutdown()
-}()
-
-// Wait for shutdown
-gs.Wait()
-```
-
-## Error Handling
-
-### Request Drain Timeout
-- If requests don't complete within `drainTimeout`, connections are forcibly closed
-- Logged as "Request drain timeout - forcing close"
-- Allows shutdown to proceed even with stuck requests
-
-### Callback Timeout
-- If callbacks don't complete within `shutdownTimeout`, they are abandoned
-- Logged as "Shutdown callback timeout - some callbacks did not complete in time"
-- Errors from timed-out callbacks are still reported
-
-### Callback Errors
-- Individual callback errors don't prevent other callbacks from running
-- Errors are logged but don't fail the shutdown
-- All callbacks execute regardless of previous errors
-
-## Performance Characteristics
-
-- **Typical shutdown time**: < 1 second (no pending requests)
-- **With pending requests**: Up to `drainTimeout` seconds
-- **Memory overhead**: Minimal (single GracefulShutdown instance)
-- **CPU overhead**: Negligible (waits in select loops)
-
-## Files Modified/Created
-
-1. **internal/shutdown/shutdown.go** - Core implementation (162 lines)
-2. **internal/shutdown/shutdown_test.go** - Unit tests (308 lines)
-3. **internal/shutdown/shutdown_integration_test.go** - Integration tests (261 lines)
-
-## Future Enhancements
-
-- [ ] Metrics collection for shutdown timing
-- [ ] Callback priority levels
-- [ ] Per-callback timeouts
-- [ ] Metrics export toprometheus
-- [ ] Health check during shutdown
-- [ ] Graceful degradation modes
-
-## Security notes
-
-- System handles shutdown safely
-- No data loss during interruption
-- Uses atomic operations / locks
-- Prevents partial writes
-
-## Runbook Docs
-
-## Reconciliation Service Runbook
-
-## Recommended Settings
-**Batch size**: 100
-**Timeout**: 30s
-**Retry attempts**: 3
-
-## Shutdown Behavior
-- Graceful shutdown supported
-- In-progress batch is stopped safely
-- Restart resumes from last checkpoint
-
-## References
-
-- [Go http.Server graceful shutdown](https://golang.org/pkg/net/http/#Server.Shutdown)
-- [Context package documentation](https://golang.org/pkg/context/)
-- [Sync package WaitGroup](https://golang.org/pkg/sync/#WaitGroup)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The backend includes a production-ready background worker system for automated b
 - **Distributed Locking**: Prevents duplicate processing when running multiple worker instances
 - **Retry Policy**: Automatic retry with exponential backoff (1s, 4s, 9s) for failed jobs
 - **Dead-Letter Queue**: Failed jobs after max attempts are moved for manual review
-- **Graceful Shutdown**: Workers complete in-flight jobs before shutting down
+- **Graceful Shutdown**: Workers and the HTTP server complete in-flight work before shutting down
 - **Metrics Tracking**: Monitor job processing statistics (processed, succeeded, failed, dead-lettered)
 - **Concurrent Workers**: Multiple workers can run safely without duplicate processing
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -21,18 +24,29 @@ var listenAndServe = func(srv *http.Server) error {
 	return srv.ListenAndServe()
 }
 
+const shutdownTimeout = 30 * time.Second
+
+type cleanupFunc func(context.Context) error
+
 func main() {
+	if err := run(); err != nil {
+		log.Printf("server shutdown failed: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	cfg, err := config.Load()
 	if err != nil {
 		printConfigError(err)
-		os.Exit(1)
+		return err
 	}
 
 	// Check if migrations should run on startup
 	runMigrationsOnStartup := os.Getenv("RUN_MIGRATIONS") == "true"
 	if runMigrationsOnStartup {
 		if err := applyMigrationsOnStartup(cfg); err != nil {
-			log.Fatalf("migrations failed: %v", err)
+			return fmt.Errorf("migrations failed: %w", err)
 		}
 	}
 
@@ -43,7 +57,7 @@ func main() {
 	router := gin.New()
 	router.Use(gin.Recovery())
 
-	routes.Register(router)
+	cleanup := routes.RegisterWithCleanup(router)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	srv := &http.Server{
@@ -54,10 +68,94 @@ func main() {
 		IdleTimeout:  time.Duration(cfg.IdleTimeout) * time.Second,
 	}
 
-	log.Printf("server listening on %s", addr)
-	if err := listenAndServe(srv); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("server error: %v", err)
+	shutdownCtx, secondSignal, stopSignals := notifyShutdownSignals()
+	defer stopSignals()
+
+	return runHTTPServer(shutdownCtx, secondSignal, srv, shutdownTimeout, cleanup)
+}
+
+func notifyShutdownSignals() (context.Context, <-chan os.Signal, func()) {
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	stop := func() {
+		signal.Stop(sigCh)
+		cancel()
 	}
+
+	return ctx, sigCh, stop
+}
+
+func runHTTPServer(ctx context.Context, secondSignal <-chan os.Signal, srv *http.Server, timeout time.Duration, cleanup cleanupFunc) error {
+	serverErr := make(chan error, 1)
+	go func() {
+		log.Printf("server listening on %s", srv.Addr)
+		serverErr <- listenAndServe(srv)
+	}()
+
+	select {
+	case err := <-serverErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("server error: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		log.Printf("shutdown signal received; allowing up to %s for graceful shutdown", timeout)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- srv.Shutdown(shutdownCtx)
+	}()
+
+	var err error
+	select {
+	case sig := <-secondSignal:
+		log.Printf("second shutdown signal received (%s); forcing server close", sig)
+		err = errors.Join(fmt.Errorf("forced shutdown after second signal: %s", sig), srv.Close())
+	case shutdownResult := <-shutdownErr:
+		if shutdownResult != nil {
+			log.Printf("http server graceful shutdown failed: %v", shutdownResult)
+			err = errors.Join(err, fmt.Errorf("http server shutdown: %w", shutdownResult))
+			err = errors.Join(err, srv.Close())
+		} else {
+			log.Printf("http server stopped accepting requests and drained in-flight work")
+		}
+	}
+
+	if cleanup != nil {
+		if cleanupErr := cleanup(shutdownCtx); cleanupErr != nil {
+			log.Printf("server cleanup failed: %v", cleanupErr)
+			err = errors.Join(err, fmt.Errorf("server cleanup: %w", cleanupErr))
+		} else {
+			log.Printf("server cleanup completed")
+		}
+	}
+
+	select {
+	case serveErr := <-serverErr:
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			err = errors.Join(err, fmt.Errorf("server error: %w", serveErr))
+		}
+	case <-time.After(time.Second):
+		err = errors.Join(err, errors.New("server did not stop after shutdown"))
+	}
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("graceful shutdown completed")
+	return nil
 }
 
 // applyMigrationsOnStartup loads and applies all pending migrations from the migrations directory.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3,14 +3,179 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"stellarbill-backend/internal/config"
 	"stellarbill-backend/internal/migrations"
 )
+
+func TestRunHTTPServer_ShutdownSignalBeforeAnyRequest(t *testing.T) {
+	ln, restore := listenOnLocalhost(t)
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var cleanupCalled atomic.Bool
+	srv := &http.Server{
+		Addr:    ln.Addr().String(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runHTTPServer(ctx, make(chan os.Signal), srv, time.Second, func(context.Context) error {
+			cleanupCalled.Store(true)
+			return nil
+		})
+	}()
+
+	waitForServer(t, ln.Addr().String())
+	cancel()
+
+	if err := <-done; err != nil {
+		t.Fatalf("expected graceful shutdown without active requests, got %v", err)
+	}
+	if !cleanupCalled.Load() {
+		t.Fatal("expected cleanup to be called")
+	}
+}
+
+func TestRunHTTPServer_DrainsInFlightRequest(t *testing.T) {
+	ln, restore := listenOnLocalhost(t)
+	defer restore()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := &http.Server{
+		Addr: ln.Addr().String(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			close(started)
+			<-release
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runHTTPServer(ctx, make(chan os.Signal), srv, time.Second, nil)
+	}()
+
+	clientDone := make(chan error, 1)
+	go func() {
+		resp, err := http.Get("http://" + ln.Addr().String())
+		if err != nil {
+			clientDone <- err
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			clientDone <- errors.New(resp.Status)
+			return
+		}
+		clientDone <- nil
+	}()
+
+	<-started
+	cancel()
+	close(release)
+
+	if err := <-clientDone; err != nil {
+		t.Fatalf("request should complete during graceful shutdown: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("expected graceful shutdown, got %v", err)
+	}
+}
+
+func TestRunHTTPServer_ShutdownTimeoutExceeded(t *testing.T) {
+	ln, restore := listenOnLocalhost(t)
+	defer restore()
+
+	started := make(chan struct{})
+	srv := &http.Server{
+		Addr: ln.Addr().String(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			close(started)
+			select {}
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runHTTPServer(ctx, make(chan os.Signal), srv, 25*time.Millisecond, nil)
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	clientDone := make(chan struct{})
+	go func() {
+		_, _ = client.Get("http://" + ln.Addr().String())
+		close(clientDone)
+	}()
+
+	<-started
+	cancel()
+
+	err := <-done
+	if err == nil {
+		t.Fatal("expected shutdown timeout error")
+	}
+	if !strings.Contains(err.Error(), "http server shutdown") {
+		t.Fatalf("expected shutdown error to mention http server shutdown, got %v", err)
+	}
+	<-clientDone
+}
+
+func TestRunHTTPServer_SecondSignalForcesClose(t *testing.T) {
+	ln, restore := listenOnLocalhost(t)
+	defer restore()
+
+	started := make(chan struct{})
+	srv := &http.Server{
+		Addr: ln.Addr().String(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			close(started)
+			select {}
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	secondSignal := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- runHTTPServer(ctx, secondSignal, srv, time.Second, nil)
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	clientDone := make(chan struct{})
+	go func() {
+		_, _ = client.Get("http://" + ln.Addr().String())
+		close(clientDone)
+	}()
+
+	<-started
+	cancel()
+	secondSignal <- syscall.SIGTERM
+
+	err := <-done
+	if err == nil {
+		t.Fatal("expected forced shutdown error")
+	}
+	if !strings.Contains(err.Error(), "forced shutdown after second signal") {
+		t.Fatalf("expected forced shutdown error, got %v", err)
+	}
+	<-clientDone
+}
 
 // TestApplyMigrationsOnStartup_MissingDatabase tests that applyMigrationsOnStartup fails gracefully
 // when the database connection string is invalid.
@@ -236,4 +401,39 @@ func TestDatabasePingVerifiesConnectivity(t *testing.T) {
 func BenchmarkApplyMigrationsOnStartup_WithoutMigrations(b *testing.B) {
 	// This benchmark is documented but not fully implemented without a test database
 	b.Log("benchmark: applyMigrationsOnStartup() with no migrations")
+}
+
+func listenOnLocalhost(t *testing.T) (net.Listener, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen on localhost: %v", err)
+	}
+
+	original := listenAndServe
+	listenAndServe = func(srv *http.Server) error {
+		return srv.Serve(ln)
+	}
+
+	return ln, func() {
+		listenAndServe = original
+		_ = ln.Close()
+	}
+}
+
+func waitForServer(t *testing.T, addr string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 25*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("server did not start listening on %s", addr)
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -24,14 +25,22 @@ import (
 
 // Register configures all routes on the provided router.
 func Register(r *gin.Engine) {
+	_ = RegisterWithCleanup(r)
+}
+
+// RegisterWithCleanup configures all routes and returns a cleanup function for
+// resources created during route wiring.
+func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 	cfg, err := config.Load()
 	if err != nil {
 		panic(fmt.Sprintf("failed to load configuration: %v", err))
 	}
 
+	var tracerShutdown func(context.Context) error
+
 	// Initialize tracing
 	if cfg.TracingExporter != "none" {
-		_, err := tracing.InitTracer(cfg.TracingServiceName)
+		tracerShutdown, err = tracing.InitTracer(cfg.TracingServiceName)
 		if err != nil {
 			fmt.Printf("Failed to initialize tracer: %v\n", err)
 		}
@@ -181,6 +190,22 @@ func Register(r *gin.Engine) {
 		reconStore := reconciliation.NewMemoryStore()
 		admin.POST("/reconcile", auth.RequirePermission(auth.PermManageSubscriptions), idemMiddleware, handlers.NewReconcileHandler(adapter, reconStore))
 		admin.GET("/reports", auth.RequirePermission(auth.PermReadReconciliation), handlers.NewListReportsHandler(reconStore))
+	}
+
+	return func(ctx context.Context) error {
+		if dbPool != nil {
+			log.Printf("closing database pool")
+			dbPool.Close()
+		}
+
+		if tracerShutdown != nil {
+			log.Printf("flushing tracer")
+			if err := tracerShutdown(ctx); err != nil {
+				return fmt.Errorf("shutdown tracer: %w", err)
+			}
+		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
This PR adds graceful shutdown handling for the HTTP server by running `ListenAndServe` in a goroutine, listening for `SIGINT`/`SIGTERM`, and calling `http.Server.Shutdown` with a bounded timeout so in-flight requests can drain before exit. It also forces server close and returns a non-zero exit path on shutdown failure, timeout, or a second signal, and wires route-owned cleanup so the database pool is closed and the OpenTelemetry tracer is flushed during shutdown. Coverage was added for shutdown before any request, in-flight request draining, timeout handling, and double-signal behavior, with docs updated to reflect the server lifecycle behavior.
closes #217 