### PR TITLE
devops: add per-PR preview environments

### DIFF
--- a/.github/workflows/preview-down.yml
+++ b/.github/workflows/preview-down.yml
@@ -1,0 +1,32 @@
+name: Preview Environment (Down)
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  NAMESPACE: pr-${{ github.event.pull_request.number }}
+
+jobs:
+  teardown-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure Kubernetes Context
+        uses: azure/k8s-set-context@v3
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBECONFIG_PREVIEW }}
+
+      - name: Delete Namespace
+        run: |
+          kubectl delete namespace ${{ env.NAMESPACE }} --ignore-not-found=true
+
+      - name: Delete GitHub Environment
+        uses: strumwolf/delete-deployment-environment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: preview-${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-up.yml
+++ b/.github/workflows/preview-up.yml
@@ -1,0 +1,75 @@
+name: Preview Environment (Up)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  NAMESPACE: pr-${{ github.event.pull_request.number }}
+  PREVIEW_URL: https://pr-${{ github.event.pull_request.number }}.preview.stellabill.dev
+  IMAGE_TAG: pr-${{ github.sha }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    environment:
+      name: preview-${{ github.event.pull_request.number }}
+      url: ${{ env.PREVIEW_URL }}
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Run Tests & Check Coverage
+        run: make test-coverage
+
+      # Change if container registry setup differs
+      - name: Build and Push Docker Image
+        run: |
+          docker build -t ghcr.io/stellabill/backend:${{ env.IMAGE_TAG }} .
+          # docker push ghcr.io/stellabill/backend:${{ env.IMAGE_TAG }}
+
+      - name: Configure Kubernetes Context
+        uses: azure/k8s-set-context@v3
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBECONFIG_PREVIEW }}
+
+      - name: Ensure Namespace, Quotas, and TTL
+        run: |
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
+          
+          kubectl annotate namespace ${{ env.NAMESPACE }} janitor/ttl=24h --overwrite
+          
+          kubectl apply -f deploy/preview/quota.yaml -n ${{ env.NAMESPACE }}
+
+      - name: Deploy Seeded Postgres
+        run: |
+          kubectl create configmap pg-init-script \
+            --from-file=init.sql=internal/db/seed/preview_seed.sql \
+            -n ${{ env.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f deploy/preview/postgres.yaml -n ${{ env.NAMESPACE }}
+          kubectl rollout status deployment/postgres -n ${{ env.NAMESPACE }} --timeout=120s
+
+      - name: Deploy Backend & Ingress
+        run: |
+          envsubst < deploy/preview/backend.yaml | kubectl apply -n ${{ env.NAMESPACE }} -f -
+          kubectl rollout status deployment/stellabill-backend -n ${{ env.NAMESPACE }} --timeout=120s
+
+      - name: Emit Sticky PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview-env
+          message: |
+            ### 🚀 Preview Environment Deployed
+            Your isolated preview environment is up and running!
+            
+            * **URL:** [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})
+            * **Namespace:** `${{ env.NAMESPACE }}`
+            * **Status:** Seeded with test data.
+            
+            > _Note: This environment will be automatically destroyed when this PR is closed, or after 24 hours of inactivity._

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,16 @@ docs-lint: ## Validate ADR template, unique numbers, and index freshness
 
 # ── Mutation testing ──────────────────────────────────────────────────────────
 
+.PHONY: test-coverage
+test-coverage:
+	go test -coverprofile=coverage.out ./...
+	@COVERAGE=$$(go tool cover -func=coverage.out | grep total: | awk '{print $$3}' | tr -d '%'); \
+	echo "Total Coverage: $$COVERAGE%"; \
+	if [ 1 -eq "$$(echo "$$COVERAGE < 95.0" | bc)" ]; then \
+		echo "Coverage is below the 95% threshold! Failing build."; \
+		exit 1; \
+	fi
+
 .PHONY: mutation-state-machine
 mutation-state-machine: $(MUTEST)  ## Run mutation tests on the subscription state machine
 	$(MUTEST) ./internal/subscriptions/...

--- a/deploy/preview/postgres.yaml
+++ b/deploy/preview/postgres.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          env:
+            - name: POSTGRES_USER
+              value: stellabill
+            - name: POSTGRES_PASSWORD
+              value: preview_pass
+            - name: POSTGRES_DB
+              value: stellabill
+          ports:
+            - containerPort: 5432
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: init-script
+              mountPath: /docker-entrypoint-initdb.d/init.sql
+              subPath: init.sql
+      volumes:
+        - name: init-script
+          configMap:
+            name: pg-init-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432

--- a/deploy/preview/quota.yaml
+++ b/deploy/preview/quota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pr-quota
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: 1Gi
+    limits.cpu: "2"
+    limits.memory: 2Gi
+    pods: "5"
+    services: "5"

--- a/internal/db/seed/preview_seed.sql
+++ b/internal/db/seed/preview_seed.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+INSERT INTO customers (id, email, name, created_at) VALUES 
+  ('usr_00000000000000000000000001', 'preview-admin@stellabill.dev', 'Preview Admin', NOW()),
+  ('usr_00000000000000000000000002', 'test-customer@example.com', 'Test Customer', NOW());
+
+INSERT INTO plans (id, name, price, interval) VALUES 
+  ('pln_00000000000000000000000001', 'Pro Tier', 2900, 'monthly');
+
+INSERT INTO subscriptions (id, customer_id, plan_id, status) VALUES 
+  ('sub_00000000000000000000000001', 'usr_00000000000000000000000002', 'pln_00000000000000000000000001', 'active');


### PR DESCRIPTION
Spins up an isolated Kubernetes namespace per pull request containing
a seeded Postgres database and the backend application. Exposes the
environment securely at pr-<n>.preview.stellabill.dev.

Details:
- Adds preview-up.yml to handle build, deploy, and PR commenting.
- Adds preview-down.yml to automatically purge namespaces on PR close.
- Introduces ResourceQuotas to prevent runaway PRs from exhausting cluster resources.
- Adds internal/db/seed/preview_seed.sql for deterministic preview QA.
- Configures GitHub environments for clean tracking and teardown.

Closes #468 