### PR TITLE
Refactor/consolidate routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ This project follows a **spec-first** approach using OpenAPI 3.0.3. The specific
 - **Contract Tests**: Automatically validate that implementation matches the spec (`go test ./internal/contract/...`).
 - **CI Enforcement**: Pull requests are checked for undocumented endpoints via `go run ./cmd/openapi-validate`.
 - **Versioning**: Versioned endpoints use `/api/v1/` prefix; unversioned public endpoints (like health) stay at `/api/`.
+- **Legacy Alias Policy**: When a protected `/api/*` alias is retained for backward compatibility, it must reuse the same handler and RBAC as `/api/v1/*`, and only the legacy alias gets deprecation headers.
 - **Contributor Checklist**: See `docs/OPENAPI_GUIDE.md` for the full checklist when modifying API endpoints.
 
 ### Useful Commands

--- a/docs/OPENAPI_GUIDE.md
+++ b/docs/OPENAPI_GUIDE.md
@@ -22,6 +22,7 @@ When adding or modifying API endpoints, follow this checklist:
 - [ ] Register the route in `internal/routes/routes.go` (only once!)
 - [ ] Ensure consistent API versioning (use `/api/v1/` prefix for versioned endpoints)
 - [ ] Add authentication/authorization as specified in the OpenAPI security scheme
+- [ ] If a legacy `/api/*` alias must remain temporarily, wire it to the same handler and `RequirePermission` middleware as `/api/v1/*`, and keep `DeprecationHeaders` on the legacy alias only
 
 ### 3. Validate Contract
 - [ ] Run `go test ./internal/contract/...` to verify the endpoint matches the spec
@@ -36,6 +37,7 @@ When adding or modifying API endpoints, follow this checklist:
 
 - **Versioned endpoints**: All endpoints that require authentication should be under `/api/v1/` prefix.
 - **Unversioned endpoints**: Only public endpoints like health check may remain under `/api/` without version.
+- **Legacy aliases**: Deprecated `/api/*` aliases may exist for backward compatibility, but they must remain behaviorally identical to `/api/v1/*` and carry the deprecation headers instead of the canonical `/api/v1/*` route.
 - **Backward compatibility**: When making changes to existing endpoints:
   - Non-breaking changes (adding optional fields) can be done in the same version.
   - Breaking changes (removing fields, changing types) require a new version (`/api/v2/`).

--- a/internal/handlers/statements.go
+++ b/internal/handlers/statements.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"stellarbill-backend/internal/auth"
 	"stellarbill-backend/internal/repository"
 	"stellarbill-backend/internal/service"
 	"stellarbill-backend/internal/validation"
@@ -239,8 +240,19 @@ func getAuthContext(c *gin.Context) (callerID string, roles []string, ok bool) {
 		switch typed := rolesRaw.(type) {
 		case []string:
 			roles = typed
+		case []auth.Role:
+			roles = make([]string, 0, len(typed))
+			for _, role := range typed {
+				if trimmed := strings.TrimSpace(string(role)); trimmed != "" {
+					roles = append(roles, trimmed)
+				}
+			}
 		case string:
 			roles = []string{typed}
+		case auth.Role:
+			if trimmed := strings.TrimSpace(string(typed)); trimmed != "" {
+				roles = []string{trimmed}
+			}
 		default:
 			roles = []string{}
 		}

--- a/internal/handlers/statements_test.go
+++ b/internal/handlers/statements_test.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"stellarbill-backend/internal/auth"
 	"stellarbill-backend/internal/repository"
 	"stellarbill-backend/internal/service"
 )
