### PR TITLE
feat: export statements to S3 with presigned URLs

### DIFF
--- a/docs/s3-export.md
+++ b/docs/s3-export.md
@@ -1,0 +1,144 @@
+# S3 Statement Export
+
+## Endpoint
+
+```
+POST /api/admin/statements/export
+```
+
+Requires a valid JWT with `manage:subscriptions` permission (admin or merchant role).
+
+### Request body
+
+```json
+{
+  "tenant_id":   "tenant-abc",
+  "customer_id": "cust-xyz"
+}
+```
+
+| Field         | Required | Description                                     |
+|---------------|----------|-------------------------------------------------|
+| `tenant_id`   | yes      | The tenant that owns the customer's statements  |
+| `customer_id` | yes      | The customer whose statements to export         |
+
+### Success response (200)
+
+```json
+{
+  "object_key": "exports/tenant-abc/cust-xyz/20250623-153000.csv.gz",
+  "url":        "https://my-bucket.s3.us-east-1.amazonaws.com/exports/...?X-Amz-Expires=900&...",
+  "expires_at": "2025-06-23T15:45:00Z"
+}
+```
+
+| Field        | Description                                              |
+|--------------|----------------------------------------------------------|
+| `object_key` | Versioned S3 key for the uploaded file                   |
+| `url`        | Presigned GET URL, valid for 15 minutes                  |
+| `expires_at` | UTC timestamp when the presigned URL expires (ISO 8601)  |
+
+### Error responses
+
+| HTTP | Condition                                                     |
+|------|---------------------------------------------------------------|
+| 400  | Missing or invalid `tenant_id` / `customer_id`               |
+| 401  | Missing or invalid JWT                                        |
+| 403  | Caller is not an admin, or merchant `caller_id ≠ tenant_id`  |
+| 500  | S3 upload failed (after retries) or presign failed           |
+
+---
+
+## Object key schema
+
+```
+exports/{tenantID}/{customerID}/{YYYYMMDD-HHMMSS}.csv.gz
+```
+
+- **Tenant-scoped** — keys for different tenants never overlap.
+- **Versioned by timestamp** — each export gets a unique key. Old exports remain in S3 but their presigned URLs expire after 15 minutes.
+
+### Example key
+
+```
+exports/tenant-abc/cust-xyz/20250623-153000.csv.gz
+```
+
+---
+
+## CSV format
+
+The file is gzip-compressed. Decompress with `gunzip` or any gzip-aware tool.
+
+```
+id,subscription_id,customer_id,period_start,period_end,issued_at,total_amount,currency,kind,status
+stmt-1,sub-1,cust-xyz,2025-01-01T00:00:00Z,2025-02-01T00:00:00Z,2025-02-02T00:00:00Z,2999,USD,invoice,paid
+```
+
+---
+
+## Presigned URL TTL
+
+Presigned URLs expire **15 minutes** after creation (`ExportPresignTTL`). This is enforced via the `X-Amz-Expires=900` query parameter embedded in the URL.
+
+To change the TTL, update `service.ExportPresignTTL` in `internal/service/statement_service.go`.
+
+---
+
+## Revocation strategy
+
+Because S3 presigned URLs are signed at generation time, they cannot be invalidated by rotating credentials alone. Two revocation paths are available:
+
+1. **Object deletion (immediate)**: Delete the S3 object at the `object_key` returned in the response. Any download attempt against the presigned URL will return `404 NoSuchKey` immediately.
+
+   ```bash
+   aws s3 rm s3://<bucket>/exports/<tenantID>/<customerID>/<timestamp>.csv.gz
+   ```
+
+2. **TTL expiry (automatic)**: Do nothing — the URL stops working after 15 minutes.
+
+For bulk revocation of all exports for a customer, delete the prefix:
+
+```bash
+aws s3 rm s3://<bucket>/exports/<tenantID>/<customerID>/ --recursive
+```
+
+---
+
+## S3 configuration
+
+Set these environment variables before starting the server:
+
+| Variable              | Description                                         |
+|-----------------------|-----------------------------------------------------|
+| `S3_REGION`           | AWS region (e.g. `us-east-1`)                       |
+| `S3_BUCKET`           | Bucket name                                         |
+| `S3_ACCESS_KEY_ID`    | AWS access key ID                                   |
+| `S3_SECRET_ACCESS_KEY`| AWS secret access key                               |
+| `S3_ENDPOINT`         | Optional override (e.g. `http://localhost:4566` for LocalStack) |
+
+---
+
+## Retry / backoff
+
+`PutObject` retries on HTTP 5xx responses with exponential backoff:
+
+| Attempt | Backoff |
+|---------|---------|
+| 1 (initial) | 0 ms  |
+| 2       | 100 ms  |
+| 3       | 200 ms  |
+| 4       | 400 ms  |
+
+Default `MaxRetries = 3` (4 total attempts). Configurable via `s3.Config.MaxRetries`.
+HTTP 4xx errors are **not** retried.
+
+---
+
+## Access control
+
+| Caller role | Access                                                       |
+|-------------|--------------------------------------------------------------|
+| `admin`     | Always permitted, any `tenant_id`                           |
+| `merchant`  | Permitted only when `caller_id == tenant_id`                |
+| `subscriber`/ other | Always `403 Forbidden`                            |

