### PR TITLE
docs: add capacity planning playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Go (Gin) API backend for Stellabill - subscription and billing plans API. This r
 - [What this backend provides (for the frontend)](#what-this-backend-provides-for-the-frontend)
 - [Background Worker](#background-worker)
 - [Local setup](#local-setup)
+- [Operational playbooks](#operational-playbooks)
 - [Configuration](#configuration)
 - [Testing](#testing)
 - [API reference](#api-reference)
@@ -158,6 +159,15 @@ curl -X POST http://localhost:8080/api/outbox/test
 ```
 
 ---
+
+## Operational playbooks
+
+Keep the operational docs close to the code so the measurement workflow is easy to find during review and incident response:
+
+- [Capacity planning playbook](docs/runbooks/capacity-planning.md)
+- [Operational runbooks index](docs/ops/README.md)
+
+The capacity planning playbook includes the reproducible snapshot script, the sizing model, alert thresholds, and the edge-case checks for zero-traffic and burst-traffic tenant profiles.
 
 ## Configuration
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -11,6 +11,7 @@ This directory contains incident response runbooks for the Stellabill backend se
 | [auth-failure-runbook.md](./auth-failure-runbook.md) | JWT validation failures, tenant mismatches, admin token errors | 401 rate > 10 % in 5 min |
 | [db-outage-runbook.md](./db-outage-runbook.md) | PostgreSQL outages, connection pool exhaustion, replica lag, slow queries | Health check `"db": "down"` for > 2 min |
 | [elevated-errors-runbook.md](./elevated-errors-runbook.md) | 5xx spike, panics, worker failures, latency degradation | 5xx rate > 5 % in 5 min |
+| [../runbooks/capacity-planning.md](../runbooks/capacity-planning.md) | Capacity planning, tenant growth sizing, CPU/memory/IOPS estimates | Measured prod snapshots required |
 
 ---
 

--- a/docs/runbooks/capacity-planning.md
+++ b/docs/runbooks/capacity-planning.md
@@ -1,0 +1,116 @@
+# Capacity Planning Playbook
+
+This playbook turns production Prometheus snapshots into a repeatable sizing model for Stellabill. The goal is to estimate the cost of one tenant and then map tenant counts to required app and database capacity.
+
+## What to Measure
+
+Capture two snapshots from the same production environment:
+
+- A baseline snapshot under low or zero tenant activity.
+- A peak snapshot after a representative load window.
+
+Required metrics:
+
+- `process_cpu_seconds_total`
+- `process_resident_memory_bytes`
+- `db_pool_stats{stat="active_conns"}`
+- `db_pool_stats{stat="max_conns"}`
+- `db_queries_total`
+- `pg_stat_database_blks_read`
+- `pg_stat_database_blks_written`
+
+If the Postgres exporter exposes additional I/O metrics, include them in the same snapshot. Do not include request bodies, secrets, or token values in the export.
+
+## Reproducible Collection Script
+
+Use the helper script to capture the baseline and peak snapshots:
+
+```bash
+scripts/capacity-collect.sh http://localhost:8080/api/metrics 300 ./artifacts/capacity
+```
+
+The script writes:
+
+- `baseline-*.prom`
+- `peak-*.prom`
+- `metadata-*.json`
+
+For a real production run, point the URL at the read-only metrics endpoint and keep the collection window short enough to avoid noisy traffic changes.
+
+## Sizing Model
+
+The sizing tool computes a linear per-tenant estimate from the baseline and peak snapshots:
+
+- `cpu_mcores_per_tenant = ((peak_cpu_seconds_total - base_cpu_seconds_total) / window_seconds) * 1000 / observed_tenants`
+- `memory_mib_per_tenant = (peak_memory_bytes - base_memory_bytes) / MiB / observed_tenants`
+- `postgres_iops_per_tenant = ((peak_blks_read + peak_blks_written) - (base_blks_read + base_blks_written)) / window_seconds / observed_tenants`
+- `db_queries_qps_per_tenant = (peak_db_queries_total - base_db_queries_total) / window_seconds / observed_tenants`
+
+The recommended cluster size is then:
+
+- `required_cpu = headroom * cpu_mcores_per_tenant * target_tenants`
+- `required_memory = headroom * (baseline_memory_mib + memory_mib_per_tenant * target_tenants)`
+- `required_postgres_iops = headroom * postgres_iops_per_tenant * target_tenants`
+
+The default headroom is `1.25`.
+
+## Tooling
+
+Run the planner against the captured snapshots:
+
+```bash
+go run ./tools/capacity \
+  -base ./artifacts/capacity/baseline.prom \
+  -peak ./artifacts/capacity/peak.prom \
+  -window 5m \
+  -tenants 120 \
+  -tenant-counts 50,100,250
+```
+
+Optional output:
+
+```bash
+go run ./tools/capacity -base ... -peak ... -window 5m -tenants 120 -json
+```
+
+## Alerting Thresholds
+
+Use these thresholds as the initial alert baseline, then tune them against your own production histograms:
+
+| Signal | Warning | Critical |
+|---|---:|---:|
+| App CPU | > 70 % of pod request for 10 min | > 85 % for 5 min |
+| App memory | > 75 % of pod limit for 10 min | > 90 % for 5 min |
+| DB pool saturation | active connections > 80 % of max | > 90 % or sustained acquire failures |
+| DB query latency | p99 > 500 ms | p99 > 2 s |
+| Postgres IOPS | > 70 % of provisioned budget | > 90 % of provisioned budget |
+
+For app-level DB pool saturation, use `db_pool_stats{stat="active_conns"}` and `db_pool_stats{stat="max_conns"}`. For Postgres saturation, rely on your Postgres exporter or cloud provider metrics.
+
+## Tenant Profiles
+
+Validate two edge cases before promoting sizing guidance:
+
+1. Zero-traffic tenant profile
+   - Baseline and peak snapshots are effectively identical.
+   - Per-tenant CPU and IOPS should evaluate to zero.
+   - Memory should still preserve the baseline process footprint.
+2. Burst-traffic tenant profile
+   - The peak snapshot should include a clear traffic spike.
+   - CPU, query rate, and IOPS should all increase monotonically.
+   - The resulting replica count should not decrease as tenant counts rise.
+
+## Security Notes
+
+- Use read-only metrics access.
+- Do not query production databases with write permissions for sizing.
+- Do not export PII, tokens, request bodies, or authorization headers.
+- Keep the metrics snapshots and generated reports in a restricted artifact location.
+
+## Review Checklist
+
+- [ ] Baseline and peak snapshots are archived.
+- [ ] Tenant count used for the measurement window is documented.
+- [ ] `go run ./tools/capacity ...` output is attached to the change.
+- [ ] Alert thresholds were validated against production history.
+- [ ] No sensitive values appear in the snapshot files or report.

--- a/scripts/capacity-collect.sh
+++ b/scripts/capacity-collect.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  cat <<'EOF' >&2
+usage: scripts/capacity-collect.sh <metrics-url> <window-seconds> [output-dir]
+
+Captures a baseline and peak Prometheus snapshot for capacity planning.
+Example:
+  scripts/capacity-collect.sh http://localhost:8080/api/metrics 300 ./artifacts/capacity
+EOF
+  exit 2
+fi
+
+metrics_url="$1"
+window_seconds="$2"
+output_dir="${3:-./artifacts/capacity}"
+
+mkdir -p "$output_dir"
+
+base_ts="$(date -u +%Y%m%dT%H%M%SZ)"
+curl -fsSL "$metrics_url" > "$output_dir/baseline-$base_ts.prom"
+sleep "$window_seconds"
+peak_ts="$(date -u +%Y%m%dT%H%M%SZ)"
+curl -fsSL "$metrics_url" > "$output_dir/peak-$peak_ts.prom"
+
+cat > "$output_dir/metadata-$base_ts.json" <<EOF
+{
+  "metrics_url": "$metrics_url",
+  "window_seconds": $window_seconds,
+  "baseline_snapshot": "baseline-$base_ts.prom",
+  "peak_snapshot": "peak-$peak_ts.prom"
+}
+EOF
+
+echo "Wrote baseline-$base_ts.prom and peak-$peak_ts.prom to $output_dir"

--- a/tools/capacity/main.go
+++ b/tools/capacity/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	var (
+		basePath   = flag.String("base", "", "path to the baseline Prometheus snapshot")
+		peakPath   = flag.String("peak", "", "path to the production Prometheus snapshot")
+		window     = flag.Duration("window", 15*time.Minute, "measurement window between snapshots")
+		tenants    = flag.Int("tenants", 0, "observed tenant count for the production snapshot")
+		counts     = flag.String("tenant-counts", "", "comma-separated tenant counts to size (defaults to -tenants)")
+		podCPU     = flag.Int("pod-cpu-milli", 500, "CPU limit per app pod in millicores")
+		podMemory  = flag.Int("pod-memory-mib", 1024, "memory limit per app pod in MiB")
+		headroom   = flag.Float64("headroom", 1.25, "safety multiplier applied to the measured totals")
+		outputJSON = flag.Bool("json", false, "emit JSON instead of a table")
+	)
+	flag.Parse()
+
+	if *basePath == "" || *peakPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: capacity -base baseline.prom -peak peak.prom [-window 15m] [-tenants 100] [-tenant-counts 100,250,500]")
+		os.Exit(2)
+	}
+
+	baseSnapshot, err := readSnapshotFile(*basePath)
+	must(err)
+
+	peakSnapshot, err := readSnapshotFile(*peakPath)
+	must(err)
+
+	observedTenants := *tenants
+	if observedTenants < 0 {
+		fatalf("-tenants cannot be negative")
+	}
+
+	tenantCounts, err := parseTenantCounts(*counts, observedTenants)
+	must(err)
+
+	plan, err := BuildPlan(Inputs{
+		Base:            baseSnapshot,
+		Peak:            peakSnapshot,
+		Window:          *window,
+		ObservedTenants: observedTenants,
+		TenantCounts:    tenantCounts,
+		PodCPUMilli:     *podCPU,
+		PodMemoryMiB:    *podMemory,
+		Headroom:        *headroom,
+	})
+	must(err)
+
+	if *outputJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		must(enc.Encode(plan))
+		return
+	}
+
+	fmt.Println("Capacity planning summary")
+	fmt.Printf("Observed tenants: %d\n", plan.ObservedTenants)
+	fmt.Printf("Window: %s\n", plan.Window)
+	fmt.Printf("Per-tenant CPU: %.2f mcores\n", plan.PerTenantCPUm)
+	fmt.Printf("Per-tenant memory: %.2f MiB\n", plan.PerTenantMemoryMiB)
+	fmt.Printf("Per-tenant Postgres IOPS: %.2f\n", plan.PerTenantPostgresIOPS)
+	fmt.Printf("Per-tenant DB queries: %.2f qps\n", plan.PerTenantDBQueriesQPS)
+	fmt.Println()
+	fmt.Printf("%-10s %-12s %-14s %-16s %-10s\n", "tenants", "cpu_mcores", "memory_mib", "postgres_iops", "replicas")
+	for _, rec := range plan.Recommendations {
+		fmt.Printf("%-10d %-12d %-14d %-16d %-10d\n",
+			rec.Tenants, rec.RequiredCPUMilli, rec.RequiredMemoryMiB, rec.RequiredPostgresIOPS, rec.AppReplicas)
+	}
+}
+
+func parseTenantCounts(raw string, fallback int) ([]int, error) {
+	if strings.TrimSpace(raw) == "" {
+		return []int{fallback}, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	counts := make([]int, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return nil, fmt.Errorf("parse tenant count %q: %w", value, err)
+		}
+		if n < 0 {
+			return nil, fmt.Errorf("tenant count %d cannot be negative", n)
+		}
+		counts = append(counts, n)
+	}
+	if len(counts) == 0 {
+		return []int{fallback}, nil
+	}
+	return counts, nil
+}
+
+func must(err error) {
+	if err != nil {
+		fatalf("%v", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/tools/capacity/main_test.go
+++ b/tools/capacity/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+const baselineMetrics = `
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+process_cpu_seconds_total 120
+process_resident_memory_bytes 268435456
+db_queries_total{operation="SELECT",table="subscriptions",error="false"} 200
+db_queries_total{operation="INSERT",table="subscriptions",error="false"} 20
+pg_stat_database_blks_read 4000
+pg_stat_database_blks_written 500
+`
+
+const peakMetrics = `
+process_cpu_seconds_total 180
+process_resident_memory_bytes 402653184
+db_queries_total{operation="SELECT",table="subscriptions",error="false"} 520
+db_queries_total{operation="INSERT",table="subscriptions",error="false"} 80
+pg_stat_database_blks_read 7600
+pg_stat_database_blks_written 1000
+`
+
+func TestBuildPlan_ZeroTrafficProfile(t *testing.T) {
+	base, err := newSnapshotFromString(`
+process_cpu_seconds_total 25
+process_resident_memory_bytes 201326592
+pg_stat_database_blks_read 100
+pg_stat_database_blks_written 50
+`)
+	if err != nil {
+		t.Fatalf("parse baseline: %v", err)
+	}
+
+	peak, err := newSnapshotFromString(`
+process_cpu_seconds_total 25
+process_resident_memory_bytes 201326592
+pg_stat_database_blks_read 100
+pg_stat_database_blks_written 50
+`)
+	if err != nil {
+		t.Fatalf("parse peak: %v", err)
+	}
+
+	plan, err := BuildPlan(Inputs{
+		Base:            base,
+		Peak:            peak,
+		Window:          10 * time.Minute,
+		ObservedTenants: 1,
+		TenantCounts:    []int{0, 10},
+		PodCPUMilli:     500,
+		PodMemoryMiB:    1024,
+		Headroom:        1.25,
+	})
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+
+	if plan.PerTenantCPUm != 0 {
+		t.Fatalf("expected zero CPU delta, got %f", plan.PerTenantCPUm)
+	}
+	if plan.PerTenantPostgresIOPS != 0 {
+		t.Fatalf("expected zero IOPS delta, got %f", plan.PerTenantPostgresIOPS)
+	}
+	if len(plan.Recommendations) != 2 {
+		t.Fatalf("expected two recommendations, got %d", len(plan.Recommendations))
+	}
+	if plan.Recommendations[0].AppReplicas != 1 {
+		t.Fatalf("expected one replica at zero tenants, got %d", plan.Recommendations[0].AppReplicas)
+	}
+}
+
+func TestBuildPlan_BurstTrafficProfile(t *testing.T) {
+	base, err := newSnapshotFromString(baselineMetrics)
+	if err != nil {
+		t.Fatalf("parse baseline: %v", err)
+	}
+	peak, err := newSnapshotFromString(peakMetrics)
+	if err != nil {
+		t.Fatalf("parse peak: %v", err)
+	}
+
+	plan, err := BuildPlan(Inputs{
+		Base:            base,
+		Peak:            peak,
+		Window:          15 * time.Minute,
+		ObservedTenants: 50,
+		TenantCounts:    []int{50, 250},
+		PodCPUMilli:     500,
+		PodMemoryMiB:    1024,
+		Headroom:        1.25,
+	})
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+
+	if plan.PerTenantCPUm <= 0 {
+		t.Fatalf("expected CPU cost to be positive")
+	}
+	if plan.PerTenantMemoryMiB <= 0 {
+		t.Fatalf("expected memory cost to be positive")
+	}
+	if plan.PerTenantPostgresIOPS <= 0 {
+		t.Fatalf("expected IOPS cost to be positive")
+	}
+
+	if plan.Recommendations[1].AppReplicas < plan.Recommendations[0].AppReplicas {
+		t.Fatalf("expected larger tenant counts to require at least as many replicas")
+	}
+}
+
+func TestParseTenantCounts(t *testing.T) {
+	counts, err := parseTenantCounts("10, 25, 100", 0)
+	if err != nil {
+		t.Fatalf("parse counts: %v", err)
+	}
+	if len(counts) != 3 || counts[0] != 10 || counts[2] != 100 {
+		t.Fatalf("unexpected counts: %#v", counts)
+	}
+}

--- a/tools/capacity/planner.go
+++ b/tools/capacity/planner.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+const (
+	mib = 1024 * 1024
+)
+
+type Inputs struct {
+	Base            Snapshot
+	Peak            Snapshot
+	Window          time.Duration
+	ObservedTenants int
+	TenantCounts    []int
+	PodCPUMilli     int
+	PodMemoryMiB    int
+	Headroom        float64
+}
+
+type Plan struct {
+	ObservedTenants       int              `json:"observed_tenants"`
+	Window                string           `json:"window"`
+	PerTenantCPUm         float64          `json:"per_tenant_cpu_mcores"`
+	PerTenantMemoryMiB    float64          `json:"per_tenant_memory_mib"`
+	PerTenantPostgresIOPS float64          `json:"per_tenant_postgres_iops"`
+	PerTenantDBQueriesQPS float64          `json:"per_tenant_db_queries_qps"`
+	Recommendations       []Recommendation `json:"recommendations"`
+}
+
+type Recommendation struct {
+	Tenants              int `json:"tenants"`
+	RequiredCPUMilli     int `json:"required_cpu_milli"`
+	RequiredMemoryMiB    int `json:"required_memory_mib"`
+	RequiredPostgresIOPS int `json:"required_postgres_iops"`
+	AppReplicas          int `json:"app_replicas"`
+}
+
+func BuildPlan(in Inputs) (Plan, error) {
+	if in.Window <= 0 {
+		return Plan{}, fmt.Errorf("window must be greater than zero")
+	}
+	if in.Headroom < 1 {
+		return Plan{}, fmt.Errorf("headroom must be at least 1.0")
+	}
+	if in.PodCPUMilli <= 0 {
+		return Plan{}, fmt.Errorf("pod CPU limit must be positive")
+	}
+	if in.PodMemoryMiB <= 0 {
+		return Plan{}, fmt.Errorf("pod memory limit must be positive")
+	}
+	if len(in.TenantCounts) == 0 {
+		return Plan{}, fmt.Errorf("at least one tenant count is required")
+	}
+
+	baseCPUSeconds := in.Base.Sum("process_cpu_seconds_total", nil)
+	peakCPUSeconds := in.Peak.Sum("process_cpu_seconds_total", nil)
+	baseMemoryBytes := in.Base.Sum("process_resident_memory_bytes", nil)
+	peakMemoryBytes := in.Peak.Sum("process_resident_memory_bytes", nil)
+
+	basePostgresOps := postgresIOPS(in.Base)
+	peakPostgresOps := postgresIOPS(in.Peak)
+
+	baseDBQueries := in.Base.Sum("db_queries_total", nil)
+	peakDBQueries := in.Peak.Sum("db_queries_total", nil)
+
+	observedTenants := in.ObservedTenants
+	if observedTenants < 0 {
+		return Plan{}, fmt.Errorf("observed tenants cannot be negative")
+	}
+
+	tenantFactor := 0.0
+	if observedTenants > 0 {
+		tenantFactor = 1 / float64(observedTenants)
+	}
+
+	cpuDelta := math.Max(0, peakCPUSeconds-baseCPUSeconds)
+	memDeltaBytes := math.Max(0, peakMemoryBytes-baseMemoryBytes)
+	iopsDelta := math.Max(0, peakPostgresOps-basePostgresOps)
+	dbQueryDelta := math.Max(0, peakDBQueries-baseDBQueries)
+
+	perTenantCPUm := (cpuDelta / in.Window.Seconds() * 1000) * tenantFactor
+	perTenantMemoryMiB := (memDeltaBytes / mib) * tenantFactor
+	perTenantIOPS := (iopsDelta / in.Window.Seconds()) * tenantFactor
+	perTenantDBQueries := (dbQueryDelta / in.Window.Seconds()) * tenantFactor
+
+	recommendations := make([]Recommendation, 0, len(in.TenantCounts))
+	for _, tenants := range in.TenantCounts {
+		totalCPUm := int(math.Ceil(perTenantCPUm * float64(tenants) * in.Headroom))
+		totalMemoryMiB := int(math.Ceil(((baseMemoryBytes / mib) + perTenantMemoryMiB*float64(tenants)) * in.Headroom))
+		totalIOPS := int(math.Ceil(perTenantIOPS * float64(tenants) * in.Headroom))
+
+		replicasByCPU := int(math.Ceil(float64(totalCPUm) / float64(in.PodCPUMilli)))
+		replicasByMemory := int(math.Ceil(float64(totalMemoryMiB) / float64(in.PodMemoryMiB)))
+		appReplicas := maxInt(1, maxInt(replicasByCPU, replicasByMemory))
+		if tenants == 0 {
+			appReplicas = maxInt(1, replicasByMemory)
+		}
+
+		recommendations = append(recommendations, Recommendation{
+			Tenants:              tenants,
+			RequiredCPUMilli:     maxInt(0, totalCPUm),
+			RequiredMemoryMiB:    maxInt(0, totalMemoryMiB),
+			RequiredPostgresIOPS: maxInt(0, totalIOPS),
+			AppReplicas:          appReplicas,
+		})
+	}
+
+	return Plan{
+		ObservedTenants:       observedTenants,
+		Window:                in.Window.String(),
+		PerTenantCPUm:         perTenantCPUm,
+		PerTenantMemoryMiB:    perTenantMemoryMiB,
+		PerTenantPostgresIOPS: perTenantIOPS,
+		PerTenantDBQueriesQPS: perTenantDBQueries,
+		Recommendations:       recommendations,
+	}, nil
+}
+
+func postgresIOPS(s Snapshot) float64 {
+	return s.Sum("pg_stat_database_blks_read", nil) + s.Sum("pg_stat_database_blks_written", nil)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/tools/capacity/snapshot.go
+++ b/tools/capacity/snapshot.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type MetricPoint struct {
+	Name   string
+	Labels map[string]string
+	Value  float64
+}
+
+type Snapshot struct {
+	Points []MetricPoint
+}
+
+func readSnapshotFile(path string) (Snapshot, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	return ParseSnapshotFromScanner(scanner)
+}
+
+func ParseSnapshotFromScanner(r interface {
+	Scan() bool
+	Text() string
+	Err() error
+}) (Snapshot, error) {
+	var points []MetricPoint
+	for r.Scan() {
+		line := strings.TrimSpace(r.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		point, ok, err := parseMetricLine(line)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		if ok {
+			points = append(points, point)
+		}
+	}
+	if err := r.Err(); err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{Points: points}, nil
+}
+
+func parseMetricLine(line string) (MetricPoint, bool, error) {
+	nameAndLabels, valuePart, ok := strings.Cut(line, " ")
+	if !ok {
+		return MetricPoint{}, false, nil
+	}
+
+	value, err := strconv.ParseFloat(strings.TrimSpace(valuePart), 64)
+	if err != nil {
+		return MetricPoint{}, false, fmt.Errorf("parse metric value %q: %w", valuePart, err)
+	}
+
+	point := MetricPoint{Value: value}
+	if strings.Contains(nameAndLabels, "{") {
+		name, labels, ok := strings.Cut(nameAndLabels, "{")
+		if !ok {
+			return MetricPoint{}, false, fmt.Errorf("parse labels from %q", line)
+		}
+		point.Name = name
+		labelText := strings.TrimSuffix(labels, "}")
+		parsed, err := parseLabels(labelText)
+		if err != nil {
+			return MetricPoint{}, false, err
+		}
+		point.Labels = parsed
+	} else {
+		point.Name = nameAndLabels
+		point.Labels = map[string]string{}
+	}
+
+	return point, true, nil
+}
+
+func parseLabels(raw string) (map[string]string, error) {
+	labels := map[string]string{}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return labels, nil
+	}
+
+	parts := splitRespectingQuotes(raw, ',')
+	for _, part := range parts {
+		key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid label segment %q", part)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"`)
+		value = strings.ReplaceAll(value, `\"`, `"`)
+		labels[key] = value
+	}
+	return labels, nil
+}
+
+func splitRespectingQuotes(s string, sep rune) []string {
+	var parts []string
+	start := 0
+	inQuotes := false
+	for i, r := range s {
+		switch r {
+		case '"':
+			inQuotes = !inQuotes
+		case sep:
+			if !inQuotes {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func (s Snapshot) Sum(name string, filters map[string]string) float64 {
+	var total float64
+	for _, p := range s.Points {
+		if p.Name != name {
+			continue
+		}
+		if !labelsMatch(p.Labels, filters) {
+			continue
+		}
+		total += p.Value
+	}
+	return total
+}
+
+func labelsMatch(labels map[string]string, filters map[string]string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for k, v := range filters {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func newSnapshotFromString(text string) (Snapshot, error) {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	return ParseSnapshotFromScanner(scanner)
+}


### PR DESCRIPTION
Closes #344\n\nSummary:\n- add a capacity planning playbook at docs/runbooks/capacity-planning.md\n- add a Go sizing tool that reads Prometheus snapshots and estimates per-tenant CPU, memory, and Postgres IOPS\n- add a reproducible snapshot collection script\n- cross-link the playbook from README.md and the ops runbooks index\n\nValidation:\n- go test ./tools/capacity/...\n- go test ./... (repo has pre-existing unrelated failures in internal/cache and internal/config)