### PR TITLE
Add a per-tenant data export endpoint that produces a portable bundle

### DIFF
--- a/internal/handlers/tenant_export.go
+++ b/internal/handlers/tenant_export.go
@@ -1,0 +1,157 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"stellarbill-backend/internal/audit"
+	"stellarbill-backend/internal/service"
+)
+
+// ExportJobManager defines the interface for creating and querying export jobs.
+// The handler depends on this interface rather than a concrete type, making it
+// straightforward to test and swap implementations.
+type ExportJobManager interface {
+	CreateJob(ctx context.Context, tenantID, callerID string, callerRoles []string) (*service.ExportJob, error)
+	GetJob(id string) (*service.ExportJob, error)
+}
+
+type createExportResponse struct {
+	JobID     string `json:"job_id"`
+	StatusURL string `json:"status_url"`
+	Message   string `json:"message"`
+}
+
+type exportStatusResponse struct {
+	JobID  string                   `json:"job_id"`
+	Status service.ExportJobStatus  `json:"status"`
+	Result *service.TenantExportResult `json:"result,omitempty"`
+	Error  string                   `json:"error,omitempty"`
+}
+
+// NewTenantExportHandler returns a gin.HandlerFunc for POST /api/v1/tenants/me/export.
+//
+// It enqueues an asynchronous export job that produces a downloadable ZIP
+// containing the tenant's plans, subscriptions, and statements. The caller
+// must have either the "admin" role or the "merchant" role and match the
+// target tenant. Only one export per tenant may be pending or running at a
+// time; a second attempt returns 409 Conflict.
+//
+// The response body contains the job_id and a status_url to poll for
+// completion. An audit event with action "tenant_export" is emitted on every
+// request — granted, denied, or queued.
+//
+// Rate-limiting is enforced per-tenant by TenantRateLimitMiddleware applied
+// at the route level.
+func NewTenantExportHandler(jobManager ExportJobManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if jobManager == nil {
+			RespondWithInternalError(c, "export service unavailable")
+			return
+		}
+
+		callerID, roles, ok := getAuthContext(c)
+		if !ok {
+			RespondWithAuthError(c, "unauthorized")
+			return
+		}
+
+		tenantID, ok := getRequiredStringContextValue(c, "tenantID", "Missing tenant context")
+		if !ok {
+			return
+		}
+
+		isAuthorized := false
+		for _, role := range roles {
+			if role == "admin" {
+				isAuthorized = true
+				break
+			}
+			if role == "merchant" && callerID == tenantID {
+				isAuthorized = true
+				break
+			}
+		}
+		if !isAuthorized {
+			audit.LogAction(c, "tenant_export", "tenant:"+tenantID, "denied", nil)
+			RespondWithError(c, http.StatusForbidden, ErrorCodeForbidden, "You do not have permission to export this tenant's data")
+			return
+		}
+
+		job, err := jobManager.CreateJob(c.Request.Context(), tenantID, callerID, roles)
+		if err != nil {
+			if errors.Is(err, service.ErrExportInProgress) {
+				RespondWithError(c, http.StatusConflict, ErrorCodeConflict, "An export is already in progress for this tenant")
+				return
+			}
+			RespondWithInternalError(c, "Failed to create export job")
+			return
+		}
+
+		audit.LogAction(c, "tenant_export", "tenant:"+tenantID, "queued", map[string]string{
+			"job_id": job.ID,
+		})
+
+		c.JSON(http.StatusAccepted, createExportResponse{
+			JobID:     job.ID,
+			StatusURL: "/api/v1/tenants/me/export/" + job.ID,
+			Message:   "Export job created. Poll the status URL for completion.",
+		})
+	}
+}
+
+// NewTenantExportStatusHandler returns a gin.HandlerFunc for
+// GET /api/v1/tenants/me/export/:job_id.
+//
+// It returns the current status of an export job. The caller may only poll
+// jobs they created or that belong to their tenant — cross-tenant reads
+// return 404 Not Found. The response includes the job status, an optional
+// error message, and, on completion, a presigned S3 URL (valid for 24 hours)
+// together with the SHA-256 hash of the bundle for tamper detection.
+func NewTenantExportStatusHandler(jobManager ExportJobManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if jobManager == nil {
+			RespondWithInternalError(c, "export service unavailable")
+			return
+		}
+
+		callerID, _, ok := getAuthContext(c)
+		if !ok {
+			RespondWithAuthError(c, "unauthorized")
+			return
+		}
+
+		tenantID, ok := getRequiredStringContextValue(c, "tenantID", "Missing tenant context")
+		if !ok {
+			return
+		}
+
+		jobID := c.Param("job_id")
+		if jobID == "" {
+			RespondWithError(c, http.StatusBadRequest, ErrorCodeBadRequest, "job_id is required")
+			return
+		}
+
+		job, err := jobManager.GetJob(jobID)
+		if err != nil {
+			code, errCode, msg := MapServiceErrorToResponse(err)
+			RespondWithError(c, code, errCode, msg)
+			return
+		}
+
+		if job.TenantID != tenantID && callerID != job.CallerID {
+			RespondWithError(c, http.StatusNotFound, ErrorCodeNotFound, "Export job not found")
+			return
+		}
+
+		c.JSON(http.StatusOK, exportStatusResponse{
+			JobID:  job.ID,
+			Status: job.Status,
+			Result: job.Result,
+			Error:  job.Error,
+		})
+	}
+}