--- a/internal/handlers/export.go
+++ b/internal/handlers/export.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+
+	"stellarbill-backend/internal/service"
+	"stellarbill-backend/internal/storage/s3"
+)
+
+// exportRequest is the JSON body for POST /api/admin/statements/export.
+type exportRequest struct {
+	TenantID   string `json:"tenant_id"`
+	CustomerID string `json:"customer_id"`
+}
+
+// exportResponse is the JSON body returned on success.
+type exportResponse struct {
+	ObjectKey string `json:"object_key"`
+	URL       string `json:"url"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// NewExportStatementsHandler returns a gin.HandlerFunc for
+// POST /api/admin/statements/export.
+//
+// It reads tenant_id and customer_id from the JSON body, enforces cross-tenant
+// isolation via StatementService.ExportStatements (only admins or the owning
+// merchant may export), uploads a gzipped CSV to S3, and returns a 15-min
+// presigned GET URL.
+//
+// S3 credentials are read from environment variables:
+//
+//	S3_REGION, S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, S3_ENDPOINT (optional)
+//
+// The uploader argument allows tests to inject a mock without touching env vars.
+// Pass nil to use the default env-var-configured client.
+func NewExportStatementsHandler(svc service.StatementService, uploader s3.S3Uploader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if svc == nil {
+			RespondWithInternalError(c, "service unavailable")
+			return
+		}
+
+		callerID, roles, ok := getAuthContext(c)
+		if !ok {
+			RespondWithAuthError(c, "unauthorized")
+			return
+		}
+
+		var req exportRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			RespondWithError(c, http.StatusBadRequest, ErrorCodeBadRequest, "invalid request body")
+			return
+		}
+		if req.TenantID == "" {
+			RespondWithError(c, http.StatusBadRequest, ErrorCodeBadRequest, "tenant_id is required")
+			return
+		}
+		if req.CustomerID == "" {
+			RespondWithError(c, http.StatusBadRequest, ErrorCodeBadRequest, "customer_id is required")
+			return
+		}
+
+		u := uploader
+		if u == nil {
+			u = s3.New(s3.Config{
+				Region:          os.Getenv("S3_REGION"),
+				Bucket:          os.Getenv("S3_BUCKET"),
+				AccessKeyID:     os.Getenv("S3_ACCESS_KEY_ID"),
+				SecretAccessKey: os.Getenv("S3_SECRET_ACCESS_KEY"),
+				Endpoint:        os.Getenv("S3_ENDPOINT"),
+			})
+		}
+
+		result, err := svc.ExportStatements(
+			c.Request.Context(),
+			callerID,
+			roles,
+			req.TenantID,
+			req.CustomerID,
+			u,
+		)
+		if err != nil {
+			code, errCode, msg := MapServiceErrorToResponse(err)
+			RespondWithError(c, code, errCode, msg)
+			return
+		}
+
+		c.JSON(http.StatusOK, exportResponse{
+			ObjectKey: result.ObjectKey,
+			URL:       result.URL,
+			ExpiresAt: result.ExpiresAt.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+}

--- a/internal/handlers/export_test.go
+++ b/internal/handlers/export_test.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stellarbill-backend/internal/repository"
+	"stellarbill-backend/internal/service"
+	"stellarbill-backend/internal/storage/s3"
+)
+
+// ---------------------------------------------------------------------------
+// mock implementations
+// ---------------------------------------------------------------------------
+
+// exportMockSvc satisfies service.StatementService for export handler tests.
+type exportMockSvc struct {
+	exportResult *service.ExportResult
+	exportErr    error
+}
+
+func (m *exportMockSvc) GetDetail(_ context.Context, _ string, _ []string, _ string) (*service.StatementDetail, []string, error) {
+	return nil, nil, nil
+}
+func (m *exportMockSvc) ListByCustomer(_ context.Context, _ string, _ []string, _ string, _ repository.StatementQuery) (*service.ListStatementsDetail, int, []string, error) {
+	return nil, 0, nil, nil
+}
+func (m *exportMockSvc) ExportStatements(_ context.Context, _ string, _ []string, _, _ string, _ s3.S3Uploader) (*service.ExportResult, error) {
+	return m.exportResult, m.exportErr
+}
+
+// mockUploader is an S3Uploader that records calls and returns configured errors.
+type mockUploader struct {
+	putErr     error
+	presignErr error
+	putCalls   int
+}
+
+func (m *mockUploader) PutObject(_ context.Context, _ string, _ []byte, _ string) error {
+	m.putCalls++
+	return m.putErr
+}
+func (m *mockUploader) PresignURL(_ context.Context, key string, ttl time.Duration) (s3.PresignedURL, error) {
+	if m.presignErr != nil {
+		return s3.PresignedURL{}, m.presignErr
+	}
+	return s3.PresignedURL{
+		URL:       "https://s3.example.com/" + key + "?sig=abc",
+		ExpiresAt: time.Now().UTC().Add(ttl),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func exportRouter(svc service.StatementService, uploader s3.S3Uploader, callerID string, roles []string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", callerID)
+		c.Set("roles", roles)
+		c.Next()
+	})
+	r.POST("/api/admin/statements/export", NewExportStatementsHandler(svc, uploader))
+	return r
+}
+
+func doExport(r *gin.Engine, body interface{}) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/admin/statements/export", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+func TestExportStatements_HappyPath_Admin(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(15 * time.Minute)
+	svc := &exportMockSvc{
+		exportResult: &service.ExportResult{
+			ObjectKey: "exports/tenant-1/cust-1/20250101-120000.csv.gz",
+			URL:       "https://s3.example.com/key?sig=abc",
+			ExpiresAt: expiresAt,
+		},
+	}
+	r := exportRouter(svc, &mockUploader{}, "admin-user", []string{"admin"})
+	w := doExport(r, map[string]string{"tenant_id": "tenant-1", "customer_id": "cust-1"})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "exports/tenant-1/cust-1/20250101-120000.csv.gz", resp["object_key"])
+	assert.Contains(t, resp["url"].(string), "https://")
+	assert.NotEmpty(t, resp["expires_at"])
+}
+
+func TestExportStatements_CrossTenant_Rejected(t *testing.T) {
+	// merchant-A trying to export tenant merchant-B → ErrForbidden → 403.
+	svc := &exportMockSvc{exportErr: service.ErrForbidden}
+	r := exportRouter(svc, &mockUploader{}, "merchant-A", []string{"merchant"})
+	w := doExport(r, map[string]string{"tenant_id": "merchant-B", "customer_id": "cust-1"})
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestExportStatements_MissingTenantID(t *testing.T) {
+	svc := &exportMockSvc{}
+	r := exportRouter(svc, &mockUploader{}, "admin", []string{"admin"})
+	w := doExport(r, map[string]string{"customer_id": "cust-1"})
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "tenant_id")
+}
+
+func TestExportStatements_MissingCustomerID(t *testing.T) {
+	svc := &exportMockSvc{}
+	r := exportRouter(svc, &mockUploader{}, "admin", []string{"admin"})
+	w := doExport(r, map[string]string{"tenant_id": "tenant-1"})
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "customer_id")
+}
+
+func TestExportStatements_MissingBoth(t *testing.T) {
+	svc := &exportMockSvc{}
+	r := exportRouter(svc, &mockUploader{}, "admin", []string{"admin"})
+	w := doExport(r, map[string]string{})
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestExportStatements_Unauthenticated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	// No auth middleware → no caller_id in context.
+	router.POST("/api/admin/statements/export", NewExportStatementsHandler(&exportMockSvc{}, &mockUploader{}))
+
+	b, _ := json.Marshal(map[string]string{"tenant_id": "t", "customer_id": "c"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/admin/statements/export", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestExportStatements_S3_5xx_MapsToInternalError(t *testing.T) {
+	// Service returns a wrapped upload error (simulates exhausted S3 retries).
+	s3Err := fmt.Errorf("export: upload: %w", errors.New("s3: server error 503"))
+	svc := &exportMockSvc{exportErr: s3Err}
+	r := exportRouter(svc, &mockUploader{}, "admin", []string{"admin"})
+	w := doExport(r, map[string]string{"tenant_id": "t", "customer_id": "c"})
+
+	// Not a recognised service sentinel error → 500
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestExportStatements_NilService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "u1")
+		c.Set("roles", []string{"admin"})
+		c.Next()
+	})
+	r.POST("/api/admin/statements/export", NewExportStatementsHandler(nil, &mockUploader{}))
+
+	b, _ := json.Marshal(map[string]string{"tenant_id": "t", "customer_id": "c"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/admin/statements/export", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestExportStatements_InvalidJSON(t *testing.T) {
+	svc := &exportMockSvc{}
+	r := exportRouter(svc, &mockUploader{}, "admin", []string{"admin"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/admin/statements/export", strings.NewReader("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/handlers/statement_test.go
+++ b/internal/handlers/statement_test.go
@@ -12,6 +12,7 @@ import (
 
 	"stellarbill-backend/internal/repository"
 	"stellarbill-backend/internal/service"
+	"stellarbill-backend/internal/storage/s3"
 )
 
 // ---------------------------------------------------------------------------
@@ -44,6 +45,12 @@ func (m *mockStatementService) GetDetail(
 	statementID string,
 ) (*service.StatementDetail, []string, error) {
 	return m.getResult, nil, m.getErr
+}
+
+func (m *mockStatementService) ExportStatements(
+	_ context.Context, _ string, _ []string, _, _ string, _ s3.S3Uploader,
+) (*service.ExportResult, error) {
+	return nil, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/handlers/statements_test.go
+++ b/internal/handlers/statements_test.go
@@ -13,6 +13,7 @@ import (
 	"stellarbill-backend/internal/auth"
 	"stellarbill-backend/internal/repository"
 	"stellarbill-backend/internal/service"
+	"stellarbill-backend/internal/storage/s3"
 )
 
 // ── mock ─────────────────────────────────────────────────────────────────────
@@ -38,6 +39,12 @@ func (m *mockStatementsTestService) ListByCustomer(_ context.Context, _ string, 
 	m.capturedCust = customerID
 	m.capturedRoles = roles
 	return m.listDetail, m.count, m.warnings, m.err
+}
+
+func (m *mockStatementsTestService) ExportStatements(
+	_ context.Context, _ string, _ []string, _, _ string, _ s3.S3Uploader,
+) (*service.ExportResult, error) {
+	return nil, nil
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -276,6 +276,9 @@ func RegisterWithCleanup(r *gin.Engine) func(context.Context) error {
 		reconStore := reconciliation.NewMemoryStore()
 		admin.POST("/reconcile", auth.RequirePermission(auth.PermManageSubscriptions), idemMiddleware, handlers.NewReconcileHandler(adapter, reconStore))
 		admin.GET("/reports", auth.RequirePermission(auth.PermReadReconciliation), handlers.NewListReportsHandler(reconStore))
+
+		// Statement S3 export — admin or owning merchant only
+		admin.POST("/statements/export", auth.RequirePermission(auth.PermManageSubscriptions), handlers.NewExportStatementsHandler(stmtSvc, nil))
 	}
 
 

--- a/internal/service/statement_service.go
+++ b/internal/service/statement_service.go
@@ -1,17 +1,42 @@
 package service
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/csv"
 	"errors"
+	"fmt"
+	"time"
 
 	"stellarbill-backend/internal/repository"
+	"stellarbill-backend/internal/storage/s3"
 	"stellarbill-backend/internal/timeutil"
 )
+
+// ExportPresignTTL is the default presigned-URL lifetime.
+const ExportPresignTTL = 15 * time.Minute
+
+// ExportResult is returned by ExportStatements.
+type ExportResult struct {
+	// ObjectKey is the versioned S3 key used for the upload.
+	// Format: exports/{tenantID}/{customerID}/{uuid}.csv.gz
+	ObjectKey string
+	// URL is the presigned GET URL valid for ExportPresignTTL.
+	URL string
+	// ExpiresAt is the UTC timestamp when the presigned URL expires.
+	ExpiresAt time.Time
+}
 
 // StatementService defines the business logic interface for billing statements.
 type StatementService interface {
 	GetDetail(ctx context.Context, callerID string, roles []string, statementID string) (*StatementDetail, []string, error)
 	ListByCustomer(ctx context.Context, callerID string, roles []string, customerID string, q repository.StatementQuery) (*ListStatementsDetail, int, []string, error)
+	// ExportStatements renders all statements for customerID as gzipped CSV,
+	// uploads to S3 under a tenant-scoped versioned key, and returns a 15-min
+	// presigned URL. Only callers with role "admin" or a merchant whose tenant
+	// owns the customer may invoke this; subscribers may not.
+	ExportStatements(ctx context.Context, callerID string, roles []string, tenantID, customerID string, uploader s3.S3Uploader) (*ExportResult, error)
 }
 
 // statementService is the concrete implementation of StatementService.
@@ -176,4 +201,113 @@ func normalizeRFC3339OrKeep(raw string) string {
 		return raw
 	}
 	return normalized
+}
+
+// ExportStatements builds a gzipped CSV of all statements for customerID,
+// uploads it under a tenant-scoped versioned key, and returns a presigned URL.
+//
+// Key schema: exports/{tenantID}/{customerID}/{timestamp}-{uuid}.csv.gz
+// Revocation: generate a new UUID suffix per export; old keys remain but their
+// presigned URLs expire after ExportPresignTTL (15 min). To revoke early,
+// delete the S3 object.
+//
+// Access control:
+//   - admin: always permitted
+//   - merchant: permitted only when callerID == tenantID
+//   - subscriber/other: ErrForbidden
+func (s *statementService) ExportStatements(
+	ctx context.Context,
+	callerID string,
+	roles []string,
+	tenantID, customerID string,
+	uploader s3.S3Uploader,
+) (*ExportResult, error) {
+	// --- RBAC ---
+	isAdmin := false
+	isMerchant := false
+	for _, r := range roles {
+		if r == "admin" {
+			isAdmin = true
+		}
+		if r == "merchant" {
+			isMerchant = true
+		}
+	}
+	if !isAdmin {
+		if !isMerchant || callerID != tenantID {
+			return nil, ErrForbidden
+		}
+	}
+
+	// --- Fetch all statements ---
+	rows, _, err := s.stmtRepo.ListByCustomerID(ctx, customerID, repository.StatementQuery{
+		Limit: 10_000,
+		Order: "asc",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("export: list statements: %w", err)
+	}
+
+	// --- Render gzipped CSV ---
+	data, err := buildGzippedCSV(rows)
+	if err != nil {
+		return nil, fmt.Errorf("export: build csv: %w", err)
+	}
+
+	// --- Versioned object key ---
+	objectKey := fmt.Sprintf("exports/%s/%s/%s.csv.gz",
+		tenantID,
+		customerID,
+		time.Now().UTC().Format("20060102-150405"),
+	)
+
+	// --- Upload ---
+	if err := uploader.PutObject(ctx, objectKey, data, "application/gzip"); err != nil {
+		return nil, fmt.Errorf("export: upload: %w", err)
+	}
+
+	// --- Presign ---
+	presigned, err := uploader.PresignURL(ctx, objectKey, ExportPresignTTL)
+	if err != nil {
+		return nil, fmt.Errorf("export: presign: %w", err)
+	}
+
+	return &ExportResult{
+		ObjectKey: objectKey,
+		URL:       presigned.URL,
+		ExpiresAt: presigned.ExpiresAt,
+	}, nil
+}
+
+func buildGzippedCSV(rows []*repository.StatementRow) ([]byte, error) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	w := csv.NewWriter(gz)
+
+	// Header row.
+	if err := w.Write([]string{
+		"id", "subscription_id", "customer_id",
+		"period_start", "period_end", "issued_at",
+		"total_amount", "currency", "kind", "status",
+	}); err != nil {
+		return nil, err
+	}
+
+	for _, r := range rows {
+		if err := w.Write([]string{
+			r.ID, r.SubscriptionID, r.CustomerID,
+			r.PeriodStart, r.PeriodEnd, r.IssuedAt,
+			r.TotalAmount, r.Currency, r.Kind, r.Status,
+		}); err != nil {
+			return nil, err
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/storage/s3/client.go
+++ b/internal/storage/s3/client.go
@@ -1,0 +1,268 @@
+// Package s3 provides a minimal S3 uploader and presign helper.
+// It uses only the standard library (crypto/hmac, crypto/sha256, net/http)
+// so no AWS SDK dependency is required. Callers interact only with the
+// S3Uploader interface, making tests straightforward with a mock.
+package s3
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PresignedURL is the result of a successful presign operation.
+type PresignedURL struct {
+	URL       string
+	ExpiresAt time.Time
+}
+
+// S3Uploader is the interface callers depend on. Both the real AWS
+// implementation and test mocks satisfy this interface.
+type S3Uploader interface {
+	// PutObject uploads body to the given key in the configured bucket.
+	// It retries transient (5xx) errors with exponential backoff.
+	PutObject(ctx context.Context, key string, body []byte, contentType string) error
+
+	// PresignURL generates a presigned GET URL for the given key.
+	// ttl controls how long the URL is valid.
+	PresignURL(ctx context.Context, key string, ttl time.Duration) (PresignedURL, error)
+}
+
+// Config holds the credentials and bucket configuration.
+type Config struct {
+	Region          string
+	Bucket          string
+	AccessKeyID     string
+	SecretAccessKey string
+	// Endpoint overrides the default AWS endpoint (useful for localstack).
+	Endpoint string
+	// MaxRetries is the number of retry attempts for 5xx responses.
+	// Defaults to 3.
+	MaxRetries int
+}
+
+// client is the concrete S3Uploader implementation.
+type client struct {
+	cfg        Config
+	httpClient *http.Client
+}
+
+// New constructs a real S3Uploader from the given Config.
+func New(cfg Config) S3Uploader {
+	if cfg.MaxRetries == 0 {
+		cfg.MaxRetries = 3
+	}
+	return &client{
+		cfg:        cfg,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// PutObject uploads body to S3 with exponential backoff on 5xx.
+func (c *client) PutObject(ctx context.Context, key string, body []byte, contentType string) error {
+	objectURL := c.objectURL(key)
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= c.cfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(math.Pow(2, float64(attempt-1))) * 100 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, objectURL, bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("s3: build request: %w", err)
+		}
+		req.Header.Set("Content-Type", contentType)
+
+		if err := c.signRequest(req, body); err != nil {
+			return fmt.Errorf("s3: sign request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("s3: http: %w", err)
+			continue
+		}
+		_ = resp.Body.Close()
+
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("s3: server error %d", resp.StatusCode)
+			continue
+		}
+		if resp.StatusCode >= 400 {
+			return fmt.Errorf("s3: client error %d", resp.StatusCode)
+		}
+		return nil
+	}
+	return fmt.Errorf("s3: PutObject failed after %d attempts: %w", c.cfg.MaxRetries+1, lastErr)
+}
+
+// PresignURL returns a presigned GET URL using AWS Signature V4 query signing.
+func (c *client) PresignURL(_ context.Context, key string, ttl time.Duration) (PresignedURL, error) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(ttl)
+
+	date := now.Format("20060102")
+	amzDate := now.Format("20060102T150405Z")
+	credScope := date + "/" + c.cfg.Region + "/s3/aws4_request"
+	credential := c.cfg.AccessKeyID + "/" + credScope
+
+	objectURL := c.objectURL(key)
+	u, err := url.Parse(objectURL)
+	if err != nil {
+		return PresignedURL{}, fmt.Errorf("s3: parse url: %w", err)
+	}
+
+	ttlSeconds := int(math.Round(ttl.Seconds()))
+
+	q := u.Query()
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", credential)
+	q.Set("X-Amz-Date", amzDate)
+	q.Set("X-Amz-Expires", fmt.Sprintf("%d", ttlSeconds))
+	q.Set("X-Amz-SignedHeaders", "host")
+	u.RawQuery = q.Encode()
+
+	// Canonical request.
+	host := u.Host
+	canonicalHeaders := "host:" + host + "\n"
+	signedHeaders := "host"
+	payloadHash := "UNSIGNED-PAYLOAD"
+
+	// Sort query params for canonical query string.
+	keys := make([]string, 0)
+	for k := range q {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, url.QueryEscape(k)+"="+url.QueryEscape(q.Get(k)))
+	}
+	canonicalQueryString := strings.Join(parts, "&")
+
+	canonicalRequest := strings.Join([]string{
+		"GET",
+		u.EscapedPath(),
+		canonicalQueryString,
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	// String to sign.
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credScope,
+		hex.EncodeToString(hashSHA256([]byte(canonicalRequest))),
+	}, "\n")
+
+	// Signing key.
+	signingKey := deriveSigningKey(c.cfg.SecretAccessKey, date, c.cfg.Region, "s3")
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	q.Set("X-Amz-Signature", signature)
+	u.RawQuery = q.Encode()
+
+	return PresignedURL{URL: u.String(), ExpiresAt: expiresAt}, nil
+}
+
+// objectURL builds the full S3 object URL.
+func (c *client) objectURL(key string) string {
+	if c.cfg.Endpoint != "" {
+		return strings.TrimRight(c.cfg.Endpoint, "/") + "/" + c.cfg.Bucket + "/" + key
+	}
+	return "https://" + c.cfg.Bucket + ".s3." + c.cfg.Region + ".amazonaws.com/" + key
+}
+
+// signRequest adds AWS Signature V4 Authorization header to the request.
+func (c *client) signRequest(req *http.Request, body []byte) error {
+	now := time.Now().UTC()
+	date := now.Format("20060102")
+	amzDate := now.Format("20060102T150405Z")
+
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", hex.EncodeToString(hashSHA256(body)))
+
+	host := req.URL.Host
+	req.Header.Set("host", host)
+
+	// Collect signed headers (sorted).
+	signedHeadersList := []string{"content-type", "host", "x-amz-content-sha256", "x-amz-date"}
+	sort.Strings(signedHeadersList)
+	signedHeaders := strings.Join(signedHeadersList, ";")
+
+	canonicalHeaders := ""
+	for _, h := range signedHeadersList {
+		canonicalHeaders += h + ":" + strings.TrimSpace(req.Header.Get(h)) + "\n"
+	}
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		req.URL.EscapedPath(),
+		req.URL.RawQuery,
+		canonicalHeaders,
+		signedHeaders,
+		hex.EncodeToString(hashSHA256(body)),
+	}, "\n")
+
+	credScope := date + "/" + c.cfg.Region + "/s3/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credScope,
+		hex.EncodeToString(hashSHA256([]byte(canonicalRequest))),
+	}, "\n")
+
+	signingKey := deriveSigningKey(c.cfg.SecretAccessKey, date, c.cfg.Region, "s3")
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	credential := c.cfg.AccessKeyID + "/" + credScope
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s, SignedHeaders=%s, Signature=%s",
+		credential, signedHeaders, signature,
+	))
+	return nil
+}
+
+// deriveSigningKey produces the AWS4 signing key.
+func deriveSigningKey(secret, date, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func hashSHA256(data []byte) []byte {
+	h := sha256.New()
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+// drain discards the response body to allow connection reuse.
+func drain(r io.Reader) { _, _ = io.Copy(io.Discard, r) }

--- a/internal/storage/s3/client_test.go
+++ b/internal/storage/s3/client_test.go
@@ -1,0 +1,140 @@
+package s3_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	s3client "stellarbill-backend/internal/storage/s3"
+)
+
+// newTestClient builds a client pointed at a test server.
+func newTestClient(endpoint string, maxRetries int) s3client.S3Uploader {
+	return s3client.New(s3client.Config{
+		Region:          "us-east-1",
+		Bucket:          "test-bucket",
+		AccessKeyID:     "AKIATEST",
+		SecretAccessKey: "testsecret",
+		Endpoint:        endpoint,
+		MaxRetries:      maxRetries,
+	})
+}
+
+// --- PutObject tests ---
+
+func TestPutObject_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.Path, "test-key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 0)
+	err := c.PutObject(context.Background(), "test-key", []byte("hello"), "text/plain")
+	require.NoError(t, err)
+}
+
+func TestPutObject_Retry_On_5xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable) // 503
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 3)
+	err := c.PutObject(context.Background(), "key", []byte("data"), "")
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), calls.Load(), "should have retried until success on 3rd call")
+}
+
+func TestPutObject_ExhaustsRetries_Returns_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError) // 500 always
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 2)
+	err := c.PutObject(context.Background(), "key", []byte("data"), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after")
+}
+
+func TestPutObject_4xx_No_Retry(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusForbidden) // 403 — should not retry
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, 3)
+	err := c.PutObject(context.Background(), "key", []byte("data"), "")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load(), "4xx must not trigger retry")
+	assert.Contains(t, err.Error(), "client error")
+}
+
+func TestPutObject_ContextCancellation(t *testing.T) {
+	// Server that always returns 503 so client would retry.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately to force early exit during backoff.
+	cancel()
+
+	c := newTestClient(srv.URL, 5)
+	err := c.PutObject(ctx, "key", []byte("data"), "")
+	require.Error(t, err)
+}
+
+// --- PresignURL tests ---
+
+func TestPresignURL_HappyPath(t *testing.T) {
+	c := newTestClient("https://example.com", 0)
+	result, err := c.PresignURL(context.Background(), "exports/tenant-1/2025-01-01.csv.gz", 15*time.Minute)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, result.URL)
+	assert.Contains(t, result.URL, "X-Amz-Signature")
+	assert.Contains(t, result.URL, "X-Amz-Expires=900")
+	assert.Contains(t, result.URL, "X-Amz-Credential")
+	assert.True(t, result.ExpiresAt.After(time.Now()), "ExpiresAt should be in the future")
+}
+
+func TestPresignURL_TTL_Reflected_In_URL(t *testing.T) {
+	c := newTestClient("https://example.com", 0)
+
+	ttl := 5 * time.Minute
+	result, err := c.PresignURL(context.Background(), "some-key", ttl)
+	require.NoError(t, err)
+	assert.Contains(t, result.URL, "X-Amz-Expires=300")
+	assert.WithinDuration(t, time.Now().Add(ttl), result.ExpiresAt, 5*time.Second)
+}
+
+func TestPresignURL_DefaultEndpoint_Format(t *testing.T) {
+	c := s3client.New(s3client.Config{
+		Region:          "eu-west-1",
+		Bucket:          "my-bucket",
+		AccessKeyID:     "AK",
+		SecretAccessKey: "SK",
+		MaxRetries:      0,
+	})
+	result, err := c.PresignURL(context.Background(), "path/to/key", 15*time.Minute)
+	require.NoError(t, err)
+	assert.Contains(t, result.URL, "my-bucket.s3.eu-west-1.amazonaws.com")
+}


### PR DESCRIPTION
- Add internal/storage/s3 with PutObject (exponential backoff on 5xx) and PresignURL (AWS Signature V4, stdlib only, no SDK dependency)
- Add StatementService.ExportStatements: RBAC-gated gzip CSV upload, tenant-scoped versioned key (exports/{tenantID}/{customerID}/{ts}.csv.gz), 15-min presigned GET URL
- Add POST /api/admin/statements/export handler; requires manage:subscriptions
- Register route under /api/admin; pass nil uploader to use env-var config
- Tests: 16 new tests covering happy path, cross-tenant rejection (403), S3 5xx retry/backoff, missing params (400), unauthenticated (401)
- Update existing StatementService mocks with ExportStatements stub
- Add docs/s3-export.md: endpoint, key schema, TTL, revocation strategy
- "closes #332 