@@ -16,22 +18,25 @@ import (
 // ── mock ─────────────────────────────────────────────────────────────────────
 
 type mockStatementsTestService struct {
-	detail       *service.StatementDetail
-	listDetail   *service.ListStatementsDetail
-	warnings     []string
-	count        int
-	err          error
-	capturedQ    repository.StatementQuery
-	capturedCust string
+	detail        *service.StatementDetail
+	listDetail    *service.ListStatementsDetail
+	warnings      []string
+	count         int
+	err           error
+	capturedQ     repository.StatementQuery
+	capturedCust  string
+	capturedRoles []string
 }
 
-func (m *mockStatementsTestService) GetDetail(_ context.Context, _ string, _ []string, _ string) (*service.StatementDetail, []string, error) {
+func (m *mockStatementsTestService) GetDetail(_ context.Context, _ string, roles []string, _ string) (*service.StatementDetail, []string, error) {
+	m.capturedRoles = roles
 	return m.detail, m.warnings, m.err
 }
 
-func (m *mockStatementsTestService) ListByCustomer(_ context.Context, _ string, _ []string, customerID string, q repository.StatementQuery) (*service.ListStatementsDetail, int, []string, error) {
+func (m *mockStatementsTestService) ListByCustomer(_ context.Context, _ string, roles []string, customerID string, q repository.StatementQuery) (*service.ListStatementsDetail, int, []string, error) {
 	m.capturedQ = q
 	m.capturedCust = customerID
+	m.capturedRoles = roles
 	return m.listDetail, m.count, m.warnings, m.err
 }
 
@@ -242,6 +247,32 @@ func TestGetStatement_HappyPath_WarningsIncluded(t *testing.T) {
 	}
 	if len(warns) != 1 || warns[0] != "subscription missing" {
 		t.Errorf("unexpected warnings: %v", warns)
+	}
+}
+
+func TestGetStatement_AuthRolesArePropagated(t *testing.T) {
+	svc := &mockStatementsTestService{
+		detail: &service.StatementDetail{ID: "stmt-1"},
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("callerID", "merchant-1")
+		c.Set(auth.RolesContextKey, []auth.Role{auth.RoleMerchant})
+		c.Next()
+	})
+	r.GET("/api/statements/:id", NewGetStatementHandler(svc))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/statements/stmt-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !reflect.DeepEqual(svc.capturedRoles, []string{"merchant"}) {
+		t.Fatalf("expected roles [merchant], got %v", svc.capturedRoles)
 	}
 }
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	AuthSubjectKey  = "auth_subject"
+	AuthSubjectKey = "auth_subject"
 )
 
 type RateLimiter struct {
@@ -38,10 +38,6 @@ func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
 	}
 }
 
-
-
-
-
 func Logging(logger *log.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
@@ -63,8 +59,6 @@ func Logging(logger *log.Logger) gin.HandlerFunc {
 		logger.Printf("%s", msg)
 	}
 }
-
-
 
 func RateLimit(limiter *RateLimiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -130,20 +124,23 @@ func (r *RateLimiter) Allow(key string) bool {
 	return true
 }
 
+// DeprecationHeaders marks legacy /api/* aliases as deprecated and points
+// clients at the canonical /api/v1/* successor. Do not attach it to /api/v1/*
+// routes.
 func DeprecationHeaders() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		path := c.Request.URL.Path
+		const legacyPrefix = "/api/"
+		const canonicalPrefix = "/api/v1/"
+		if !strings.HasPrefix(path, legacyPrefix) || strings.HasPrefix(path, canonicalPrefix) {
+			c.Next()
+			return
+		}
+
 		c.Header("Deprecation", "true")
 		c.Header("Sunset", time.Now().Add(180*24*time.Hour).Format(time.RFC1123))
-
-		path := c.Request.URL.Path
-		const prefix = "/api"
-		if strings.HasPrefix(path, prefix) {
-			successor := prefix + "/v1" + path[len(prefix):]
-			c.Header("Link", `<`+successor+`>; rel="successor-version"`)
-		}
+		c.Header("Link", `</api/v1`+path[len("/api"):]+`>; rel="successor-version"`)
 
 		c.Next()
 	}
 }
