### PR TITLE
feat: expose dead-letter inspection and requeue endpoint

### DIFF
--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -2,7 +2,12 @@ package handlers
 
 import (
 	"database/sql"
+	"net/http"
+	"strconv"
+
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"stellarbill-backend/internal/audit"
 	"stellarbill-backend/internal/outbox"
 	"stellarbill-backend/internal/repositories"
 )
@@ -28,6 +33,7 @@ type Handler struct {
 	Outbox        interface{} // OutboxHealther - dependency for queue health checks
 	SubRepo       repositories.SubscriptionRepository
 	PlanRepo      repositories.PlanRepository
+	OutboxRepo    outbox.Repository
 }
 
 // NewHandler creates a new Handler with the given dependencies
@@ -53,4 +59,56 @@ func NewHandlerWithDependencies(
 		Database:      db,
 		Outbox:        outbox,
 	}
+}
+
+// ListDeadLetteredEvents handles GET /api/admin/outbox/dead-letter
+func (h *Handler) ListDeadLetteredEvents(c *gin.Context) {
+	if h.OutboxRepo == nil {
+		RespondWithError(c, http.StatusServiceUnavailable, ErrorCodeInternal, "outbox repository not available")
+		return
+	}
+
+	limit := 100
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	events, err := h.OutboxRepo.ListDeadLetteredEvents(limit)
+	if err != nil {
+		RespondWithError(c, http.StatusInternalServerError, ErrorCodeInternal, "failed to list dead-lettered events")
+		return
+	}
+
+	c.JSON(http.StatusOK, events)
+}
+
+// RequeueOutboxEvent handles POST /api/admin/outbox/:id/requeue
+func (h *Handler) RequeueOutboxEvent(c *gin.Context) {
+	if h.OutboxRepo == nil {
+		RespondWithError(c, http.StatusServiceUnavailable, ErrorCodeInternal, "outbox repository not available")
+		return
+	}
+
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		RespondWithError(c, http.StatusBadRequest, ErrorCodeInvalidRequest, "invalid event ID")
+		return
+	}
+
+	err = h.OutboxRepo.RequeueEvent(id)
+	if err != nil {
+		if err.Error() == "event not found or not in failed status" {
+			RespondWithError(c, http.StatusNotFound, ErrorCodeNotFound, err.Error())
+			return
+		}
+		RespondWithError(c, http.StatusInternalServerError, ErrorCodeInternal, "failed to requeue event")
+		return
+	}
+
+	audit.LogAction(c, "outbox_requeue", idStr, "success", nil)
+
+	c.Status(http.StatusNoContent)
 }

--- a/internal/outbox/repository.go
+++ b/internal/outbox/repository.go
@@ -180,6 +180,63 @@ func (r *postgresRepository) DeleteCompletedEvents(olderThan time.Time) (int64, 
 	return result.RowsAffected()
 }
 
