### PR TITLE
feat: instrument HTTP and DB metrics and expose /metrics

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,9 +84,11 @@ type Config struct {
 	RateLimitRPS       int
 	RateLimitBurst     int
 	RateLimitWhitelist []string
+	// Metrics configuration
+	MetricsAllowedCIDRs []string
 	// Tracing configuration
-	TracingExporter    string
-	TracingServiceName string
+	TracingExporter        string
+	TracingServiceName     string
 	SecurityFrameAncestors string
 	// CORS configuration
 }
@@ -207,22 +209,22 @@ func Load(opts ...Option) (Config, error) {
 	}
 
 	cfg := Config{
-		Env:                 getEnv("ENV", "development"),
-		Port:                DefaultPort,
-		DBConn:              "",
-		JWTSecret:           "",
-		JWKSURL:             getEnv("JWKS_URL", ""),
-		MaxHeaderBytes:      MaxHeaderBytes,
-		MaxRequestSize:      getEnvInt64("MAX_REQUEST_SIZE", DefaultMaxRequestSize),
-		MaxGzipUncompressed: getEnvInt64("MAX_GZIP_UNCOMPRESSED", DefaultMaxGzipUncompressed),
-		MaxGzipRatio:        getEnvFloat64("MAX_GZIP_RATIO", DefaultMaxGzipRatio),
-		ReadTimeout:         DefaultReadTimeout,
-		WriteTimeout:        DefaultWriteTimeout,
-		IdleTimeout:         DefaultIdleTimeout,
-		TracingExporter:     getEnv("TRACING_EXPORTER", "stdout"),
-		TracingServiceName:  getEnv("TRACING_SERVICE_NAME", "stellabill-backend"),
-		AllowedOrigins:      getEnv("ALLOWED_ORIGINS", ""),
-		SecurityFrameAncestors: getEnv("SECURITY_FRAME_ANCESTORS", "'none'"),
+		Env:                     getEnv("ENV", "development"),
+		Port:                    DefaultPort,
+		DBConn:                  "",
+		JWTSecret:               "",
+		JWKSURL:                 getEnv("JWKS_URL", ""),
+		MaxHeaderBytes:          MaxHeaderBytes,
+		MaxRequestSize:          getEnvInt64("MAX_REQUEST_SIZE", DefaultMaxRequestSize),
+		MaxGzipUncompressed:     getEnvInt64("MAX_GZIP_UNCOMPRESSED", DefaultMaxGzipUncompressed),
+		MaxGzipRatio:            getEnvFloat64("MAX_GZIP_RATIO", DefaultMaxGzipRatio),
+		ReadTimeout:             DefaultReadTimeout,
+		WriteTimeout:            DefaultWriteTimeout,
+		IdleTimeout:             DefaultIdleTimeout,
+		TracingExporter:         getEnv("TRACING_EXPORTER", "stdout"),
+		TracingServiceName:      getEnv("TRACING_SERVICE_NAME", "stellabill-backend"),
+		AllowedOrigins:          getEnv("ALLOWED_ORIGINS", ""),
+		SecurityFrameAncestors:  getEnv("SECURITY_FRAME_ANCESTORS", "'none'"),
 		DBPoolMaxConns:          DefaultDBPoolMaxConns,
 		DBPoolMinConns:          DefaultDBPoolMinConns,
 		DBPoolMaxConnLifetime:   DefaultDBPoolMaxConnLifetime,
@@ -505,6 +507,27 @@ func (c *Config) validate(resolvedSecrets map[string]string, secretErrs map[stri
 		c.RateLimitWhitelist = paths
 	} else {
 		c.RateLimitWhitelist = []string{"/api/health"} // Only health check whitelisted by default
+	}
+	// Validate and set MetricsAllowedCIDRs
+	if cidrs := os.Getenv("METRICS_ALLOWED_CIDRS"); cidrs != "" {
+		parts := strings.Split(cidrs, ",")
+		var allowed []string
+		for _, part := range parts {
+			clean := strings.TrimSpace(part)
+			if clean != "" {
+				allowed = append(allowed, clean)
+			}
+		}
+		c.MetricsAllowedCIDRs = allowed
+	} else {
+		// Default to private/internal IP ranges
+		c.MetricsAllowedCIDRs = []string{
+			"127.0.0.0/8",
+			"10.0.0.0/8",
+			"172.16.0.0/12",
+			"192.168.0.0/16",
+			"::1/128",
+		}
 	}
 
 	// Validate TRACING_EXPORTER

--- a/internal/middleware/ip_restriction.go
+++ b/internal/middleware/ip_restriction.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func IPRestrictionMiddleware(allowedCIDRs []string) gin.HandlerFunc {
+	var allowedNets []*net.IPNet
+	for _, cidr := range allowedCIDRs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err == nil {
+			allowedNets = append(allowedNets, ipnet)
+		}
+	}
+	return func(c *gin.Context) {
+		remoteIP := getClientIP(c)
+		ip := net.ParseIP(remoteIP)
+		if ip == nil {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		for _, net := range allowedNets {
+			if net.Contains(ip) {
+				c.Next()
+				return
+			}
+		}
+		c.AbortWithStatus(http.StatusForbidden)
+	}
+}

--- a/internal/repository/postgres/plan_repo.go
+++ b/internal/repository/postgres/plan_repo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"stellarbill-backend/internal/metrics"
 	"stellarbill-backend/internal/repository"
 
 	"go.opentelemetry.io/otel"
@@ -39,8 +40,10 @@ func (r *PlanRepo) FindByID(ctx context.Context, id string) (*repository.PlanRow
 		trace.WithAttributes(attribute.String("plan.id", id)))
 	defer span.End()
 
+	timer := metrics.DBTimer("find_by_id", "plans")
 	err := r.pool.QueryRow(ctx, q, id).
 		Scan(&p.ID, &p.Name, &p.Amount, &p.Currency, &p.Interval, &p.Description)
+	timer(err)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, repository.ErrNotFound

--- a/internal/repository/postgres/subscription_repo.go
+++ b/internal/repository/postgres/subscription_repo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"stellarbill-backend/internal/metrics"
 	"stellarbill-backend/internal/repository"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -39,11 +40,13 @@ func (r *SubscriptionRepo) FindByID(ctx context.Context, id string) (*repository
 		trace.WithAttributes(attribute.String("subscription.id", id)))
 	defer span.End()
 
+	timer := metrics.DBTimer("find_by_id", "subscriptions")
 	err := r.pool.QueryRow(ctx, q, id).Scan(
 		&s.ID, &s.PlanID, &s.CustomerID, &s.Status,
 		&s.Amount, &s.Currency, &s.Interval, &s.NextBilling,
 		&deletedAt,
 	)
+	timer(err)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, repository.ErrNotFound

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -11,6 +11,7 @@ import (
 	"stellarbill-backend/internal/cache"
 	"stellarbill-backend/internal/config"
 	"stellarbill-backend/internal/handlers"
+	"stellarbill-backend/internal/metrics"
 	"stellarbill-backend/internal/middleware"
 	"stellarbill-backend/internal/reconciliation"
 	"stellarbill-backend/internal/repository"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
@@ -51,8 +53,12 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 	r.Use(middleware.Recovery())
 	r.Use(otelgin.Middleware(cfg.TracingServiceName))
 	r.Use(middleware.TraceIDMiddleware())
+	r.Use(metrics.MetricsMiddleware())
 
 	r.Use(middleware.CORS(cfg.Env, cfg.AllowedOrigins))
+
+	// Metrics endpoint with IP restriction
+	r.GET("/metrics", middleware.IPRestrictionMiddleware(cfg.MetricsAllowedCIDRs), gin.WrapH(promhttp.Handler()))
 
 	// Apply rate limiting middleware
 	rateLimitConfig := middleware.RateLimiterConfig{


### PR DESCRIPTION
- Updated Config ( internal/config/config.go ): Added MetricsAllowedCIDRs with defaults for private/internal IP ranges (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, ::1/128).
- Created IP Restriction Middleware ( internal/middleware/ip_restriction.go ): Added IPRestrictionMiddleware to limit /metrics access to only allowed CIDR ranges, using the existing getClientIP function from ratelimit middleware.
- Added Metrics to Routes ( internal/routes/routes.go ):

- Imported internal/metrics and prometheus client
- Added metrics.MetricsMiddleware() to global middleware stack
- Registered /metrics endpoint with IPRestrictionMiddleware using promhttp.Handler()
- Instrumented Postgres Repos:

- Modified internal/repository/postgres/plan_repo.go to use metrics.DBTimer("find_by_id", "plans")
- Modified internal/repository/postgres/subscription_repo.go to use metrics.DBTimer("find_by_id", "subscriptions")

closes #275 