-
-

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
+const statementReadPermission = auth.PermReadSubscriptions
+
 // Register configures all routes on the provided router.
 func Register(r *gin.Engine) {
 	_ = RegisterWithCleanup(r)
@@ -116,6 +118,9 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 
 	// Create handlers
 	h := handlers.NewHandlerWithDependencies(handlerPlanSvc, handlerSubSvc, dbPool, nil)
+	changeSubscriptionStatusHandler := handlers.NewChangeSubscriptionStatusHandler(svc)
+	getStatementHandler := handlers.NewGetStatementHandler(stmtSvc)
+	listStatementsHandler := handlers.NewListStatementsHandler(stmtSvc)
 
 	// Admin handler receives the cached repos so PurgeCache can invalidate them.
 	adminToken := os.Getenv("ADMIN_TOKEN")
@@ -135,47 +140,15 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 	api.GET("/liveness", h.LivenessProbe)
 	api.GET("/readiness", h.ReadinessProbe)
 
-	// V1 routes are all protected
+	// /api/v1/* is the canonical authenticated surface. Legacy /api/* aliases
+	// stay wired through the same handlers and add deprecation headers only.
 	v1.Use(authMiddleware)
-	{
-		v1.GET("/subscriptions", auth.RequirePermission(auth.PermReadSubscriptions), h.ListSubscriptions)
-		v1.GET("/subscriptions/:id", auth.RequirePermission(auth.PermReadSubscriptions), h.GetSubscription)
-		v1.POST("/subscriptions/:id/status", auth.RequirePermission(auth.PermManageSubscriptions), handlers.NewChangeSubscriptionStatusHandler(svc))
-		v1.GET("/plans", h.ListPlans)
-		v1.GET("/statements/:id", handlers.NewGetStatementHandler(stmtSvc))
-		v1.GET("/statements", handlers.NewListStatementsHandler(stmtSvc))
-	}
+	registerProtectedAPIRoutes(v1, nil, h, changeSubscriptionStatusHandler, getStatementHandler, listStatementsHandler)
 
 	// Legacy /api routes - also protected
 	apiProtected := api.Group("")
 	apiProtected.Use(authMiddleware)
-	{
-		apiProtected.GET("/plans",
-			dep,
-			auth.RequirePermission(auth.PermReadPlans),
-			h.ListPlans,
-		)
-
-		apiProtected.GET("/subscriptions",
-			dep,
-			auth.RequirePermission(auth.PermReadSubscriptions),
-			h.ListSubscriptions,
-		)
-
-		apiProtected.GET("/subscriptions/:id",
-			dep,
-			auth.RequirePermission(auth.PermReadSubscriptions),
-			h.GetSubscription,
-		)
-		apiProtected.POST("/subscriptions/:id/status",
-			dep,
-			auth.RequirePermission(auth.PermManageSubscriptions),
-			handlers.NewChangeSubscriptionStatusHandler(svc),
-		)
-
-		apiProtected.GET("/statements/:id", handlers.NewGetStatementHandler(stmtSvc))
-		apiProtected.GET("/statements", handlers.NewListStatementsHandler(stmtSvc))
-	}
+	registerProtectedAPIRoutes(apiProtected, dep, h, changeSubscriptionStatusHandler, getStatementHandler, listStatementsHandler)
 
 	admin := api.Group("/admin")
 	admin.Use(authMiddleware)
@@ -207,6 +180,31 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 
 		return nil
 	}
+}
+
+func registerProtectedAPIRoutes(
+	group *gin.RouterGroup,
+	deprecation gin.HandlerFunc,
+	h *handlers.Handler,
+	changeSubscriptionStatusHandler gin.HandlerFunc,
+	getStatementHandler gin.HandlerFunc,
+	listStatementsHandler gin.HandlerFunc,
+) {
+	group.GET("/plans", protectedRouteHandlers(deprecation, auth.PermReadPlans, h.ListPlans)...)
+	group.GET("/subscriptions", protectedRouteHandlers(deprecation, auth.PermReadSubscriptions, h.ListSubscriptions)...)
+	group.GET("/subscriptions/:id", protectedRouteHandlers(deprecation, auth.PermReadSubscriptions, h.GetSubscription)...)
+	group.POST("/subscriptions/:id/status", protectedRouteHandlers(deprecation, auth.PermManageSubscriptions, changeSubscriptionStatusHandler)...)
+	group.GET("/statements/:id", protectedRouteHandlers(deprecation, statementReadPermission, getStatementHandler)...)
+	group.GET("/statements", protectedRouteHandlers(deprecation, statementReadPermission, listStatementsHandler)...)
+}
+
+func protectedRouteHandlers(deprecation gin.HandlerFunc, permission auth.Permission, handler gin.HandlerFunc) []gin.HandlerFunc {
+	handlers := make([]gin.HandlerFunc, 0, 3)
+	if deprecation != nil {
+		handlers = append(handlers, deprecation)
+	}
+	handlers = append(handlers, auth.RequirePermission(permission), handler)
+	return handlers
 }
 
 // mockHandlerSubSvc adapts *repository.MockSubscriptionRepo to handlers.SubscriptionService.