+// ListDeadLetteredEvents retrieves dead-lettered (failed) events
+func (r *postgresRepository) ListDeadLetteredEvents(limit int) ([]*Event, error) {
+	query := `
+		SELECT id, event_type, event_data, aggregate_id, aggregate_type,
+			   occurred_at, status, retry_count, max_retries, next_retry_at,
+			   error_message, created_at, updated_at, version, deduplication_id
+		FROM dead_letter_events
+		LIMIT $1
+	`
+	
+	rows, err := r.db.Query(query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dead-lettered events: %w", err)
+	}
+	defer rows.Close()
+	
+	var events []*Event
+	for rows.Next() {
+		event, err := r.scanEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating dead-lettered events: %w", err)
+	}
+	
+	return events, nil
+}
+
+// RequeueEvent resets a failed event to pending for reprocessing
+func (r *postgresRepository) RequeueEvent(id uuid.UUID) error {
+	query := `
+		UPDATE outbox_events
+		SET status = $1, retry_count = 0, next_retry_at = NULL, error_message = NULL
+		WHERE id = $2 AND status = $3
+	`
+	
+	result, err := r.db.Exec(query, StatusPending, id, StatusFailed)
+	if err != nil {
+		return fmt.Errorf("failed to requeue event: %w", err)
+	}
+	
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	
+	if rowsAffected == 0 {
+		return fmt.Errorf("event not found or not in failed status")
+	}
+	
+	return nil
+}
+
 // scanEvent scans a database row into an Event struct
 func (r *postgresRepository) scanEvent(scanner interface{ Scan(...interface{}) error }) (*Event, error) {
 	var event Event

--- a/internal/outbox/types.go
+++ b/internal/outbox/types.go
@@ -58,6 +58,8 @@ type Repository interface {
 	MarkAsProcessing(id uuid.UUID) error
 	IncrementRetryCount(id uuid.UUID, nextRetryAt time.Time, errorMessage *string) error
 	DeleteCompletedEvents(olderThan time.Time) (int64, error)
+	ListDeadLetteredEvents(limit int) ([]*Event, error)
+	RequeueEvent(id uuid.UUID) error
 }
 
 // Dispatcher handles the outbox event dispatching

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"stellarbill-backend/internal/config"
 	"stellarbill-backend/internal/handlers"
 	"stellarbill-backend/internal/middleware"
+	"stellarbill-backend/internal/outbox"
 	"stellarbill-backend/internal/reconciliation"
 	"stellarbill-backend/internal/repository"
 	"stellarbill-backend/internal/service"
@@ -116,6 +118,17 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 
 	// Create handlers
 	h := handlers.NewHandlerWithDependencies(handlerPlanSvc, handlerSubSvc, dbPool, nil)
+	// Set up outbox repository if db is available
+	if dbPool != nil {
+		var sqlDB *sql.DB
+		// Try to get *sql.DB from dbPool (which is *pgxpool.Pool)
+		if d, ok := dbPool.(interface{ Config() *pgxpool.Config }); ok {
+			// Alternatively, we can open a *sql.DB via lib/pq
+			connStr := d.Config().ConnString()
+			sqlDB, _ = sql.Open("postgres", connStr)
+			h.OutboxRepo = outbox.NewPostgresRepository(sqlDB)
+		}
+	}
 
 	// Admin handler receives the cached repos so PurgeCache can invalidate them.
 	adminToken := os.Getenv("ADMIN_TOKEN")
@@ -190,6 +203,10 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 		reconStore := reconciliation.NewMemoryStore()
 		admin.POST("/reconcile", auth.RequirePermission(auth.PermManageSubscriptions), idemMiddleware, handlers.NewReconcileHandler(adapter, reconStore))
 		admin.GET("/reports", auth.RequirePermission(auth.PermReadReconciliation), handlers.NewListReportsHandler(reconStore))
+
+		// Outbox dead-letter endpoints
+		admin.GET("/outbox/dead-letter", auth.RequirePermission(auth.PermManageReconciliation), h.ListDeadLetteredEvents)
+		admin.POST("/outbox/:id/requeue", auth.RequirePermission(auth.PermManageReconciliation), idemMiddleware, h.RequeueOutboxEvent)
 	}
 
 	return func(ctx context.Context) error {

--- a/migrations/0007_outbox_dead_letter_view.down.sql
+++ b/migrations/0007_outbox_dead_letter_view.down.sql
@@ -1,0 +1,2 @@
+-- Drop dead letter view
+DROP VIEW IF EXISTS dead_letter_events;

--- a/migrations/0007_outbox_dead_letter_view.up.sql
+++ b/migrations/0007_outbox_dead_letter_view.up.sql
@@ -1,0 +1,8 @@
+-- Create dead letter view for outbox events
+CREATE OR REPLACE VIEW dead_letter_events AS
+SELECT id, event_type, event_data, aggregate_id, aggregate_type,
+       occurred_at, status, retry_count, max_retries, next_retry_at,
+       error_message, created_at, updated_at, version
+FROM outbox_events
+WHERE status = 'failed'
+ORDER BY occurred_at DESC;


### PR DESCRIPTION
Closes #272

---

Adds support for inspecting dead-lettered outbox events and requeuing them:

- Adds a dead_letter_events view
- Adds ListDeadLetteredEvents and RequeueEvent methods to outbox.Repository
- Adds GET /api/admin/outbox/dead-letter endpoint (requires manage:reconciliation permission)
- Adds POST /api/admin/outbox/:id/requeue endpoint (requires manage:reconciliation permission and idempotency key)
- Audits requeue actions