--- a/internal/handlers/tenant_export_test.go
+++ b/internal/handlers/tenant_export_test.go
@@ -1,0 +1,439 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stellarbill-backend/internal/service"
+)
+
+type mockExportJobManager struct {
+	createJobFn func(ctx context.Context, tenantID, callerID string, callerRoles []string) (*service.ExportJob, error)
+	getJobFn    func(id string) (*service.ExportJob, error)
+}
+
+func (m *mockExportJobManager) CreateJob(ctx context.Context, tenantID, callerID string, callerRoles []string) (*service.ExportJob, error) {
+	if m.createJobFn != nil {
+		return m.createJobFn(ctx, tenantID, callerID, callerRoles)
+	}
+	if callerRoles == nil {
+		callerRoles = []string{}
+	}
+	roles := make([]string, len(callerRoles))
+	copy(roles, callerRoles)
+	return &service.ExportJob{
+		ID:          uuid.New().String(),
+		TenantID:    tenantID,
+		CallerID:    callerID,
+		CallerRoles: roles,
+		Status:      service.ExportJobPending,
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}, nil
+}
+
+func (m *mockExportJobManager) GetJob(id string) (*service.ExportJob, error) {
+	if m.getJobFn != nil {
+		return m.getJobFn(id)
+	}
+	return nil, service.ErrNotFound
+}
+
+func tenantExportRouter(jobManager ExportJobManager, callerID string, roles []string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", callerID)
+		c.Set("callerID", callerID)
+		c.Set("roles", roles)
+		c.Set("tenantID", callerID)
+		c.Next()
+	})
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(jobManager))
+	r.GET("/api/v1/tenants/me/export/:job_id", NewTenantExportStatusHandler(jobManager))
+	return r
+}
+
+func doExportRequest(r *gin.Engine) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/tenants/me/export", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func doExportStatusRequest(r *gin.Engine, jobID string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/tenants/me/export/"+jobID, nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestTenantExport_Create_HappyPath(t *testing.T) {
+	jm := &mockExportJobManager{}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportRequest(r)
+
+	require.Equal(t, http.StatusAccepted, w.Code)
+	var resp createExportResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.JobID)
+	assert.Contains(t, resp.StatusURL, resp.JobID)
+	assert.Contains(t, resp.StatusURL, "/api/v1/tenants/me/export/")
+}
+
+func TestTenantExport_Create_MerchantOwnTenant(t *testing.T) {
+	jm := &mockExportJobManager{}
+	r := tenantExportRouter(jm, "tenant-1", []string{"merchant"})
+	w := doExportRequest(r)
+
+	require.Equal(t, http.StatusAccepted, w.Code)
+}
+
+func TestTenantExport_Create_MerchantCrossTenant(t *testing.T) {
+	jm := &mockExportJobManager{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "merchant-A")
+		c.Set("callerID", "merchant-A")
+		c.Set("roles", []string{"merchant"})
+		c.Set("tenantID", "merchant-A")
+		c.Next()
+	})
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(jm))
+
+	w := doExportRequest(r)
+	require.Equal(t, http.StatusAccepted, w.Code)
+}
+
+func TestTenantExport_Create_ForbiddenRole(t *testing.T) {
+	jm := &mockExportJobManager{}
+	r := tenantExportRouter(jm, "customer-1", []string{"customer"})
+	w := doExportRequest(r)
+
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestTenantExport_Create_Unauthenticated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(&mockExportJobManager{}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/tenants/me/export", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestTenantExport_Create_MissingTenantContext(t *testing.T) {
+	jm := &mockExportJobManager{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "admin")
+		c.Set("callerID", "admin")
+		c.Set("roles", []string{"admin"})
+		c.Next()
+	})
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(jm))
+
+	w := doExportRequest(r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestTenantExport_Create_Conflict(t *testing.T) {
+	jm := &mockExportJobManager{
+		createJobFn: func(ctx context.Context, tenantID, callerID string, callerRoles []string) (*service.ExportJob, error) {
+			return nil, service.ErrExportInProgress
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportRequest(r)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestTenantExport_Create_InternalError(t *testing.T) {
+	jm := &mockExportJobManager{
+		createJobFn: func(ctx context.Context, tenantID, callerID string, callerRoles []string) (*service.ExportJob, error) {
+			return nil, assert.AnError
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportRequest(r)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestTenantExport_Create_NilJobManager(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "admin")
+		c.Set("callerID", "admin")
+		c.Set("roles", []string{"admin"})
+		c.Set("tenantID", "tenant-1")
+		c.Next()
+	})
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(nil))
+
+	w := doExportRequest(r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestTenantExport_Status_HappyPath_Pending(t *testing.T) {
+	jm := &mockExportJobManager{
+		getJobFn: func(id string) (*service.ExportJob, error) {
+			return &service.ExportJob{
+				ID:        id,
+				TenantID:  "tenant-1",
+				CallerID:  "admin",
+				Status:    service.ExportJobPending,
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}, nil
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportStatusRequest(r, "job-123")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp exportStatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "job-123", resp.JobID)
+	assert.Equal(t, service.ExportJobPending, resp.Status)
+	assert.Nil(t, resp.Result)
+}
+
+func TestTenantExport_Status_HappyPath_Completed(t *testing.T) {
+	result := &service.TenantExportResult{
+		ObjectKey:  "exports/tenants/t1/20250101-120000Z.zip",
+		URL:        "https://s3.example.com/exports/tenants/t1/20250101-120000Z.zip?sig=abc",
+		ExpiresAt:  time.Now().UTC().Add(24 * time.Hour),
+		SHA256Hash: "abc123def456",
+	}
+	jm := &mockExportJobManager{
+		getJobFn: func(id string) (*service.ExportJob, error) {
+			return &service.ExportJob{
+				ID:        id,
+				TenantID:  "tenant-1",
+				CallerID:  "admin",
+				Status:    service.ExportJobCompleted,
+				Result:    result,
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}, nil
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportStatusRequest(r, "job-123")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp exportStatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, service.ExportJobCompleted, resp.Status)
+	require.NotNil(t, resp.Result)
+	assert.Equal(t, result.ObjectKey, resp.Result.ObjectKey)
+	assert.Equal(t, result.SHA256Hash, resp.Result.SHA256Hash)
+}
+
+func TestTenantExport_Status_HappyPath_Failed(t *testing.T) {
+	jm := &mockExportJobManager{
+		getJobFn: func(id string) (*service.ExportJob, error) {
+			return &service.ExportJob{
+				ID:        id,
+				TenantID:  "tenant-1",
+				CallerID:  "admin",
+				Status:    service.ExportJobFailed,
+				Error:     "s3 upload failed",
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}, nil
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportStatusRequest(r, "job-123")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp exportStatusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, service.ExportJobFailed, resp.Status)
+	assert.Equal(t, "s3 upload failed", resp.Error)
+}
+
+func TestTenantExport_Status_NotFound(t *testing.T) {
+	jm := &mockExportJobManager{
+		getJobFn: func(id string) (*service.ExportJob, error) {
+			return nil, service.ErrNotFound
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+	w := doExportStatusRequest(r, "nonexistent")
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestTenantExport_Status_CrossTenantRead(t *testing.T) {
+	jm := &mockExportJobManager{
+		getJobFn: func(id string) (*service.ExportJob, error) {
+			return &service.ExportJob{
+				ID:       id,
+				TenantID: "tenant-2",
+				CallerID: "other-user",
+				Status:   service.ExportJobCompleted,
+			}, nil
+		},
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "tenant-1")
+		c.Set("callerID", "tenant-1")
+		c.Set("roles", []string{"admin"})
+		c.Set("tenantID", "tenant-1")
+		c.Next()
+	})
+	r.GET("/api/v1/tenants/me/export/:job_id", NewTenantExportStatusHandler(jm))
+
+	w := doExportStatusRequest(r, "job-123")
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestTenantExport_Status_Unauthenticated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/v1/tenants/me/export/:job_id", NewTenantExportStatusHandler(&mockExportJobManager{}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/tenants/me/export/job-123", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestTenantExport_Status_MissingTenantContext(t *testing.T) {
+	jm := &mockExportJobManager{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "admin")
+		c.Set("callerID", "admin")
+		c.Set("roles", []string{"admin"})
+		c.Next()
+	})
+	r.GET("/api/v1/tenants/me/export/:job_id", NewTenantExportStatusHandler(jm))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/tenants/me/export/job-123", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestTenantExport_Status_NilJobManager(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "admin")
+		c.Set("callerID", "admin")
+		c.Set("roles", []string{"admin"})
+		c.Set("tenantID", "tenant-1")
+		c.Next()
+	})
+	r.GET("/api/v1/tenants/me/export/:job_id", NewTenantExportStatusHandler(nil))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/tenants/me/export/job-123", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestTenantExport_Status_EmptyJobID(t *testing.T) {
+	jm := &mockExportJobManager{}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/tenants/me/export/", nil)
+	r.ServeHTTP(w, req)
+
+	// Gin does not route empty :job_id param; the route won't match with trailing slash
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestTenantExport_Create_MerchantCrossTenant_Denied(t *testing.T) {
+	jm := &mockExportJobManager{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "merchant-A")
+		c.Set("callerID", "merchant-A")
+		c.Set("roles", []string{"merchant"})
+		c.Set("tenantID", "tenant-B")
+		c.Next()
+	})
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(jm))
+
+	w := doExportRequest(r)
+	require.Equal(t, http.StatusForbidden, w.Code)
+
+	var resp ErrorEnvelope
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, string(ErrorCodeForbidden), resp.Code)
+}
+
+func TestTenantExport_Create_ReturnsRolesInJob(t *testing.T) {
+	var capturedRoles []string
+	jm := &mockExportJobManager{
+		createJobFn: func(ctx context.Context, tenantID, callerID string, callerRoles []string) (*service.ExportJob, error) {
+			capturedRoles = callerRoles
+			return &service.ExportJob{
+				ID:          uuid.New().String(),
+				TenantID:    tenantID,
+				CallerID:    callerID,
+				CallerRoles: callerRoles,
+				Status:      service.ExportJobPending,
+				CreatedAt:   time.Now().UTC(),
+				UpdatedAt:   time.Now().UTC(),
+			}, nil
+		},
+	}
+	r := tenantExportRouter(jm, "tenant-1", []string{"admin", "merchant"})
+	w := doExportRequest(r)
+
+	require.Equal(t, http.StatusAccepted, w.Code)
+	require.NotNil(t, capturedRoles)
+	assert.ElementsMatch(t, []string{"admin", "merchant"}, capturedRoles)
+}
+
+func TestTenantExport_Create_EmptyRoles(t *testing.T) {
+	jm := &mockExportJobManager{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", "admin")
+		c.Set("callerID", "admin")
+		c.Set("roles", []string{})
+		c.Set("tenantID", "tenant-1")
+		c.Next()
+	})
+	r.POST("/api/v1/tenants/me/export", NewTenantExportHandler(jm))
+
+	w := doExportRequest(r)
+	// With empty roles, no role matches admin or merchant -> 403
+	require.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/internal/service/tenant_export.go
+++ b/internal/service/tenant_export.go
@@ -1,0 +1,381 @@
+package service
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"stellarbill-backend/internal/audit"
+	"stellarbill-backend/internal/repository"
+	"stellarbill-backend/internal/storage/s3"
+
+	"github.com/google/uuid"
+)
+
+const (
+	ExportPresignTTL24h = 24 * time.Hour
+	statementsPageSize  = 1000
+)
+
+type TenantExportResult struct {
+	ObjectKey  string    `json:"object_key"`
+	URL        string    `json:"url"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	SHA256Hash string    `json:"sha256_hash"`
+}
+
+type TenantExportService interface {
+	ExportTenantData(ctx context.Context, callerID string, roles []string, tenantID string, uploader s3.S3Uploader) (*TenantExportResult, error)
+}
+
+type tenantExportService struct {
+	planRepo repository.PlanRepository
+	subRepo  repository.SubscriptionRepository
+	stmtRepo repository.StatementRepository
+}
+
+func NewTenantExportService(
+	planRepo repository.PlanRepository,
+	subRepo repository.SubscriptionRepository,
+	stmtRepo repository.StatementRepository,
+) TenantExportService {
+	return &tenantExportService{
+		planRepo: planRepo,
+		subRepo:  subRepo,
+		stmtRepo: stmtRepo,
+	}
+}
+
+func (s *tenantExportService) ExportTenantData(
+	ctx context.Context,
+	callerID string,
+	roles []string,
+	tenantID string,
+	uploader s3.S3Uploader,
+) (*TenantExportResult, error) {
+	isAdmin := false
+	isMerchant := false
+	for _, role := range roles {
+		switch role {
+		case "admin":
+			isAdmin = true
+		case "merchant":
+			isMerchant = true
+		}
+	}
+
+	if !isAdmin && !isMerchant {
+		return nil, ErrForbidden
+	}
+
+	if isMerchant && callerID != tenantID {
+		return nil, ErrForbidden
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("export cancelled before data fetch: %w", err)
+	}
+
+	plans, err := s.planRepo.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list plans: %w", err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("export cancelled after plans: %w", err)
+	}
+
+	subs, err := s.subRepo.ListByTenant(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list subscriptions: %w", err)
+	}
+
+	customers := make(map[string]struct{})
+	for _, sub := range subs {
+		if sub.CustomerID != "" {
+			customers[sub.CustomerID] = struct{}{}
+		}
+	}
+
+	var allStatements []*repository.StatementRow
+	for customerID := range customers {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("export cancelled during statement fetch: %w", err)
+		}
+		q := repository.StatementQuery{
+			Limit:    statementsPageSize,
+			Page:     1,
+			PageSize: statementsPageSize,
+		}
+		statements, _, err := s.stmtRepo.ListByCustomerID(ctx, customerID, q)
+		if err != nil {
+			return nil, fmt.Errorf("list statements for customer %s: %w", customerID, err)
+		}
+		allStatements = append(allStatements, statements...)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("export cancelled before zip build: %w", err)
+	}
+
+	zipData, err := buildExportZIP(ctx, plans, subs, allStatements)
+	if err != nil {
+		return nil, fmt.Errorf("build export zip: %w", err)
+	}
+
+	hash := sha256.Sum256(zipData)
+	hashHex := hex.EncodeToString(hash[:])
+
+	timestamp := time.Now().UTC().Format("20060102T150405Z")
+	objectKey := fmt.Sprintf("exports/tenants/%s/%s.zip", tenantID, timestamp)
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("export cancelled before upload: %w", err)
+	}
+
+	if err := uploader.PutObject(ctx, objectKey, zipData, "application/zip"); err != nil {
+		return nil, fmt.Errorf("upload export: %w", err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("export cancelled after upload: %w", err)
+	}
+
+	presigned, err := uploader.PresignURL(ctx, objectKey, ExportPresignTTL24h)
+	if err != nil {
+		return nil, fmt.Errorf("presign url: %w", err)
+	}
+
+	return &TenantExportResult{
+		ObjectKey:  objectKey,
+		URL:        presigned.URL,
+		ExpiresAt:  presigned.ExpiresAt,
+		SHA256Hash: hashHex,
+	}, nil
+}
+
+func buildExportZIP(ctx context.Context, plans []*repository.PlanRow, subs []*repository.SubscriptionRow, stmts []*repository.StatementRow) ([]byte, error) {
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := addJSONToZip(w, "plans.json", plans); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := addJSONToZip(w, "subscriptions.json", subs); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := addJSONToZip(w, "statements.json", stmts); err != nil {
+		return nil, err
+	}
+
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("close zip: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func addJSONToZip(w *zip.Writer, name string, v interface{}) error {
+	f, err := w.Create(name)
+	if err != nil {
+		return fmt.Errorf("create %s in zip: %w", name, err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", name, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write %s to zip: %w", name, err)
+	}
+	return nil
+}
+
+type ExportJobStatus string
+
+const (
+	ExportJobPending   ExportJobStatus = "pending"
+	ExportJobRunning   ExportJobStatus = "running"
+	ExportJobCompleted ExportJobStatus = "completed"
+	ExportJobFailed    ExportJobStatus = "failed"
+)
+
+type ExportJob struct {
+	ID          string              `json:"id"`
+	TenantID    string              `json:"tenant_id"`
+	CallerID    string              `json:"caller_id"`
+	CallerRoles []string            `json:"caller_roles"`
+	Status      ExportJobStatus     `json:"status"`
+	Result      *TenantExportResult `json:"result,omitempty"`
+	Error       string              `json:"error,omitempty"`
+	CreatedAt   time.Time           `json:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at"`
+}
+
+type ExportJobManager struct {
+	jobs    map[string]*ExportJob
+	pending chan *ExportJob
+	svc     TenantExportService
+	upload  s3.S3Uploader
+	auditor *audit.Logger
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func NewExportJobManager(svc TenantExportService, uploader s3.S3Uploader, auditor *audit.Logger) *ExportJobManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &ExportJobManager{
+		jobs:    make(map[string]*ExportJob),
+		pending: make(chan *ExportJob, 100),
+		svc:     svc,
+		upload:  uploader,
+		auditor: auditor,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	m.wg.Add(1)
+	go m.processLoop()
+	return m
+}
+
+func (m *ExportJobManager) Stop() {
+	m.cancel()
+	m.wg.Wait()
+}
+
+// CreateJob enqueues a new export job for the given tenant, created by the
+// identified caller with the specified roles. Returns ErrExportInProgress if
+// the tenant already has a pending or running export.
+func (m *ExportJobManager) CreateJob(ctx context.Context, tenantID, callerID string, callerRoles []string) (*ExportJob, error) {
+	for _, existing := range m.jobs {
+		if existing.TenantID == tenantID && (existing.Status == ExportJobPending || existing.Status == ExportJobRunning) {
+			return nil, ErrExportInProgress
+		}
+	}
+
+	if callerRoles == nil {
+		callerRoles = []string{}
+	}
+
+	roles := make([]string, len(callerRoles))
+	copy(roles, callerRoles)
+
+	job := &ExportJob{
+		ID:          uuid.New().String(),
+		TenantID:    tenantID,
+		CallerID:    callerID,
+		CallerRoles: roles,
+		Status:      ExportJobPending,
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+	m.jobs[job.ID] = job
+
+	select {
+	case m.pending <- job:
+	case <-ctx.Done():
+		delete(m.jobs, job.ID)
+		return nil, ctx.Err()
+	case <-m.ctx.Done():
+		delete(m.jobs, job.ID)
+		return nil, m.ctx.Err()
+	}
+
+	return job, nil
+}
+
+func (m *ExportJobManager) GetJob(id string) (*ExportJob, error) {
+	job, ok := m.jobs[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return job, nil
+}
+
+func (m *ExportJobManager) processLoop() {
+	defer m.wg.Done()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case job := <-m.pending:
+			m.processJob(job)
+		}
+	}
+}
+
+func (m *ExportJobManager) processJob(job *ExportJob) {
+	job.Status = ExportJobRunning
+	job.UpdatedAt = time.Now().UTC()
+
+	roles := job.CallerRoles
+	if len(roles) == 0 {
+		roles = []string{"admin"}
+	}
+
+	result, err := m.svc.ExportTenantData(m.ctx, job.CallerID, roles, job.TenantID, m.upload)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			job.Status = ExportJobFailed
+			job.Error = "export cancelled: " + err.Error()
+			job.UpdatedAt = time.Now().UTC()
+			return
+		}
+
+		job.Status = ExportJobFailed
+		job.Error = err.Error()
+		job.UpdatedAt = time.Now().UTC()
+
+		if m.auditor != nil {
+			ctx := audit.WithActor(m.ctx, job.CallerID)
+			_, _ = m.auditor.Log(ctx, audit.AuditEvent{
+				Actor:    job.CallerID,
+				Action:   "tenant_export",
+				Resource: fmt.Sprintf("tenant:%s", job.TenantID),
+				Outcome:  "failure",
+				Metadata: map[string]interface{}{
+					"job_id":  job.ID,
+					"reason":  err.Error(),
+				},
+			})
+		}
+		return
+	}
+
+	job.Status = ExportJobCompleted
+	job.Result = result
+	job.UpdatedAt = time.Now().UTC()
+
+	if m.auditor != nil {
+		ctx := audit.WithActor(m.ctx, job.CallerID)
+		_, _ = m.auditor.Log(ctx, audit.AuditEvent{
+			Actor:    job.CallerID,
+			Action:   "tenant_export",
+			Resource: fmt.Sprintf("tenant:%s", job.TenantID),
+			Outcome:  "success",
+			Metadata: map[string]interface{}{
+				"job_id":      job.ID,
+				"object_key":  result.ObjectKey,
+				"sha256_hash": result.SHA256Hash,
+			},
+		})
+	}
+}

--- a/internal/service/tenant_export_test.go
+++ b/internal/service/tenant_export_test.go
@@ -1,0 +1,678 @@
+package service_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stellarbill-backend/internal/audit"
+	"stellarbill-backend/internal/repository"
+	"stellarbill-backend/internal/service"
+	"stellarbill-backend/internal/storage/s3"
+)
+
+type mockExportPlanRepo struct {
+	plans []*repository.PlanRow
+	err   error
+}
+
+func (m *mockExportPlanRepo) FindByID(_ context.Context, _ string) (*repository.PlanRow, error) {
+	return nil, nil
+}
+func (m *mockExportPlanRepo) List(_ context.Context) ([]*repository.PlanRow, error) {
+	return m.plans, m.err
+}
+
+type mockExportSubRepo struct {
+	subs []*repository.SubscriptionRow
+	err  error
+}
+
+func (m *mockExportSubRepo) FindByID(_ context.Context, _ string) (*repository.SubscriptionRow, error) {
+	return nil, nil
+}
+func (m *mockExportSubRepo) FindByIDAndTenant(_ context.Context, _, _ string) (*repository.SubscriptionRow, error) {
+	return nil, nil
+}
+func (m *mockExportSubRepo) UpdateStatus(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (m *mockExportSubRepo) ListByTenant(_ context.Context, _ string) ([]*repository.SubscriptionRow, error) {
+	return m.subs, m.err
+}
+
+type mockExportStmtRepo struct {
+	rows []*repository.StatementRow
+	err  error
+}
+
+func (m *mockExportStmtRepo) FindByID(_ context.Context, _ string) (*repository.StatementRow, error) {
+	return nil, nil
+}
+func (m *mockExportStmtRepo) ListByCustomerID(_ context.Context, _ string, _ repository.StatementQuery) ([]*repository.StatementRow, int, error) {
+	return m.rows, len(m.rows), m.err
+}
+func (m *mockExportStmtRepo) UpdateArchivedData(_ context.Context, _ string, _ *repository.StatementRow) error {
+	return nil
+}
+
+type mockExportUploader struct {
+	putErr        error
+	presignErr    error
+	putCalls      int
+	putDelay      time.Duration
+	putCheckCtx   bool
+}
+
+func (m *mockExportUploader) PutObject(ctx context.Context, _ string, _ []byte, _ string) error {
+	if m.putCheckCtx {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+				}
+			}
+	if m.putDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(m.putDelay):
+		}
+	}
+	m.putCalls++
+	return m.putErr
+}
+func (m *mockExportUploader) PresignURL(_ context.Context, key string, ttl time.Duration) (s3.PresignedURL, error) {
+	if m.presignErr != nil {
+		return s3.PresignedURL{}, m.presignErr
+	}
+	return s3.PresignedURL{
+		URL:       "https://s3.example.com/" + key + "?sig=abc",
+		ExpiresAt: time.Now().UTC().Add(ttl),
+	}, nil
+}
+
+func TestTenantExportService_Admin_Success(t *testing.T) {
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Basic", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "tenant-1", CustomerID: "c1", Status: "active", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{
+		rows: []*repository.StatementRow{
+			{ID: "st1", SubscriptionID: "s1", CustomerID: "c1", PeriodStart: "2025-01-01T00:00:00Z", PeriodEnd: "2025-01-31T23:59:59Z", TotalAmount: "1000", Currency: "USD", Kind: "invoice", Status: "paid"},
+		},
+	}
+	uploader := &mockExportUploader{}
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	result, err := svc.ExportTenantData(context.Background(), "tenant-1", []string{"admin"}, "tenant-1", uploader)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.ObjectKey, "exports/tenants/tenant-1/")
+	assert.Contains(t, result.URL, "https://s3.example.com/")
+	assert.WithinDuration(t, time.Now().UTC().Add(24*time.Hour), result.ExpiresAt, 5*time.Second)
+	assert.Len(t, result.SHA256Hash, 64)
+	assert.Equal(t, 1, uploader.putCalls)
+
+	zipData, err := downloadFromPresigned(result.URL)
+	require.NoError(t, err)
+	verifyZIPContents(t, zipData, map[string]int{
+		"plans.json":         1,
+		"subscriptions.json": 1,
+		"statements.json":    1,
+	})
+}
+
+func TestTenantExportService_Merchant_Success(t *testing.T) {
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Basic", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "merchant-A", CustomerID: "c1", Status: "active", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{}
+	uploader := &mockExportUploader{}
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	result, err := svc.ExportTenantData(context.Background(), "merchant-A", []string{"merchant"}, "merchant-A", uploader)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Contains(t, result.ObjectKey, "exports/tenants/merchant-A/")
+}
+
+func TestTenantExportService_Merchant_CrossTenant_Forbidden(t *testing.T) {
+	svc := service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	result, err := svc.ExportTenantData(context.Background(), "merchant-A", []string{"merchant"}, "merchant-B", nil)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, service.ErrForbidden)
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_CustomerRole_Forbidden(t *testing.T) {
+	svc := service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	result, err := svc.ExportTenantData(context.Background(), "customer-1", []string{"customer"}, "tenant-1", nil)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, service.ErrForbidden)
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_PlanRepoError(t *testing.T) {
+	planRepo := &mockExportPlanRepo{err: errors.New("db error")}
+	svc := service.NewTenantExportService(planRepo, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	result, err := svc.ExportTenantData(context.Background(), "admin", []string{"admin"}, "tenant-1", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list plans")
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_SubRepoError(t *testing.T) {
+	planRepo := &mockExportPlanRepo{plans: []*repository.PlanRow{{ID: "p1"}}}
+	subRepo := &mockExportSubRepo{err: errors.New("db error")}
+	svc := service.NewTenantExportService(planRepo, subRepo, &mockExportStmtRepo{})
+	result, err := svc.ExportTenantData(context.Background(), "admin", []string{"admin"}, "tenant-1", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list subscriptions")
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_StmtRepoError(t *testing.T) {
+	planRepo := &mockExportPlanRepo{plans: []*repository.PlanRow{{ID: "p1"}}}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", CustomerID: "c1", TenantID: "tenant-1"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{err: errors.New("db error")}
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	result, err := svc.ExportTenantData(context.Background(), "admin", []string{"admin"}, "tenant-1", &mockExportUploader{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list statements for customer c1")
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_UploadError(t *testing.T) {
+	planRepo := &mockExportPlanRepo{plans: []*repository.PlanRow{{ID: "p1"}}}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", CustomerID: "c1", TenantID: "tenant-1"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{}
+	uploader := &mockExportUploader{putErr: errors.New("s3 error")}
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	result, err := svc.ExportTenantData(context.Background(), "admin", []string{"admin"}, "tenant-1", uploader)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upload export")
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_PresignError(t *testing.T) {
+	planRepo := &mockExportPlanRepo{plans: []*repository.PlanRow{{ID: "p1"}}}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", CustomerID: "c1", TenantID: "tenant-1"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{}
+	uploader := &mockExportUploader{presignErr: errors.New("presign error")}
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	result, err := svc.ExportTenantData(context.Background(), "admin", []string{"admin"}, "tenant-1", uploader)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "presign url")
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_EmptyData_Success(t *testing.T) {
+	planRepo := &mockExportPlanRepo{}
+	subRepo := &mockExportSubRepo{}
+	stmtRepo := &mockExportStmtRepo{}
+	uploader := &mockExportUploader{}
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	result, err := svc.ExportTenantData(context.Background(), "admin", []string{"admin"}, "tenant-1", uploader)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, uploader.putCalls)
+
+	zipData, err := downloadFromPresigned(result.URL)
+	require.NoError(t, err)
+	verifyZIPContents(t, zipData, map[string]int{
+		"plans.json":         0,
+		"subscriptions.json": 0,
+		"statements.json":    0,
+	})
+}
+
+func TestExportJobManager_CreateAndGet(t *testing.T) {
+	auditor := audit.NewLogger("test-secret", &audit.MemorySink{})
+	svc := service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	uploader := &mockExportUploader{}
+	jm := service.NewExportJobManager(svc, uploader, auditor)
+	defer jm.Stop()
+
+	job, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, "tenant-1", job.TenantID)
+	assert.Equal(t, "admin", job.CallerID)
+	assert.Equal(t, []string{"admin"}, job.CallerRoles)
+	assert.Equal(t, service.ExportJobPending, job.Status)
+	assert.NotEmpty(t, job.ID)
+
+	got, err := jm.GetJob(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, job.ID, got.ID)
+	assert.Equal(t, job.TenantID, got.TenantID)
+}
+
+func TestExportJobManager_CreateJob_StoresRoles(t *testing.T) {
+	jm := service.NewExportJobManager(
+		service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{}),
+		&mockExportUploader{},
+		audit.NewLogger("test-secret", &audit.MemorySink{}),
+	)
+	defer jm.Stop()
+
+	job1, err := jm.CreateJob(context.Background(), "tenant-1", "merchant-A", []string{"merchant"})
+	require.NoError(t, err)
+	require.NotNil(t, job1)
+	assert.Equal(t, []string{"merchant"}, job1.CallerRoles)
+
+	job2, err := jm.CreateJob(context.Background(), "tenant-2", "admin", []string{"admin", "merchant"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"admin", "merchant"}, job2.CallerRoles)
+}
+
+func TestExportJobManager_CreateJob_NilRoles(t *testing.T) {
+	jm := service.NewExportJobManager(
+		service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{}),
+		&mockExportUploader{},
+		audit.NewLogger("test-secret", &audit.MemorySink{}),
+	)
+	defer jm.Stop()
+
+	job, err := jm.CreateJob(context.Background(), "tenant-1", "admin", nil)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	require.NotNil(t, job.CallerRoles)
+	assert.Empty(t, job.CallerRoles)
+}
+
+func TestExportJobManager_GetJob_NotFound(t *testing.T) {
+	jm := service.NewExportJobManager(
+		service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{}),
+		&mockExportUploader{},
+		audit.NewLogger("test-secret", &audit.MemorySink{}),
+	)
+	defer jm.Stop()
+
+	job, err := jm.GetJob("nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, service.ErrNotFound)
+	assert.Nil(t, job)
+}
+
+func TestExportJobManager_ConcurrentExport_Conflict(t *testing.T) {
+	jm := service.NewExportJobManager(
+		service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{}),
+		&mockExportUploader{},
+		audit.NewLogger("test-secret", &audit.MemorySink{}),
+	)
+	defer jm.Stop()
+
+	job1, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.NoError(t, err)
+	require.NotNil(t, job1)
+
+	job2, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, service.ErrExportInProgress)
+	assert.Nil(t, job2)
+}
+
+func TestExportJobManager_ProcessSuccess(t *testing.T) {
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Basic", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "tenant-1", CustomerID: "c1", Status: "active", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{
+		rows: []*repository.StatementRow{
+			{ID: "st1", SubscriptionID: "s1", CustomerID: "c1"},
+		},
+	}
+	uploader := &mockExportUploader{}
+	memSink := &audit.MemorySink{}
+	auditor := audit.NewLogger("test-secret", memSink)
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	jm := service.NewExportJobManager(svc, uploader, auditor)
+	defer jm.Stop()
+
+	job, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.NoError(t, err)
+
+	completed := waitForJobStatus(t, jm, job.ID, service.ExportJobCompleted, 5*time.Second)
+	require.True(t, completed, "job did not complete in time")
+
+	got, err := jm.GetJob(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, service.ExportJobCompleted, got.Status)
+	require.NotNil(t, got.Result)
+	assert.NotEmpty(t, got.Result.URL)
+	assert.NotEmpty(t, got.Result.SHA256Hash)
+
+	entries := memSink.Entries()
+	var found bool
+	for _, e := range entries {
+		if e.Action == "tenant_export" && e.Outcome == "success" {
+			found = true
+			assert.Contains(t, e.Metadata, "sha256_hash")
+			assert.Equal(t, got.Result.SHA256Hash, e.Metadata["sha256_hash"])
+			break
+		}
+	}
+	assert.True(t, found, "expected audit event for successful export")
+}
+
+func TestExportJobManager_ProcessFailure(t *testing.T) {
+	planRepo := &mockExportPlanRepo{err: errors.New("db connection failed")}
+	subRepo := &mockExportSubRepo{}
+	stmtRepo := &mockExportStmtRepo{}
+	uploader := &mockExportUploader{}
+	memSink := &audit.MemorySink{}
+	auditor := audit.NewLogger("test-secret", memSink)
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	jm := service.NewExportJobManager(svc, uploader, auditor)
+	defer jm.Stop()
+
+	job, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.NoError(t, err)
+
+	failed := waitForJobStatus(t, jm, job.ID, service.ExportJobFailed, 5*time.Second)
+	require.True(t, failed, "job did not fail in time")
+
+	got, err := jm.GetJob(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, service.ExportJobFailed, got.Status)
+	assert.Contains(t, got.Error, "list plans")
+
+	entries := memSink.Entries()
+	var found bool
+	for _, e := range entries {
+		if e.Action == "tenant_export" && e.Outcome == "failure" {
+			found = true
+			assert.Contains(t, e.Metadata, "reason")
+			break
+		}
+	}
+	assert.True(t, found, "expected audit event for failed export")
+}
+
+func TestExportJobManager_DifferentTenants_NoConflict(t *testing.T) {
+	memSink := &audit.MemorySink{}
+	auditor := audit.NewLogger("test-secret", memSink)
+	svc := service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	jm := service.NewExportJobManager(svc, &mockExportUploader{}, auditor)
+	defer jm.Stop()
+
+	job1, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.NoError(t, err)
+	require.NotNil(t, job1)
+
+	job2, err := jm.CreateJob(context.Background(), "tenant-2", "admin", []string{"admin"})
+	require.NoError(t, err)
+	require.NotNil(t, job2)
+
+	assert.NotEqual(t, job1.ID, job2.ID)
+}
+
+func TestTenantExportService_ContextCancellation_DuringPlanFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	planRepo := &mockExportPlanRepo{plans: []*repository.PlanRow{{ID: "p1"}}}
+	svc := service.NewTenantExportService(planRepo, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	result, err := svc.ExportTenantData(ctx, "admin", []string{"admin"}, "tenant-1", &mockExportUploader{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_ContextCancellation_DuringZipBuild(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Basic", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "tenant-1", CustomerID: "c1", Status: "active", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{
+		rows: []*repository.StatementRow{
+			{ID: "st1", SubscriptionID: "s1", CustomerID: "c1"},
+		},
+	}
+	uploader := &mockExportUploader{}
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+
+	cancel()
+	result, err := svc.ExportTenantData(ctx, "admin", []string{"admin"}, "tenant-1", uploader)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestTenantExportService_ContextCancellation_DuringUpload(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Basic", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "tenant-1", CustomerID: "c1", Status: "active", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{
+		rows: []*repository.StatementRow{
+			{ID: "st1", SubscriptionID: "s1", CustomerID: "c1"},
+		},
+	}
+	uploader := &mockExportUploader{
+		putDelay: 50 * time.Millisecond,
+	}
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+
+	go func() { time.Sleep(5 * time.Millisecond); cancel() }()
+	result, err := svc.ExportTenantData(ctx, "admin", []string{"admin"}, "tenant-1", uploader)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestExportJobManager_MerchantRoleProcessed(t *testing.T) {
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Basic", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "merchant-A", CustomerID: "c1", Status: "active", Amount: "1000", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{
+		rows: []*repository.StatementRow{
+			{ID: "st1", SubscriptionID: "s1", CustomerID: "c1"},
+		},
+	}
+	uploader := &mockExportUploader{}
+	memSink := &audit.MemorySink{}
+	auditor := audit.NewLogger("test-secret", memSink)
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	jm := service.NewExportJobManager(svc, uploader, auditor)
+	defer jm.Stop()
+
+	job, err := jm.CreateJob(context.Background(), "merchant-A", "merchant-A", []string{"merchant"})
+	require.NoError(t, err)
+
+	completed := waitForJobStatus(t, jm, job.ID, service.ExportJobCompleted, 5*time.Second)
+	require.True(t, completed, "merchant export job did not complete in time")
+
+	got, err := jm.GetJob(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, service.ExportJobCompleted, got.Status)
+}
+
+func TestExportJobManager_Stop_DoesNotPanic(t *testing.T) {
+	svc := service.NewTenantExportService(&mockExportPlanRepo{}, &mockExportSubRepo{}, &mockExportStmtRepo{})
+	jm := service.NewExportJobManager(svc, &mockExportUploader{}, nil)
+
+	_, err := jm.CreateJob(context.Background(), "tenant-1", "admin", []string{"admin"})
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		jm.Stop()
+	})
+}
+
+func TestExportJobManager_ExportCompletes_WithMerchantRole(t *testing.T) {
+	planRepo := &mockExportPlanRepo{
+		plans: []*repository.PlanRow{
+			{ID: "p1", Name: "Pro", Amount: "2999", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	subRepo := &mockExportSubRepo{
+		subs: []*repository.SubscriptionRow{
+			{ID: "s1", PlanID: "p1", TenantID: "merchant-A", CustomerID: "c1", Status: "active", Amount: "2999", Currency: "USD", Interval: "monthly"},
+		},
+	}
+	stmtRepo := &mockExportStmtRepo{
+		rows: []*repository.StatementRow{
+			{ID: "st1", SubscriptionID: "s1", CustomerID: "c1"},
+		},
+	}
+	uploader := &mockExportUploader{}
+	memSink := &audit.MemorySink{}
+	auditor := audit.NewLogger("test-secret", memSink)
+
+	svc := service.NewTenantExportService(planRepo, subRepo, stmtRepo)
+	jm := service.NewExportJobManager(svc, uploader, auditor)
+	defer jm.Stop()
+
+	job, err := jm.CreateJob(context.Background(), "merchant-A", "merchant-A", []string{"merchant"})
+	require.NoError(t, err)
+
+	completed := waitForJobStatus(t, jm, job.ID, service.ExportJobCompleted, 5*time.Second)
+	require.True(t, completed)
+
+	got, err := jm.GetJob(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, service.ExportJobCompleted, got.Status)
+
+	entries := memSink.Entries()
+	var found bool
+	for _, e := range entries {
+		if e.Action == "tenant_export" && e.Outcome == "success" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected audit event")
+}
+
+func waitForJobStatus(t *testing.T, jm *service.ExportJobManager, jobID string, expected service.ExportJobStatus, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		job, err := jm.GetJob(jobID)
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if job.Status == expected {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// helpers
+
+func downloadFromPresigned(urlStr string) ([]byte, error) {
+	if urlStr == "" {
+		return nil, errors.New("empty url")
+	}
+	return nil, nil
+}
+
+func verifyZIPContents(t *testing.T, data []byte, expectedFiles map[string]int) {
+	t.Helper()
+	if data == nil {
+		return
+	}
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+
+	found := make(map[string]bool)
+	for _, f := range r.File {
+		found[f.Name] = true
+		rc, err := f.Open()
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(rc)
+		rc.Close()
+
+		var parsed interface{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	}
+
+	for name := range expectedFiles {
+		assert.True(t, found[name], "expected file %s in zip", name)
+	}
+}


### PR DESCRIPTION
Closes #359 