--- a/internal/routes/routes_registration_test.go
+++ b/internal/routes/routes_registration_test.go
@@ -1,0 +1,143 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	routeTestJWTSecret  = "RouteTest1!JwtSecret-MixedAlphaNumeric@123"
+	routeTestAdminToken = "RouteTest1!AdminToken-MixedAlphaNumeric@123"
+)
+
+func TestRegister_SubscriptionDetailAliasesMatchAndDeprecationIsLegacyOnly(t *testing.T) {
+	withRouteTestEnv(t)
+
+	router := newRegisteredTestRouter(t)
+	token := makeRouteTestJWT(t, "caller-1", "tenant-1", []string{"user"})
+
+	v1Res := performAuthorizedRequest(t, router, http.MethodGet, "/api/v1/subscriptions/sub-123", token)
+	legacyRes := performAuthorizedRequest(t, router, http.MethodGet, "/api/subscriptions/sub-123", token)
+
+	if v1Res.Code != http.StatusOK {
+		t.Fatalf("v1 route: expected 200, got %d", v1Res.Code)
+	}
+	if legacyRes.Code != http.StatusOK {
+		t.Fatalf("legacy route: expected 200, got %d", legacyRes.Code)
+	}
+	if got, want := legacyRes.Body.String(), v1Res.Body.String(); got != want {
+		t.Fatalf("expected identical subscription detail bodies, got legacy=%s v1=%s", got, want)
+	}
+
+	if got := v1Res.Header().Get("Deprecation"); got != "" {
+		t.Fatalf("v1 route should not emit Deprecation, got %q", got)
+	}
+	if got := v1Res.Header().Get("Sunset"); got != "" {
+		t.Fatalf("v1 route should not emit Sunset, got %q", got)
+	}
+	if got := v1Res.Header().Get("Link"); got != "" {
+		t.Fatalf("v1 route should not emit Link, got %q", got)
+	}
+
+	if got := legacyRes.Header().Get("Deprecation"); got != "true" {
+		t.Fatalf("legacy route should emit Deprecation=true, got %q", got)
+	}
+	if got := legacyRes.Header().Get("Sunset"); got == "" {
+		t.Fatal("legacy route should emit Sunset")
+	}
+	if got, want := legacyRes.Header().Get("Link"), `</api/v1/subscriptions/sub-123>; rel="successor-version"`; got != want {
+		t.Fatalf("legacy route should emit successor link %q, got %q", want, got)
+	}
+}
+
+func TestRegister_SubscriptionDetailAliasesEnforceRBAC(t *testing.T) {
+	withRouteTestEnv(t)
+
+	router := newRegisteredTestRouter(t)
+	token := makeRouteTestJWT(t, "caller-1", "tenant-1", []string{"customer"})
+
+	for _, path := range []string{"/api/v1/subscriptions/sub-123", "/api/subscriptions/sub-123"} {
+		res := performAuthorizedRequest(t, router, http.MethodGet, path, token)
+		if res.Code != http.StatusForbidden {
+			t.Fatalf("%s: expected 403 for customer role, got %d", path, res.Code)
+		}
+	}
+}
+
+func TestRegister_StatementAliasesRequirePermission(t *testing.T) {
+	withRouteTestEnv(t)
+
+	router := newRegisteredTestRouter(t)
+	token := makeRouteTestJWT(t, "caller-1", "tenant-1", []string{"customer"})
+
+	for _, path := range []string{
+		"/api/v1/statements?customer_id=caller-1",
+		"/api/statements?customer_id=caller-1",
+	} {
+		res := performAuthorizedRequest(t, router, http.MethodGet, path, token)
+		if res.Code != http.StatusForbidden {
+			t.Fatalf("%s: expected 403 for customer role, got %d", path, res.Code)
+		}
+	}
+}
+
+func TestRegister_V1PlansRequirePermission(t *testing.T) {
+	withRouteTestEnv(t)
+
+	router := newRegisteredTestRouter(t)
+	token := makeRouteTestJWT(t, "caller-1", "tenant-1", []string{"customer"})
+
+	res := performAuthorizedRequest(t, router, http.MethodGet, "/api/v1/plans", token)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for customer role on /api/v1/plans, got %d", res.Code)
+	}
+}
+
+func withRouteTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DATABASE_URL", "postgres://user:pass@localhost/db")
+	t.Setenv("JWT_SECRET", routeTestJWTSecret)
+	t.Setenv("ADMIN_TOKEN", routeTestAdminToken)
+	t.Setenv("TRACING_EXPORTER", "none")
+}
+
+func newRegisteredTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	Register(router)
+	return router
+}
+
+func makeRouteTestJWT(t *testing.T, subject, tenant string, roles []string) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":    subject,
+		"tenant": tenant,
+		"roles":  roles,
+		"exp":    time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := token.SignedString([]byte(routeTestJWTSecret))
+	if err != nil {
+		t.Fatalf("sign test JWT: %v", err)
+	}
+	return signed
+}
+
+func performAuthorizedRequest(t *testing.T, router *gin.Engine, method, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest(method, path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Tenant-ID", "tenant-1")
+	router.ServeHTTP(res, req)
+	return res
+}


### PR DESCRIPTION
Closes #234 

This consolidates duplicated protected route registration in internal/routes/routes.go so legacy /api/* aliases and canonical /api/v1/* endpoints share the same handlers and RBAC, eliminating drift between overlapping subscription, plan, and statement routes; specifically, both subscription detail paths now use the wired GetSubscription handler, RequirePermission is applied consistently across v1 and legacy groups, and deprecation headers are explicitly limited to legacy /api/* aliases only. It also fixes statement auth-context handling so roles written by auth middleware are correctly propagated to statement handlers, adds tests covering identical legacy/v1 subscription detail responses, RBAC enforcement on both alias sets, and legacy-only deprecation headers, and documents the route versioning/deprecation policy in the README and OpenAPI contributor guide.