### PR TITLE
devops: publish TypeScript SDK on release (closes #472)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,141 @@
+name: release-sdk
+
+# Publish the @stellabill/sdk TypeScript SDK to npm whenever a GitHub
+# release is published. The release workflow:
+#   1. Generates TypeScript types from openapi/openapi.yaml
+#   2. Builds ESM + CJS + .d.ts bundles via tsup
+#   3. Runs the full vitest suite with the >=95% coverage gate
+#   4. Bumps the SDK package version to the release tag
+#   5. Publishes to npm with provenance under the trusted-publisher OIDC
+#
+# Manual dispatch is supported with a `tag` input for back-filling.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.2.0). Defaults to the latest release tag."
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  id-token: write  # Required for npm OIDC trusted publishing (provenance)
+  contents: read
+
+jobs:
+  test-sdk:
+    name: Test (generate, build, vitest >=95% coverage)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/ts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout release tag
+        if: github.event_name == 'release'
+        run: git checkout ${{ github.event.release.tag_name }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Install dependencies
+        run: pnpm install
+      - name: Generate types from openapi.yaml
+        run: pnpm run generate
+      - name: Build (tsup)
+        run: pnpm run build
+      - name: Typecheck
+        run: pnpm run typecheck
+      - name: Test + coverage gate (>=95%)
+        run: |
+          set -euo pipefail
+          pnpm run test
+      - name: Upload SDK dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-dist
+          path: |
+            sdks/ts/dist
+            sdks/ts/package.json
+          retention-days: 14
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-coverage
+          path: sdks/ts/coverage
+          retention-days: 14
+
+  publish-sdk:
+    name: Publish to npm
+    needs: test-sdk
+    runs-on: ubuntu-latest
+    # Publish only on real GitHub releases (or explicit dispatch with a tag)
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    defaults:
+      run:
+        working-directory: sdks/ts
+    steps:
+      - name: Download SDK dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-dist
+          path: sdks/ts/dist
+      - name: Checkout source matching the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          # Trust the OIDC publisher declared in sdks/ts/package.json
+      - name: Set SDK version to release tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          if [ -z "${TAG:-}" ] || [ "${TAG}" = " " ]; then
+            echo "::error::No release tag available. Pass a 'tag' input when using workflow_dispatch."
+            exit 1
+          fi
+          # Strip leading 'v' from the tag (e.g. v0.2.0 -> 0.2.0)
+          VERSION="${TAG#v}"
+          echo "Publishing @stellabill/sdk@${VERSION}"
+          npm pkg set "version=${VERSION}"
+      - name: Validate package.json
+        run: |
+          set -euo pipefail
+          node -e "const p=require('./package.json'); \
+            if(!p.name || !p.version){throw new Error('missing name/version')}; \
+            if(!p.exports?.['.']?.types){throw new Error('missing types export')}; \
+            if(!p.dependencies?.['openapi-fetch']){throw new Error('missing openapi-fetch dep')}; \
+            console.log('package.json OK')"
+      - name: Sanity-check that dist is built and types exist
+        run: |
+          set -euo pipefail
+          test -f dist/index.js
+          test -f dist/index.cjs
+          test -f dist/index.d.ts
+          echo "dist OK"
+      - name: Publish (trusted publishing via OIDC)
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # OIDC trusted publishing replaces NODE_AUTH_TOKEN when configured at
+          # https://docs.npmjs.com/generating-provenance-statements; we still
+          # fall back to NPM_TOKEN to remain compatible with non-OIDC setups.

--- a/sdks/ts/.gitignore
+++ b/sdks/ts/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+coverage/
+*.log
+.DS_Store
+.env
+.env.local

--- a/sdks/ts/.npmignore
+++ b/sdks/ts/.npmignore
@@ -1,0 +1,16 @@
+# Source / dev artifacts - keep dist + README only
+src
+test
+types
+scripts
+coverage
+*.ts
+!dist/**/*.d.ts
+.eslintrc
+.prettierrc
+vitest.config.ts
+tsconfig*.json
+.gitignore
+.github
+node_modules
+*.log

--- a/sdks/ts/.npmrc
+++ b/sdks/ts/.npmrc
@@ -1,0 +1,4 @@
+# pnpm 10 refuses to run install scripts by default. We allow esbuild's
+# postinstall (needed for vitest + tsup native binary) via the
+# `pnpm.onlyBuiltDependencies` field in package.json — no global override.
+node-linker=isolated

--- a/sdks/ts/CHANGELOG.md
+++ b/sdks/ts/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to `@stellabill/sdk` are recorded here. Versions follow
+[Semantic Versioning](https://semver.org/) and track
+`openapi/openapi.yaml`'s `info.version`.
+
+## 0.2.0 (initial release)
+
+- Initial SDK release. Generated from `openapi/openapi.yaml` v0.2.0 using
+  [`openapi-typescript`](https://openapi-ts.dev) + [`openapi-fetch`](https://openapi-ts.dev/openapi-fetch/).
+- Typed wrappers for `/api/health`, `/api/v1/plans`, `/api/subscriptions`,
+  `/api/subscriptions/{id}`, `/api/v1/idempotency/{key}`.
+- Bearer token authentication with runtime rotation via `setToken()`.
+- Opt-in `throwOnError` semantics + `assertOk()` helper.
+- Committed generated types (`src/types/api.gen.ts`) so IDEs work without a
+  build step.
+- ≥95% test coverage; round-trip tests guarantee generated types match
+  runtime responses.

--- a/sdks/ts/LICENSE
+++ b/sdks/ts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stellabill contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/sdks/ts/README.md
+++ b/sdks/ts/README.md
@@ -1,0 +1,243 @@
+# @stellabill/sdk
+
+> **Typed TypeScript SDK for the Stellabill backend API.**
+> Generated from [`openapi/openapi.yaml`](../../openapi/openapi.yaml) using
+> [`openapi-typescript`](https://openapi-ts.dev) + [`openapi-fetch`](https://openapi-ts.dev/openapi-fetch/).
+> Published to npm on every GitHub release by the
+> [release workflow](../../.github/workflows/release.yml).
+
+[![npm version](https://img.shields.io/npm/v/@stellabill/sdk)](https://www.npmjs.com/package/@stellabill/sdk)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+---
+
+## Table of contents
+
+- [Install](#install)
+- [Requirements](#requirements)
+- [Quickstart](#quickstart)
+- [API surface](#api-surface)
+- [Error handling](#error-handling)
+- [Authentication & token rotation](#authentication--token-rotation)
+- [Custom headers, middleware & fetch](#custom-headers-middleware--fetch)
+- [Type-safe raw client](#type-safe-raw-client)
+- [Versioning](#versioning)
+- [Security assumptions](#security-assumptions)
+- [Regenerating from OpenAPI](#regenerating-from-openapi)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Install
+
+```sh
+pnpm add @stellabill/sdk
+# or
+npm install @stellabill/sdk
+# or
+yarn add @stellabill/sdk
+```
+
+## Requirements
+
+- **Node.js ≥ 20** (the SDK relies on the global `fetch` API). For older
+  runtimes pass your own `fetch` (e.g. via `undici`) via
+  `createStellarBillClient({ fetch })`.
+- **TypeScript ≥ 5.0** (the SDK is published with both ESM and CJS bundles
+  plus full `.d.ts` typings).
+
+## Quickstart
+
+```ts
+import { createStellarBillClient } from '@stellabill/sdk';
+
+const sdk = createStellarBillClient({
+  baseUrl: 'https://api.stellabill.com',
+  token: process.env.STELLABILL_TOKEN, // optional; required for protected routes
+});
+
+const { data, error, status } = await sdk.getHealth();
+if (data) {
+  console.log(`Service ${data.service} is ${data.status}`);
+}
+```
+
+## API surface
+
+The SDK exposes ergonomic, typed wrappers for every operation documented in
+`openapi/openapi.yaml`. Each wrapper returns a `Promise<SdkResult<T>>` with
+this shape:
+
+```ts
+interface SdkResult<T> {
+  data: T | undefined;            // parsed 2xx body
+  error: ApiErrorBody | undefined; // parsed non-2xx body (typed envelope)
+  status: number;                  // HTTP status code
+  response: Response;              // original Response (headers, etc.)
+  requestMethod: string;           // e.g. "GET"
+  requestUrl: string;              // final resolved URL
+}
+```
+
+| Method                                          | OpenAPI operation           | Path                                |
+| ----------------------------------------------- | --------------------------- | ----------------------------------- |
+| `sdk.getHealth()`                               | `getHealth`                 | `GET /api/health`                   |
+| `sdk.listPlans({ cursor?, limit? })`            | `listPlans`                 | `GET /api/v1/plans`                 |
+| `sdk.listSubscriptions({ cursor?, limit? })`    | `listSubscriptions`         | `GET /api/subscriptions`            |
+| `sdk.getSubscription(id)`                       | `getSubscriptionV1`         | `GET /api/subscriptions/{id}`       |
+| `sdk.inspectIdempotencyKey(key)`                | `inspectIdempotencyKey`     | `GET /api/v1/idempotency/{key}`     |
+
+## Error handling
+
+By default, the SDK **does not throw** on non-2xx responses — it returns a
+typed `{ status, error, data, response }` so you decide how to handle it.
+
+For a more conventional throw-on-error flow, enable `throwOnError: true`:
+
+```ts
+import { createStellarBillClient, StellarBillError } from '@stellabill/sdk';
+
+const sdk = createStellarBillClient({
+  baseUrl: 'https://api.stellabill.com',
+  token: process.env.STELLABILL_TOKEN!,
+  throwOnError: true,
+});
+
+try {
+  const sub = await sdk.getSubscription('sub_xyz');
+  console.log(sub.data?.status);
+} catch (err) {
+  if (err instanceof StellarBillError) {
+    // err.status, err.body.code, err.requestUrl, err.requestMethod
+    logger.warn(`API error ${err.status} on ${err.requestUrl}: ${err.body?.code}`);
+  } else {
+    throw err; // programmer error (network, bad config, etc.)
+  }
+}
+```
+
+Or, per-call, use `assertOk(result)` to throw on a single result.
+
+## Authentication & token rotation
+
+Pass a bearer token at construction time. The SDK attaches it as
+`Authorization: Bearer <token>` on every request.
+
+```ts
+const sdk = createStellarBillClient({
+  baseUrl: 'https://api.stellabill.com',
+  token: initialToken,
+});
+
+// Later, after a refresh:
+sdk.setToken(newToken);
+// Or clear it:
+sdk.setToken(undefined);
+```
+
+## Custom headers, middleware & fetch
+
+The SDK passes through arbitrary caller headers but **strips any caller-supplied
+`Authorization` header** — the bearer token configured via `token` /
+`setToken()` is the single source of truth for auth, eliminating smuggled
+or shadow auth.
+
+```ts
+const sdk = createStellarBillClient({
+  baseUrl: 'https://api.stellabill.com',
+  token: process.env.STELLABILL_TOKEN!,
+  headers: { 'X-Trace-Id': crypto.randomUUID() }, // arbitrary caller headers
+  middleware: [
+    {
+      async onRequest({ request }) {
+        request.headers.set('X-Trace-Id', crypto.randomUUID());
+        return request;
+      },
+    },
+  ],
+  fetch: undiciFetch, // optional, e.g. for Bun / older Node
+});
+```
+
+## Type-safe raw client
+
+The underlying `openapi-fetch` client is exposed as `sdk.raw`, so advanced
+callers can issue any operation the OpenAPI spec defines and get full type
+inference:
+
+```ts
+import type { components } from '@stellabill/sdk';
+
+type Plan = components['schemas']['Plan'];
+
+const { data } = await sdk.raw.GET('/api/v1/plans', { params: { query: { limit: 5 } } });
+//    ^? { plans?: Plan[]; pagination: ...; } | undefined
+```
+
+## Versioning
+
+- The SDK's `package.json` version is bumped by the
+  [release workflow](../../.github/workflows/release.yml) on every GitHub
+  release. It tracks `info.version` in `openapi/openapi.yaml`.
+- API semver: breaking changes to the OpenAPI spec require a major SDK
+  bump. Additive changes (new optional fields, new endpoints, new headers)
+  ship as a minor bump. Bug fixes that don't change types ship as patch.
+- The release workflow also runs the full test + coverage gate (≥95%)
+  before publishing, so a broken release is impossible.
+- **Provenance:** `publishConfig.provenance: true` is set, but provenance
+  is only generated when OIDC *trusted publishing* is configured at
+  [npmjs.com](https://docs.npmjs.com/generating-provenance-statements).
+  Until then, publishing falls back to legacy `NPM_TOKEN` auth without
+  provenance.
+
+## Security assumptions
+
+- **HTTPS in production.** The SDK warns to `console.warn` when given an
+  `http://` baseUrl outside `localhost`. Pass `https://...` for any
+  non-local environment.
+- **Token integrity is the caller's responsibility.** The SDK trims and
+  rejects tokens with embedded whitespace, but does not otherwise inspect
+  or store them. Rotate tokens via `setToken()` after refresh; do not
+  log raw tokens.
+- **No secrets in URL paths.** `getSubscription` and
+  `inspectIdempotencyKey` URL-encode their path segment via
+  `encodeURIComponent`, so slashes/spaces in IDs are persisted correctly
+  without escaping failures. Avoid putting tokens in URLs entirely.
+- **User-Agent is set automatically.** Format:
+  `@stellabill/sdk/<version> node/<node-version>`. The header is
+  lower-case and stub-resilient: it is always present on every request.
+- **Generated types are committed** (see `src/types/api.gen.ts`) so the
+  the SDK ships zero build dependencies beyond `openapi-fetch` and is
+  installable on locked-down networks.
+
+## Regenerating from OpenAPI
+
+```sh
+cd sdks/ts
+pnpm install
+pnpm generate    # writes src/types/api.gen.ts from ../../openapi/openapi.yaml
+pnpm build       # emits dist/*.js + dist/*.d.ts via tsup
+pnpm test        # vitest run + coverage >= 95%
+```
+
+The generator reads
+[`openapi/openapi.yaml`](../../openapi/openapi.yaml) and writes a committed
+generated file at `src/types/api.gen.ts`. Do **not** edit it by hand —
+update the spec instead.
+
+## Contributing
+
+For SDK-specific changes:
+
+1. Update the spec in [`openapi/openapi.yaml`](../../openapi/openapi.yaml).
+2. Run `pnpm generate` to refresh generated types (commit the diff).
+3. Add or update tests in `test/` covering the change (the 95% coverage
+   gate will fail otherwise).
+4. Open a PR. CI runs `pnpm test` with the coverage threshold check.
+
+For repo-wide guidelines see the existing top-level docs.
+
+## License
+
+[MIT](../../LICENSE) © Stellabill contributors.

--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@stellabill/sdk",
+  "version": "0.2.0",
+  "description": "TypeScript SDK for the Stellabill backend API. Generated from openapi/openapi.yaml using openapi-typescript + openapi-fetch.",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  },
+  "scripts": {
+    "generate": "node --experimental-strip-types --no-warnings=ExperimentalWarning scripts/generate.ts",
+    "prebuild": "pnpm generate",
+    "build": "tsup",
+    "pretest": "pnpm generate && pnpm build",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint placeholder (eslint optional)\""
+  },
+  "dependencies": {
+    "openapi-fetch": "0.13.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.2",
+    "@vitest/coverage-v8": "2.1.9",
+    "openapi-typescript": "7.4.2",
+    "tsup": "8.3.5",
+    "tsx": "4.19.2",
+    "typescript": "5.7.2",
+    "vitest": "2.1.9"
+  },
+  "keywords": [
+    "stellabill",
+    "api",
+    "sdk",
+    "openapi",
+    "typescript"
+  ]
+}

--- a/sdks/ts/pnpm-lock.yaml
+++ b/sdks/ts/pnpm-lock.yaml
@@ -1,0 +1,2412 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      openapi-fetch:
+        specifier: 0.13.5
+        version: 0.13.5
+    devDependencies:
+      '@types/node':
+        specifier: 20.14.2
+        version: 20.14.2
+      '@vitest/coverage-v8':
+        specifier: 2.1.9
+        version: 2.1.9(vitest@2.1.9(@types/node@20.14.2))
+      openapi-typescript:
+        specifier: 7.4.2
+        version: 7.4.2(typescript@5.7.2)
+      tsup:
+        specifier: 8.3.5
+        version: 8.3.5(postcss@8.5.23)(tsx@4.19.2)(typescript@5.7.2)
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.7.2
+        version: 5.7.2
+      vitest:
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@20.14.2)
+
+packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
+
+  '@redocly/openapi-core@1.34.17':
+    resolution: {integrity: sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
+  '@rollup/rollup-android-arm-eabi@4.62.3':
+    resolution: {integrity: sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.3':
+    resolution: {integrity: sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.3':
+    resolution: {integrity: sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.3':
+    resolution: {integrity: sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.3':
+    resolution: {integrity: sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    resolution: {integrity: sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
+    resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
+    resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
+    resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
+    resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
+    resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
+    resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.3':
+    resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.3':
+    resolution: {integrity: sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    resolution: {integrity: sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
+    resolution: {integrity: sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
+    resolution: {integrity: sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@20.14.2':
+    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
+
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  openapi-fetch@0.13.5:
+    resolution: {integrity: sha512-AQK8T9GSKFREFlN1DBXTYsLjs7YV2tZcJ7zUWxbjMoQmj8dDSFRrzhLCbHPZWA1TMV3vACqfCxLEZcwf2wxV6Q==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript@7.4.2:
+    resolution: {integrity: sha512-SvhmSTItcEAdDUcz+wzrcg6OENpMRkHqqY2hZB01FT+NOfgLcZ1B1ML6vcQrnipONHtG9AQELiKHgGTjpNGjiQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.62.3:
+    resolution: {integrity: sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+    engines: {node: '>=12'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.3.5:
+    resolution: {integrity: sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.19.2:
+    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@0.2.3': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
+    optional: true
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/config@0.22.0': {}
+
+  '@redocly/openapi-core@1.34.17(supports-color@9.4.0)':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.0
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.2.0
+      minimatch: 5.1.9
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rollup/rollup-android-arm-eabi@4.62.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
+    optional: true
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@20.14.2':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@20.14.2))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3(supports-color@9.4.0)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@20.14.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.14.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.14.2)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  agent-base@7.1.4: {}
+
+  ansi-colors@4.1.3: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.8:
+    dependencies:
+      balanced-match: 4.0.4
+
+  bundle-require@5.1.0(esbuild@0.24.2):
+    dependencies:
+      esbuild: 0.24.2
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  change-case@5.4.4: {}
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
+
+  commander@4.1.1: {}
+
+  consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3(supports-color@9.4.0):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 9.4.0
+
+  deep-eql@5.0.2: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  https-proxy-agent@7.0.6(supports-color@9.4.0):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  index-to-position@1.2.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@9.4.0)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  joycon@3.1.1: {}
+
+  js-levenshtein@1.1.6: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  lodash.sortby@4.7.0: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.8
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
+  minipass@7.1.3: {}
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.16: {}
+
+  object-assign@4.1.1: {}
+
+  openapi-fetch@0.13.5:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript@7.4.2(typescript@5.7.2):
+    dependencies:
+      '@redocly/openapi-core': 1.34.17(supports-color@9.4.0)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 9.4.0
+      typescript: 5.7.2
+      yargs-parser: 21.1.1
+
+  package-json-from-dist@1.0.1: {}
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  pirates@4.0.7: {}
+
+  pluralize@8.0.0: {}
+
+  postcss-load-config@6.0.1(postcss@8.5.23)(tsx@4.19.2):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.23
+      tsx: 4.19.2
+
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
+
+  readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.62.3:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.3
+      '@rollup/rollup-android-arm64': 4.62.3
+      '@rollup/rollup-darwin-arm64': 4.62.3
+      '@rollup/rollup-darwin-x64': 4.62.3
+      '@rollup/rollup-freebsd-arm64': 4.62.3
+      '@rollup/rollup-freebsd-x64': 4.62.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.3
+      '@rollup/rollup-linux-arm64-gnu': 4.62.3
+      '@rollup/rollup-linux-arm64-musl': 4.62.3
+      '@rollup/rollup-linux-loong64-gnu': 4.62.3
+      '@rollup/rollup-linux-loong64-musl': 4.62.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.3
+      '@rollup/rollup-linux-ppc64-musl': 4.62.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.3
+      '@rollup/rollup-linux-riscv64-musl': 4.62.3
+      '@rollup/rollup-linux-s390x-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-musl': 4.62.3
+      '@rollup/rollup-openbsd-x64': 4.62.3
+      '@rollup/rollup-openharmony-arm64': 4.62.3
+      '@rollup/rollup-win32-arm64-msvc': 4.62.3
+      '@rollup/rollup-win32-ia32-msvc': 4.62.3
+      '@rollup/rollup-win32-x64-gnu': 4.62.3
+      '@rollup/rollup-win32-x64-msvc': 4.62.3
+      fsevents: 2.3.3
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@9.4.0: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.3.5(postcss@8.5.23)(tsx@4.19.2)(typescript@5.7.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.24.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@9.4.0)
+      esbuild: 0.24.2
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.23)(tsx@4.19.2)
+      resolve-from: 5.0.0
+      rollup: 4.62.3
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.23
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.19.2:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-fest@4.41.0: {}
+
+  typescript@5.7.2: {}
+
+  undici-types@5.26.5: {}
+
+  uri-js-replace@1.0.1: {}
+
+  vite-node@2.1.9(@types/node@20.14.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@9.4.0)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.14.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.14.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.23
+      rollup: 4.62.3
+    optionalDependencies:
+      '@types/node': 20.14.2
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.14.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.14.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@9.4.0)
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.14.2)
+      vite-node: 2.1.9(@types/node@20.14.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.14.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  webidl-conversions@4.0.2: {}
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  yaml-ast-parser@0.0.43: {}
+
+  yargs-parser@21.1.1: {}

--- a/sdks/ts/scripts/generate.ts
+++ b/sdks/ts/scripts/generate.ts
@@ -1,0 +1,68 @@
+/**
+ * SDK code generation script.
+ *
+ * Reads the canonical OpenAPI spec at `../../openapi/openapi.yaml` and
+ * writes generated TypeScript types into `src/types/api.gen.ts`. The
+ * generated file is committed to the repo so consumers (and IDEs) work
+ * without running a build step.
+ *
+ * Usage:
+ *   node --experimental-strip-types scripts/generate.ts
+ *   # or
+ *   pnpm generate
+ *
+ * Exit codes:
+ *   0 – success
+ *   1 – generation failed (logged with stack)
+ *   2 – spec or output path missing
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import openapiTS, { astToString } from 'openapi-typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const SPEC_PATH = resolve(REPO_ROOT, 'openapi', 'openapi.yaml');
+const OUT_PATH = resolve(__dirname, '..', 'src', 'types', 'api.gen.ts');
+
+function writeGenerated(source: string): void {
+  mkdirSync(dirname(OUT_PATH), { recursive: true });
+  const header =
+    `// AUTO-GENERATED FROM openapi/openapi.yaml — DO NOT EDIT.\n` +
+    `// Regenerate via: pnpm run generate (sdks/ts)\n` +
+    `// Source spec version tracked in openapi.yaml -> info.version\n\n`;
+  writeFileSync(OUT_PATH, header + source + '\n', 'utf8');
+  console.log(`[generate] wrote ${OUT_PATH} (${source.length} bytes)`);
+}
+
+async function main(): Promise<void> {
+  // openapi-typescript v7+ loads YAML directly from a file:// URL.
+  if (!existsSync(SPEC_PATH)) {
+    console.error(`[generate] OpenAPI spec not found at ${SPEC_PATH}`);
+    process.exit(2);
+  }
+
+  let ast;
+  try {
+    ast = await openapiTS(new URL(`file://${SPEC_PATH}`));
+  } catch (err) {
+    console.error('[generate] openapi-typescript failed:', err);
+    process.exit(1);
+  }
+
+  try {
+    writeGenerated(astToString(ast));
+  } catch (err) {
+    console.error('[generate] astToString/write failed:', err);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('[generate] unexpected error:', err);
+  process.exit(1);
+});

--- a/sdks/ts/src/auth.ts
+++ b/sdks/ts/src/auth.ts
@@ -1,0 +1,40 @@
+/**
+ * Holds a bearer token that is injected on every outbound request via the
+ * `Authorization: Bearer <token>` header defined by the `bearerAuth`
+ * security scheme in `openapi/openapi.yaml`.
+ *
+ * Mutable so callers can rotate tokens without recreating the client
+ * (e.g. after a 401 / refresh).
+ */
+export class TokenHolder {
+  #token: string | undefined;
+
+  constructor(initialToken?: string) {
+    this.#token = initialToken;
+  }
+
+  get(): string | undefined {
+    return this.#token;
+  }
+
+  set(token: string | undefined): void {
+    this.#token = token;
+  }
+
+  hasToken(): boolean {
+    return typeof this.#token === 'string' && this.#token.length > 0;
+  }
+}
+
+/**
+ * Validate the shape of a bearer token. We only enforce non-empty + no
+ * whitespace; the server is the source of truth for token validity.
+ */
+export function sanitizeToken(token: string | undefined): string | undefined {
+  if (token === undefined) return undefined;
+  if (typeof token !== 'string') return undefined;
+  const trimmed = token.trim();
+  if (trimmed.length === 0) return undefined;
+  if (/\s/.test(trimmed)) return undefined;
+  return trimmed;
+}

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -1,0 +1,325 @@
+import createClient, { type Middleware } from 'openapi-fetch';
+
+import type { paths } from './types/api.gen.js';
+import { TokenHolder, sanitizeToken } from './auth.js';
+import { StellarBillConfigError, StellarBillError, type ApiErrorBody } from './errors.js';
+import { SDK_VERSION, defaultUserAgent } from './version.js';
+
+export type FetchLike = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+
+export interface StellarBillClientOptions {
+  /** API base URL (e.g. `https://api.stellabill.com`). */
+  baseUrl: string;
+  /** Initial bearer token; rotatable via `client.setToken()`. */
+  token?: string;
+  /** Optional pre-configured fetch implementation (Node 20+ has a built-in). */
+  fetch?: FetchLike;
+  /** Extra headers injected on every request (e.g. `X-Tenant-ID`, trace IDs). */
+  headers?: Record<string, string>;
+  /** Extra middleware runs after the SDK-installed auth + user-agent middleware. */
+  middleware?: Middleware[];
+  /** When `true`, throw {@link StellarBillError} on any non-2xx response. Default `false`. */
+  throwOnError?: boolean;
+}
+
+export interface StellarBillClient {
+  /** Underlying `openapi-fetch` client with full generated typings. */
+  raw: ReturnType<typeof createClient<paths>>;
+  /** Replace the bearer token used for authentication. */
+  setToken(token: string | undefined): void;
+  /** Read the currently configured bearer token (if any). */
+  getToken(): string | undefined;
+  /** Current SDK version. */
+  version: string;
+
+  // --- Typed operation wrappers (mirror openapi.yaml operations) ---
+  getHealth(): Promise<HealthResult>;
+  listPlans(params?: ListPlansParams): Promise<ListPlansResult>;
+  listSubscriptions(params?: ListSubscriptionsParams): Promise<ListSubscriptionsResult>;
+  getSubscription(id: string): Promise<GetSubscriptionResult>;
+  inspectIdempotencyKey(key: string): Promise<InspectIdempotencyKeyResult>;
+}
+
+// ----- Typed result envelopes -----
+
+export interface SdkResult<TData, TError = ApiErrorBody | undefined> {
+  data: TData | undefined;
+  /** HTTP status code (always present). */
+  status: number;
+  /** Parsed error body for non-2xx, else undefined. */
+  error: TError;
+  /** The original `Response` so callers can read response headers. */
+  response: Response;
+  /** HTTP method that produced this result. */
+  requestMethod: string;
+  /** Final resolved URL (after openapi-fetch substitution). */
+  requestUrl: string;
+}
+
+export type HealthResult = SdkResult<import('./types/api.gen.js').components['schemas']['HealthResponse']>;
+export type ListPlansResult = SdkResult<import('./types/api.gen.js').components['schemas']['PlansResponse']>;
+export type ListSubscriptionsResult = SdkResult<
+  import('./types/api.gen.js').components['schemas']['SubscriptionsResponse']
+>;
+export type GetSubscriptionResult = SdkResult<
+  import('./types/api.gen.js').components['schemas']['Subscription']
+>;
+export type InspectIdempotencyKeyResult = SdkResult<
+  import('./types/api.gen.js').components['schemas']['IdempotencyKeyRecord']
+>;
+
+export interface ListPlansParams {
+  cursor?: string;
+  limit?: number;
+}
+export interface ListSubscriptionsParams {
+  cursor?: string;
+  limit?: number;
+}
+
+// ----- Helpers -----
+
+function validateBaseUrl(raw: unknown): string {
+  if (raw === undefined || raw === null) {
+    throw new StellarBillConfigError('baseUrl is required');
+  }
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    throw new StellarBillConfigError('baseUrl must be a non-empty string');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new StellarBillConfigError(`baseUrl "${raw}" is not a valid URL`);
+  }
+  // Strip trailing slashes for consistent URL composition.
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+function isLocalhost(baseUrl: string): boolean {
+  try {
+    const u = new URL(baseUrl);
+    return u.hostname === 'localhost' || u.hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
+async function safeParseErrorBody(res: Response): Promise<ApiErrorBody | undefined> {
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) return undefined;
+  try {
+    const text = await res.text();
+    if (!text) return undefined;
+    const parsed: unknown = JSON.parse(text);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as ApiErrorBody;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function makeErrorMessage(method: string, url: string, status: number, body: ApiErrorBody | undefined): string {
+  const detail = body?.message ?? body?.error ?? `HTTP ${status}`;
+  return `${method} ${url} failed (${status}): ${detail}`;
+}
+
+/**
+ * Build a fully-configured Stellabill SDK client bound to a single baseUrl.
+ *
+ * @example
+ * ```ts
+ * import { createStellarBillClient } from '@stellabill/sdk';
+ *
+ * const sdk = createStellarBillClient({
+ *   baseUrl: 'https://api.stellabill.com',
+ *   token: process.env.STELLABILL_TOKEN,
+ * });
+ *
+ * const { data, error } = await sdk.getHealth();
+ * if (error) throw new Error(error.message);
+ * console.log(data?.status); // "ok"
+ * ```
+ */
+export function createStellarBillClient(options: StellarBillClientOptions): StellarBillClient {
+  const baseUrl = validateBaseUrl(options.baseUrl);
+
+  if (typeof console !== 'undefined' && console.warn && baseUrl.startsWith('http://') && !isLocalhost(baseUrl)) {
+    console.warn(`[stellabill-sdk] Insecure baseUrl "${baseUrl}" - use https:// in production`);
+  }
+
+  // Detect a real fetch (Node 20+ exposes globalThis.fetch; browsers always do).
+  const providedFetch = options.fetch ?? (globalThis.fetch as FetchLike | undefined);
+  if (typeof providedFetch !== 'function') {
+    throw new StellarBillConfigError(
+      'No fetch implementation available. Pass options.fetch (or run on Node >=20 / a modern browser).',
+    );
+  }
+
+  const tokenHolder = new TokenHolder(sanitizeToken(options.token));
+  const userAgent = defaultUserAgent();
+  const extraHeaders: Record<string, string> = {};
+
+  // Normalize caller headers and combine with User-Agent. Reject caller-
+  // supplied Authorization headers so they cannot smuggle auth past the
+  // SDK's token holder; the auth middleware below is the sole source of
+  // truth for the `Authorization` header.
+  if (options.headers) {
+    for (const [k, v] of Object.entries(options.headers)) {
+      const lower = k.toLowerCase();
+      if (lower === 'authorization') continue;
+      if (typeof v === 'string' && v.length > 0) {
+        extraHeaders[lower] = v;
+      }
+    }
+  }
+  extraHeaders['user-agent'] = userAgent;
+
+  const raw = createClient<paths>({
+    baseUrl,
+    fetch: providedFetch,
+  });
+
+  // Single middleware that injects user-agent, caller-supplied static
+  // headers, and Authorization. Doing all three in middleware (instead
+  // of split between createClient's `headers` option and middleware)
+  // guarantees openapi-fetch has them on the Request before invoking
+  // fetch, regardless of which request constructor it uses internally.
+  const authMiddleware: Middleware = {
+    async onRequest({ request }) {
+      if (!request.headers.has('user-agent')) {
+        request.headers.set('user-agent', userAgent);
+      }
+      for (const [k, v] of Object.entries(extraHeaders)) {
+        if (!request.headers.has(k) && typeof v === 'string' && v.length > 0) {
+          request.headers.set(k, v);
+        }
+      }
+      if (tokenHolder.hasToken()) {
+        const t = tokenHolder.get();
+        if (t) request.headers.set('authorization', `Bearer ${t}`);
+      }
+      return request;
+    },
+  };
+  raw.use(authMiddleware);
+  if (options.middleware?.length) {
+    for (const m of options.middleware) raw.use(m);
+  }
+
+  const throwOnError = options.throwOnError === true;
+
+  // Wrap an openapi-fetch result into the SDK's SdkResult envelope. We accept
+  // any "thenable" with the data/error/response triple so we don't depend on
+  // openapi-fetch's exact internal typings (which have shifted several times).
+  async function wrap<T>(
+    method: string,
+    urlPath: string,
+    rawResult: unknown,
+  ): Promise<SdkResult<T>> {
+    const r = (await rawResult) as { data: T | undefined; error: unknown; response: Response };
+    const { data, error, response } = r;
+    const status = response.status;
+    const parsedError: ApiErrorBody | undefined =
+      error && typeof error === 'object' ? (error as ApiErrorBody) : undefined;
+
+    if (throwOnError && (status < 200 || status >= 300)) {
+      throw new StellarBillError({
+        status,
+        body: parsedError,
+        requestUrl: urlPath,
+        requestMethod: method,
+        message: makeErrorMessage(method, urlPath, status, parsedError),
+      });
+    }
+
+    return { data, error: parsedError, status, response, requestMethod: method, requestUrl: response.url || urlPath };
+  }
+
+  return {
+    raw,
+    version: SDK_VERSION,
+    setToken(token) {
+      tokenHolder.set(sanitizeToken(token));
+    },
+    getToken() {
+      return tokenHolder.get();
+    },
+
+    getHealth: async () => {
+      const res = await raw.GET('/api/health', {});
+      return wrap('GET', '/api/health', res);
+    },
+
+    listPlans: async (params: ListPlansParams = {}) => {
+      const query: Record<string, string | number> = {};
+      if (params.cursor !== undefined) query['cursor'] = params.cursor;
+      if (params.limit !== undefined) query['limit'] = params.limit;
+      const res = await raw.GET('/api/v1/plans', { params: { query } });
+      return wrap('GET', '/api/v1/plans', res);
+    },
+
+    listSubscriptions: async (params: ListSubscriptionsParams = {}) => {
+      const query: Record<string, string | number> = {};
+      if (params.cursor !== undefined) query['cursor'] = params.cursor;
+      if (params.limit !== undefined) query['limit'] = params.limit;
+      const res = await raw.GET('/api/subscriptions', { params: { query } });
+      return wrap('GET', '/api/subscriptions', res);
+    },
+
+    getSubscription: async (id: string) => {
+      if (typeof id !== 'string' || id.length === 0) {
+        throw new StellarBillConfigError('subscription id must be a non-empty string');
+      }
+      const path = encodeURIComponent(id);
+      const res = await raw.GET('/api/subscriptions/{id}', { params: { path: { id } } });
+      return wrap('GET', `/api/subscriptions/${path}`, res);
+    },
+
+    inspectIdempotencyKey: async (key: string) => {
+      if (typeof key !== 'string' || key.length === 0) {
+        throw new StellarBillConfigError('idempotency key must be a non-empty string');
+      }
+      if (key.length > 255) {
+        throw new StellarBillConfigError('idempotency key exceeds maximum length of 255 characters');
+      }
+      const path = encodeURIComponent(key);
+      const res = await raw.GET('/api/v1/idempotency/{key}', { params: { path: { key } } });
+      return wrap('GET', `/api/v1/idempotency/${path}`, res);
+    },
+  };
+}
+
+/**
+ * Manual helper for callers that want throw-on-error semantics on a single
+ * call without enabling `throwOnError` globally.
+ */
+export async function assertOk<T>(result: SdkResult<T>): Promise<T> {
+  if (result.status >= 200 && result.status < 300) {
+    if (result.data === undefined) {
+      throw new StellarBillError({
+        status: result.status,
+        body: undefined,
+        requestUrl: result.requestUrl,
+        requestMethod: result.requestMethod,
+        message: `${result.requestMethod} ${result.requestUrl} returned 2xx with empty body`,
+      });
+    }
+    return result.data;
+  }
+  throw new StellarBillError({
+    status: result.status,
+    body: result.error,
+    requestUrl: result.requestUrl,
+    requestMethod: result.requestMethod,
+    message: makeErrorMessage(result.requestMethod, result.requestUrl, result.status, result.error),
+  });
+}
+
+/**
+ * Re-export for callers that want to construct or inspect API error
+ * envelopes manually (e.g. for response-shape validation in their own tests).
+ */
+export { safeParseErrorBody };

--- a/sdks/ts/src/errors.ts
+++ b/sdks/ts/src/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Typed error envelope returned by the Stellabill backend (see
+ * `openapi/openapi.yaml` -> `components.schemas.Error`).
+ */
+export interface ApiErrorBody {
+  error?: string;
+  message?: string;
+  code?: string;
+}
+
+/**
+ * Base SDK error. Thrown by helpers like `assertOk` and `.throwOnError()`
+ * when the API returns a non-2xx response.
+ */
+export class StellarBillError extends Error {
+  public readonly status: number;
+  public readonly body: ApiErrorBody | undefined;
+  public readonly requestUrl: string;
+  public readonly requestMethod: string;
+
+  constructor(opts: {
+    status: number;
+    body: ApiErrorBody | undefined;
+    requestUrl: string;
+    requestMethod: string;
+    message: string;
+  }) {
+    super(opts.message);
+    this.name = 'StellarBillError';
+    this.status = opts.status;
+    this.body = opts.body;
+    this.requestUrl = opts.requestUrl;
+    this.requestMethod = opts.requestMethod;
+    // Reset prototype chain for `instanceof` to work after transpilation
+    Object.setPrototypeOf(this, StellarBillError.prototype);
+  }
+
+  /**
+   * Best-effort text serialization for logging.
+   */
+  override toString(): string {
+    const code = this.body?.code ?? 'unknown';
+    return `StellarBillError [${this.requestMethod} ${this.requestUrl} -> ${this.status} (${code})]: ${this.message}`;
+  }
+}
+
+/**
+ * Error thrown when caller-configured inputs are invalid (e.g. missing
+ * baseUrl, malformed token). These are programmer errors and never come
+ * from the API itself.
+ */
+export class StellarBillConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StellarBillConfigError';
+    Object.setPrototypeOf(this, StellarBillConfigError.prototype);
+  }
+}

--- a/sdks/ts/src/index.ts
+++ b/sdks/ts/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * @stellabill/sdk — typed TypeScript client for the Stellabill backend API.
+ *
+ * Generated from `openapi/openapi.yaml` via `openapi-typescript` + `openapi-fetch`.
+ * Install with:
+ *
+ * ```sh
+ * pnpm add @stellabill/sdk
+ * ```
+ *
+ * See [`README.md`](../../README.md) for the full API surface and examples.
+ */
+
+export {
+  createStellarBillClient,
+  assertOk,
+  safeParseErrorBody,
+  type StellarBillClient,
+  type StellarBillClientOptions,
+  type SdkResult,
+  type HealthResult,
+  type ListPlansResult,
+  type ListSubscriptionsResult,
+  type GetSubscriptionResult,
+  type InspectIdempotencyKeyResult,
+  type ListPlansParams,
+  type ListSubscriptionsParams,
+  type FetchLike,
+} from './client.js';
+
+export {
+  StellarBillError,
+  StellarBillConfigError,
+  type ApiErrorBody,
+} from './errors.js';
+
+export { TokenHolder, sanitizeToken } from './auth.js';
+
+export { SDK_VERSION, defaultUserAgent } from './version.js';
+
+// Generated types are re-exported so consumers can `import type { components }`
+// from a stable entrypoint.
+export type { paths, components, operations } from './types/api.gen.js';

--- a/sdks/ts/src/types/api.gen.ts
+++ b/sdks/ts/src/types/api.gen.ts
@@ -1,0 +1,395 @@
+// AUTO-GENERATED FROM openapi/openapi.yaml — DO NOT EDIT.
+// Regenerate via: pnpm run generate (sdks/ts)
+// Source spec version tracked in openapi.yaml -> info.version
+
+export interface paths {
+    "/api/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health check */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/plans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List billing plans */
+        get: operations["listPlans"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List subscriptions */
+        get: operations["listSubscriptions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/subscriptions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one subscription */
+        get: operations["getSubscriptionV1"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/idempotency/{key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Inspect an idempotency key
+         * @description Returns the stored metadata for a previously recorded idempotency key.
+         *
+         *     Results are **tenant-scoped**: a caller can only inspect keys that were
+         *     created under their own tenant/caller identity. Keys that have expired
+         *     or were never recorded return `404`.
+         *
+         */
+        get: operations["inspectIdempotencyKey"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        Error: {
+            /** @description High-level error type */
+            error: string;
+            /** @description Human-readable error detail */
+            message: string;
+            /** @description Machine-readable error code */
+            code: string;
+        };
+        Pagination: {
+            /**
+             * @description Opaque token to retrieve the next page of results
+             * @example Y3Vyc29yX25leHRfcGFnZQ==
+             */
+            next_cursor?: string;
+            /**
+             * @description Indicates if there are more results available
+             * @example true
+             */
+            has_more: boolean;
+        };
+        HealthResponse: {
+            /** @example ok */
+            status: string;
+            /** @example stellarbill-backend */
+            service: string;
+        };
+        Plan: {
+            /** @example plan_basic */
+            id: string;
+            /** @example Basic */
+            name: string;
+            /** @example 1000 */
+            amount: string;
+            /** @example NGN */
+            currency: string;
+            /** @example monthly */
+            interval: string;
+            /** @example Starter plan */
+            description?: string;
+        };
+        PlansResponse: {
+            plans: components["schemas"]["Plan"][];
+            pagination: components["schemas"]["Pagination"];
+        };
+        Subscription: {
+            /** @example sub_123 */
+            id: string;
+            /** @example plan_basic */
+            plan_id: string;
+            /** @example customer_123 */
+            customer: string;
+            /** @example active */
+            status: string;
+            /** @example 1000 */
+            amount: string;
+            /** @example monthly */
+            interval: string;
+            /** @example 2026-04-01T00:00:00Z */
+            next_billing?: string;
+        };
+        SubscriptionsResponse: {
+            subscriptions: components["schemas"]["Subscription"][];
+            pagination: components["schemas"]["Pagination"];
+        };
+        /** @description Metadata for a stored idempotency key, scoped to the authenticated caller's tenant. */
+        IdempotencyKeyRecord: {
+            /**
+             * @description The idempotency key that was queried.
+             * @example order-abc-123
+             */
+            key: string;
+            /**
+             * Format: date-time
+             * @description When the key was first recorded (RFC 3339 UTC).
+             * @example 2026-07-27T10:00:00Z
+             */
+            used_at: string;
+            /**
+             * Format: date-time
+             * @description When the key will be purged (RFC 3339 UTC).
+             * @example 2026-07-28T10:00:00Z
+             */
+            expires_at: string;
+            /**
+             * @description HTTP status code stored with the completed response.
+             *     `0` indicates the original request is still in-flight.
+             *
+             * @example 201
+             */
+            status_code: number;
+            /**
+             * @description SHA-256 hex digest of the original request body, used to detect key reuse with a different payload.
+             * @example e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+             */
+            request_fingerprint: string;
+        };
+    };
+    responses: {
+        /** @description Validation or client error */
+        BadRequest: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Missing or invalid authentication */
+        Unauthorized: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Insufficient permissions */
+        Forbidden: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+        /** @description Resource not found */
+        NotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["Error"];
+            };
+        };
+    };
+    parameters: {
+        /** @description Opaque cursor for pagination */
+        Cursor: string;
+        /** @description Maximum number of items to return */
+        Limit: number;
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Service is up */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    listPlans: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Pagination cursor for the next page of results
+                 * @example Y3Vyc29yX25leHRfcGFnZQ==
+                 */
+                cursor?: string;
+                /**
+                 * @description Maximum number of items to return
+                 * @example 20
+                 */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Plans list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlansResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    listSubscriptions: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Pagination cursor for the next page of results
+                 * @example Y3Vyc29yX25leHRfcGFnZQ==
+                 */
+                cursor?: string;
+                /**
+                 * @description Maximum number of items to return
+                 * @example 20
+                 */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscriptions list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscriptionsResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getSubscriptionV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description Subscription identifier
+                 * @example sub_123
+                 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscription */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subscription"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    inspectIdempotencyKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description The idempotency key to inspect.
+                 * @example order-abc-123
+                 */
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Key found — returns stored metadata. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IdempotencyKeyRecord"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+}
+

--- a/sdks/ts/src/version.ts
+++ b/sdks/ts/src/version.ts
@@ -1,0 +1,13 @@
+/**
+ * SDK version. Keep in lock-step with `openapi/openapi.yaml`'s `info.version`.
+ * Bumped by the release pipeline on each tagged release.
+ */
+export const SDK_VERSION = '0.2.0';
+
+/**
+ * The user-agent identifier sent on every request. Format:
+ *   @stellabill/sdk/<version> node/<node-version>
+ */
+export function defaultUserAgent(nodeVersion: string = process.versions.node): string {
+  return `@stellabill/sdk/${SDK_VERSION} node/${nodeVersion}`;
+}

--- a/sdks/ts/test/auth.test.ts
+++ b/sdks/ts/test/auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeToken } from '../src/index.js';
+
+describe('sanitizeToken', () => {
+  it('returns undefined for undefined input', () => {
+    expect(sanitizeToken(undefined)).toBeUndefined();
+  });
+  it('returns undefined for non-string input', () => {
+    expect(sanitizeToken(123 as unknown as string)).toBeUndefined();
+    expect(sanitizeToken({} as unknown as string)).toBeUndefined();
+    expect(sanitizeToken(null as unknown as string)).toBeUndefined();
+  });
+  it('returns undefined for empty string after trim', () => {
+    expect(sanitizeToken('')).toBeUndefined();
+    expect(sanitizeToken('   ')).toBeUndefined();
+  });
+  it('returns undefined when trimmed string still contains whitespace', () => {
+    expect(sanitizeToken('a b')).toBeUndefined();
+    expect(sanitizeToken('a b c')).toBeUndefined();
+  });
+  it('returns trimmed token when surrounding whitespace is stripped', () => {
+    // sanitizeToken first trims, then rejects strings still containing whitespace.
+    expect(sanitizeToken('  abc  ')).toBe('abc');
+    expect(sanitizeToken('\tabc\n')).toBe('abc');
+    expect(sanitizeToken('abc')).toBe('abc');
+  });
+});

--- a/sdks/ts/test/client.test.ts
+++ b/sdks/ts/test/client.test.ts
@@ -1,0 +1,579 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  assertOk,
+  createStellarBillClient,
+  safeParseErrorBody,
+  StellarBillConfigError,
+  StellarBillError,
+} from '../src/index.js';
+
+type FetchCall = {
+  url: string;
+  init: RequestInit | undefined;
+  /** Headers extracted from the Request object (openapi-fetch passes Request as input). */
+  inputHeaders: Record<string, string>;
+  /** Headers extracted from init.headers (fallback if openapi-fetch passes a URL). */
+  initHeaders: Record<string, string>;
+};
+
+function toUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+function headersFromInit(init?: RequestInit): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!init?.headers) return out;
+  new Headers(init.headers).forEach((value, key) => {
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+/** Headers as observed by the mock fetch (covers both Request input + URL+init input). */
+function callHeaders(call: FetchCall): Record<string, string> {
+  return { ...call.initHeaders, ...call.inputHeaders };
+}
+
+function mockFetchOnce(
+  body: unknown,
+  init: { status?: number; contentType?: string } = {},
+): { fetch: typeof globalThis.fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const status = init.status ?? 200;
+  const contentType = init.contentType ?? 'application/json';
+  const text = body === undefined ? '' : typeof body === 'string' ? body : JSON.stringify(body);
+  const res = new Response(text, { status, headers: { 'content-type': contentType } });
+  const fetch: typeof globalThis.fetch = vi.fn(async (input, initArg) => {
+    const inputHeaders: Record<string, string> = {};
+    if (input instanceof Request) {
+      input.headers.forEach((value, key) => {
+        inputHeaders[key.toLowerCase()] = value;
+      });
+    }
+    calls.push({
+      url: toUrl(input),
+      init: initArg as RequestInit | undefined,
+      inputHeaders,
+      initHeaders: headersFromInit(initArg as RequestInit | undefined),
+    });
+    return res;
+  });
+  return { fetch, calls };
+}
+
+function makeFetchForResponse(response: Response): { fetch: typeof globalThis.fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetch: typeof globalThis.fetch = vi.fn(async (input, initArg) => {
+    const inputHeaders: Record<string, string> = {};
+    if (input instanceof Request) {
+      input.headers.forEach((value, key) => {
+        inputHeaders[key.toLowerCase()] = value;
+      });
+    }
+    calls.push({
+      url: toUrl(input),
+      init: initArg as RequestInit | undefined,
+      inputHeaders,
+      initHeaders: headersFromInit(initArg as RequestInit | undefined),
+    });
+    return response;
+  });
+  return { fetch, calls };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createStellarBillClient - configuration', () => {
+  it('throws StellarBillConfigError on missing baseUrl', () => {
+    expect(() => createStellarBillClient({ baseUrl: undefined as unknown as string })).toThrow(
+      StellarBillConfigError,
+    );
+    expect(() => createStellarBillClient({ baseUrl: '' })).toThrow(/non-empty/);
+    expect(() => createStellarBillClient({ baseUrl: '   ' })).toThrow(/non-empty/);
+    expect(() => createStellarBillClient({ baseUrl: 'not-a-url' })).toThrow(/not a valid URL/);
+  });
+
+  it('warns when baseUrl is http and not localhost', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fetch } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'http://example.com', fetch });
+    await sdk.getHealth();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Insecure baseUrl'));
+  });
+
+  it('does not warn when baseUrl is https', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fetch } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await sdk.getHealth();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when baseUrl is http on localhost/127.0.0.1', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { fetch: f1 } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk1 = createStellarBillClient({ baseUrl: 'http://localhost:8080', fetch: f1 });
+    await sdk1.getHealth();
+    const { fetch: f2 } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk2 = createStellarBillClient({ baseUrl: 'http://127.0.0.1:8080', fetch: f2 });
+    await sdk2.getHealth();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('throws StellarBillConfigError when no fetch implementation is available', () => {
+    const saved = (globalThis as { fetch?: unknown }).fetch;
+    (globalThis as { fetch?: unknown }).fetch = undefined;
+    try {
+      expect(() => createStellarBillClient({ baseUrl: 'https://api.example.com' })).toThrow(/No fetch/);
+    } finally {
+      (globalThis as { fetch?: unknown }).fetch = saved;
+    }
+  });
+
+  it('accepts an explicit fetch option', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await sdk.getHealth();
+    expect(calls).toHaveLength(1);
+  });
+
+  it('strips trailing slashes from baseUrl', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com///', fetch });
+    await sdk.getHealth();
+    expect(calls[0]!.url.startsWith('https://api.example.com/api/health')).toBe(true);
+    expect(calls[0]!.url).not.toContain('///api');
+  });
+
+  it('strips trailing slashes from baseUrl including port variants', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'http://127.0.0.1:8080/', fetch });
+    await sdk.getHealth();
+    expect(calls[0]!.url).toBe('http://127.0.0.1:8080/api/health');
+  });
+});
+
+describe('createStellarBillClient - headers and auth', () => {
+  it('injects Authorization Bearer header when token is set', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      token: '  my-token  ',
+      fetch,
+    });
+    await sdk.getHealth();
+    const headers = callHeaders(calls[0]!);
+    expect(headers['authorization']).toBe('Bearer my-token');
+  });
+
+  it('drops malformed token (whitespace inside)', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      token: 'bad token',
+      fetch,
+    });
+    await sdk.getHealth();
+    const headers = callHeaders(calls[0]!);
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('setToken rotates the token; subsequent calls use the new one', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', token: 'old', fetch });
+    expect(sdk.getToken()).toBe('old');
+    sdk.setToken('new');
+    expect(sdk.getToken()).toBe('new');
+    sdk.setToken(undefined);
+    expect(sdk.getToken()).toBeUndefined();
+    await sdk.getHealth();
+    const headers = callHeaders(calls[0]!);
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('attaches user-agent and static headers on every request', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      headers: { 'X-Custom-Trace': 'abc' },
+      fetch,
+    });
+    await sdk.getHealth();
+    const headers = callHeaders(calls[0]!);
+    expect(headers['user-agent']).toMatch(/^@stellabill\/sdk\//);
+    expect(headers['x-custom-trace']).toBe('abc');
+  });
+
+  it('skips empty-valued static headers', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      headers: { 'X-Empty': '', 'X-Keep': 'v' },
+      fetch,
+    });
+    await sdk.getHealth();
+    const headers = callHeaders(calls[0]!);
+    expect(headers['x-empty']).toBeUndefined();
+    expect(headers['x-keep']).toBe('v');
+  });
+
+  it('rejects caller-supplied Authorization header (auth bypass prevention)', async () => {
+    const { fetch, calls } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      headers: { Authorization: 'Bearer attacker-controlled' },
+      fetch,
+    });
+    await sdk.getHealth();
+    const headers = callHeaders(calls[0]!);
+    expect(headers['authorization']).toBeUndefined();
+  });
+
+  it('runs user-supplied middleware around the auth middleware', async () => {
+    const order: string[] = [];
+    let bearerSeen = false;
+    const res = new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+    const inner = makeFetchForResponse(res);
+    const trackingFetch: typeof globalThis.fetch = vi.fn(async (input, init) => {
+      order.push('fetch');
+      return inner.fetch(input, init as RequestInit | undefined);
+    });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      token: 'tok',
+      fetch: trackingFetch,
+      middleware: [
+        {
+          async onRequest({ request }) {
+            order.push('user-mw-before');
+            // Request must already carry Bearer by the time user middleware runs.
+            bearerSeen = request.headers.get('authorization') === 'Bearer tok';
+            return request;
+          },
+          async onResponse({ response }) {
+            order.push('user-mw-after');
+            return response;
+          },
+        },
+      ],
+    });
+    await sdk.getHealth();
+    expect(order).toEqual(['user-mw-before', 'fetch', 'user-mw-after']);
+    expect(bearerSeen).toBe(true);
+  });
+});
+
+describe('createStellarBillClient - typed wrappers (success paths)', () => {
+  it('getHealth returns parsed data', async () => {
+    const { fetch } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.getHealth();
+    expect(r.status).toBe(200);
+    expect(r.error).toBeUndefined();
+    expect(r.data?.status).toBe('ok');
+    expect(r.requestMethod).toBe('GET');
+    expect(r.requestUrl).toContain('/api/health');
+  });
+
+  it('listPlans forwards cursor and limit', async () => {
+    const { fetch, calls } = mockFetchOnce({ plans: [{ id: 'p1' }], pagination: { has_more: false } });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await sdk.listPlans({ cursor: 'c', limit: 25 });
+    expect(calls[0]!.url).toContain('/api/v1/plans');
+    expect(calls[0]!.url).toContain('cursor=c');
+    expect(calls[0]!.url).toContain('limit=25');
+  });
+
+  it('listSubscriptions forwards cursor and limit', async () => {
+    const { fetch, calls } = mockFetchOnce({ subscriptions: [], pagination: { has_more: false } });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await sdk.listSubscriptions({ cursor: 'c', limit: 25 });
+    expect(calls[0]!.url).toContain('/api/subscriptions');
+    expect(calls[0]!.url).toContain('cursor=c');
+    expect(calls[0]!.url).toContain('limit=25');
+  });
+
+  it('listSubscriptions omits undefined query params', async () => {
+    const { fetch, calls } = mockFetchOnce({ subscriptions: [], pagination: { has_more: false } });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await sdk.listSubscriptions();
+    expect(calls[0]!.url).toContain('/api/subscriptions');
+    expect(calls[0]!.url).not.toContain('cursor=');
+    expect(calls[0]!.url).not.toContain('limit=');
+  });
+
+  it('getSubscription throws on empty id', async () => {
+    const { fetch } = mockFetchOnce({ id: 'x', plan_id: 'p', customer: 'c', status: 'a', amount: '1', interval: 'm' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await expect(sdk.getSubscription('')).rejects.toBeInstanceOf(StellarBillConfigError);
+  });
+
+  it('getSubscription preserves special characters in the path', async () => {
+    const { fetch, calls } = mockFetchOnce({ id: 'sub/with spaces', plan_id: 'p' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await sdk.getSubscription('sub/with spaces');
+    expect(calls[0]!.url).toContain('/api/subscriptions/');
+    expect(decodeURIComponent(calls[0]!.url)).toContain('/api/subscriptions/sub/with spaces');
+  });
+
+  it('inspectIdempotencyKey rejects empty key', async () => {
+    const { fetch } = mockFetchOnce({});
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await expect(sdk.inspectIdempotencyKey('')).rejects.toBeInstanceOf(StellarBillConfigError);
+  });
+
+  it('inspectIdempotencyKey rejects key longer than 255 chars', async () => {
+    const { fetch } = mockFetchOnce({});
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    await expect(sdk.inspectIdempotencyKey('x'.repeat(256))).rejects.toBeInstanceOf(
+      StellarBillConfigError,
+    );
+  });
+
+  it('inspectIdempotencyKey returns parsed record on success', async () => {
+    const { fetch } = mockFetchOnce({
+      key: 'abc',
+      used_at: '2026-01-01T00:00:00Z',
+      expires_at: '2026-01-02T00:00:00Z',
+      status_code: 201,
+      request_fingerprint: 'fp',
+    });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.inspectIdempotencyKey('abc');
+    expect(r.data?.status_code).toBe(201);
+  });
+
+  it('exposes version, raw client, and token accessors', () => {
+    const { fetch } = mockFetchOnce({});
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', token: 't', fetch });
+    expect(sdk.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(typeof sdk.raw).toBe('object');
+    expect(sdk.getToken()).toBe('t');
+  });
+
+  it('listPlans throws when throwOnError + non-2xx', async () => {
+    const { fetch } = mockFetchOnce({ error: 'Bad Request', message: 'bad', code: 'x' }, { status: 400 });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      throwOnError: true,
+      fetch,
+    });
+    await expect(sdk.listPlans()).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('listSubscriptions returns parsed data on success', async () => {
+    const { fetch } = mockFetchOnce({ subscriptions: [], pagination: { has_more: false } });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.listSubscriptions();
+    expect(r.data?.subscriptions.length).toBe(0);
+  });
+
+  it('getSubscription throws when throwOnError + non-2xx', async () => {
+    const { fetch } = mockFetchOnce({ error: 'Not Found', message: 'gone', code: 'missing' }, { status: 404 });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      throwOnError: true,
+      fetch,
+    });
+    await expect(sdk.getSubscription('missing')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('inspectIdempotencyKey throws when throwOnError + non-2xx', async () => {
+    const { fetch } = mockFetchOnce(
+      { error: 'Unauthorized', message: 'auth', code: 'auth_unauthorized' },
+      { status: 401 },
+    );
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      throwOnError: true,
+      fetch,
+    });
+    await expect(sdk.inspectIdempotencyKey('abc')).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe('createStellarBillClient - error paths (non-2xx)', () => {
+  it('returns parsed error in result when not throwOnError', async () => {
+    const { fetch } = mockFetchOnce(
+      { error: 'Bad Request', message: 'Invalid cursor', code: 'invalid_cursor' },
+      { status: 400 },
+    );
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.listPlans({ limit: 999 });
+    expect(r.status).toBe(400);
+    expect(r.error?.code).toBe('invalid_cursor');
+    expect(r.data).toBeUndefined();
+  });
+
+  it('throws StellarBillError when throwOnError: true and status is non-2xx', async () => {
+    const { fetch } = mockFetchOnce(
+      { error: 'Not Found', message: 'gone', code: 'missing' },
+      { status: 404 },
+    );
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      throwOnError: true,
+      fetch,
+    });
+    let caught: unknown;
+    try {
+      await sdk.getSubscription('missing-id');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(StellarBillError);
+    const e = caught as StellarBillError;
+    expect(e.status).toBe(404);
+    expect(e.requestMethod).toBe('GET');
+    expect(e.requestUrl).toContain('/api/subscriptions/');
+    expect(e.body?.code).toBe('missing');
+  });
+
+  it('non-2xx with non-JSON content returns undefined error body', async () => {
+    const { fetch } = mockFetchOnce('<html>nope</html>', { status: 500, contentType: 'text/html' });
+    const sdk = createStellarBillClient({
+      baseUrl: 'https://api.example.com',
+      throwOnError: true,
+      fetch,
+    });
+    await expect(sdk.getHealth()).rejects.toMatchObject({
+      status: 500,
+      body: undefined,
+    });
+  });
+});
+
+describe('createStellarBillClient - warning path coverage', () => {
+  it('does not crash when console is fully unavailable', async () => {
+    const { fetch } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const savedConsole = globalThis.console;
+    (globalThis as { console?: Console }).console = undefined as unknown as Console;
+    try {
+      const sdk = createStellarBillClient({ baseUrl: 'http://example.com', fetch });
+      const r = await sdk.getHealth();
+      expect(r.status).toBe(200);
+    } finally {
+      (globalThis as { console?: Console }).console = savedConsole;
+    }
+  });
+
+  it('skips warning when console.warn is missing', async () => {
+    const { fetch } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const savedWarn = console.warn;
+    (console as unknown as { warn?: () => void }).warn = undefined;
+    try {
+      const sdk = createStellarBillClient({ baseUrl: 'http://example.com', fetch });
+      const r = await sdk.getHealth();
+      expect(r.status).toBe(200);
+    } finally {
+      console.warn = savedWarn;
+    }
+  });
+});
+
+describe('assertOk', () => {
+  it('returns data when 2xx and data present', async () => {
+    const { fetch } = mockFetchOnce({ status: 'ok', service: 'stellarbill-backend' });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.getHealth();
+    const data = await assertOk(r);
+    expect(data.status).toBe('ok');
+  });
+
+  it('throws when 2xx but body has no parsed data', async () => {
+    // openapi-fetch always calls res.json(), so the SDK cannot produce
+    // a `data === undefined` with status 200. Construct the SdkResult
+    // inline to exercise the assertOk branch directly.
+    const r = {
+      data: undefined,
+      error: undefined,
+      status: 200,
+      response: new Response('{}', { status: 200 }),
+      requestMethod: 'GET',
+      requestUrl: '/test',
+    };
+    await expect(assertOk(r)).rejects.toThrow(/empty body/);
+  });
+
+  it('throws StellarBillError on non-2xx', async () => {
+    const { fetch } = mockFetchOnce({ error: 'oops' }, { status: 500 });
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.getHealth();
+    await expect(assertOk(r)).rejects.toBeInstanceOf(StellarBillError);
+    await expect(assertOk(r)).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+describe('safeParseErrorBody', () => {
+  it('returns undefined when content-type is missing', async () => {
+    const r = new Response('{}', { status: 400 });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when content-type is not JSON', async () => {
+    const r = new Response('oops', { status: 400, headers: { 'content-type': 'text/plain' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when body is empty', async () => {
+    const r = new Response('', { status: 400, headers: { 'content-type': 'application/json' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('parses a valid error body', async () => {
+    const r = new Response(JSON.stringify({ message: 'bad', code: 'x' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(await safeParseErrorBody(r)).toEqual({ message: 'bad', code: 'x' });
+  });
+
+  it('returns undefined on invalid JSON', async () => {
+    const r = new Response('not-json', { status: 400, headers: { 'content-type': 'application/json' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when parsed value is a string', async () => {
+    const r = new Response('"a string"', { status: 400, headers: { 'content-type': 'application/json' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when parsed value is an array', async () => {
+    const r = new Response('[1,2,3]', { status: 400, headers: { 'content-type': 'application/json' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when parsed value is null', async () => {
+    const r = new Response('null', { status: 400, headers: { 'content-type': 'application/json' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when status 200 with empty body and non-json content', async () => {
+    const r = new Response('', { status: 200, headers: { 'content-type': 'text/plain' } });
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+
+  it('returns undefined when res.text() throws', async () => {
+    const r = new Response('ok', { status: 400, headers: { 'content-type': 'application/json' } });
+    vi.spyOn(r, 'text').mockRejectedValue(new Error('boom'));
+    expect(await safeParseErrorBody(r)).toBeUndefined();
+  });
+});
+
+describe('Token integration with createStellarBillClient', () => {
+  it('handles basic TokenHolder behavior via the SDK', async () => {
+    const { fetch } = mockFetchOnce({});
+    const sdk1 = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    expect(sdk1.getToken()).toBeUndefined();
+    sdk1.setToken('a');
+    expect(sdk1.getToken()).toBe('a');
+    sdk1.setToken(undefined);
+    expect(sdk1.getToken()).toBeUndefined();
+  });
+});

--- a/sdks/ts/test/errors.test.ts
+++ b/sdks/ts/test/errors.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { StellarBillConfigError, StellarBillError } from '../src/index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('StellarBillError', () => {
+  it('stores all fields and instanceof works', () => {
+    const err = new StellarBillError({
+      status: 404,
+      body: { error: 'Not Found', message: 'gone', code: 'missing' },
+      requestUrl: 'https://api.example.com/api/subscriptions/x',
+      requestMethod: 'GET',
+      message: 'GET https://api.example.com/api/subscriptions/x failed (404): gone',
+    });
+    expect(err).toBeInstanceOf(StellarBillError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('StellarBillError');
+    expect(err.status).toBe(404);
+    expect(err.body?.code).toBe('missing');
+    expect(err.requestUrl).toContain('/api/subscriptions/x');
+    expect(err.requestMethod).toBe('GET');
+  });
+
+  it('toString includes method, url, status and body code', () => {
+    const err = new StellarBillError({
+      status: 400,
+      body: { error: 'Bad Request', message: 'x', code: 'invalid_cursor' },
+      requestUrl: 'https://api.example.com/api/v1/plans',
+      requestMethod: 'GET',
+      message: 'GET ... failed',
+    });
+    expect(err.toString()).toContain('StellarBillError');
+    expect(err.toString()).toContain('GET');
+    expect(err.toString()).toContain('invalid_cursor');
+  });
+
+  it('toString falls back to "unknown" when body lacks code', () => {
+    const err = new StellarBillError({
+      status: 500,
+      body: undefined,
+      requestUrl: 'https://api.example.com/api/health',
+      requestMethod: 'GET',
+      message: 'GET ... failed',
+    });
+    expect(err.toString()).toContain('(unknown)');
+  });
+});
+
+describe('StellarBillConfigError', () => {
+  it('is an Error subclass and instanceof works', () => {
+    const err = new StellarBillConfigError('bad config');
+    expect(err).toBeInstanceOf(StellarBillConfigError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('StellarBillConfigError');
+    expect(err.message).toBe('bad config');
+  });
+});

--- a/sdks/ts/test/roundtrip.test.ts
+++ b/sdks/ts/test/roundtrip.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { assertOk, createStellarBillClient, SDK_VERSION } from '../src/index.js';
+import type { components } from '../src/types/api.gen.js';
+
+type HealthResp = components['schemas']['HealthResponse'];
+type PlansResp = components['schemas']['PlansResponse'];
+type SubResp = components['schemas']['SubscriptionsResponse'];
+type Sub = components['schemas']['Subscription'];
+type Idemp = components['schemas']['IdempotencyKeyRecord'];
+
+function mockWithJson(json: unknown, status = 200): { fetch: typeof globalThis.fetch } {
+  const res = new Response(JSON.stringify(json), { status, headers: { 'content-type': 'application/json' } });
+  const fetch: typeof globalThis.fetch = vi.fn(async () => res);
+  return { fetch };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * End-to-end round-trip test: drives every documented operation through
+ * the SDK and asserts the response shape matches the generated TypeScript
+ * type. This guarantees the SDK's wrapper surface and the OpenAPI-
+ * generated types stay in sync.
+ */
+describe('SDK round-trip (generated types match runtime responses)', () => {
+  it('GET /api/health round-trips a typed HealthResponse', async () => {
+    const sample: HealthResp = { status: 'ok', service: 'stellarbill-backend' };
+    const { fetch } = mockWithJson(sample);
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', token: 'rt-token', fetch });
+    const data = await assertOk(await sdk.getHealth());
+    // Compile-time assertion: the variable `typed` MUST match HealthResponse.
+    const typed: HealthResp = data;
+    expect(typed).toEqual(sample);
+    expect(sdk.version).toBe(SDK_VERSION);
+  });
+
+  it('GET /api/v1/plans round-trips a typed PlansResponse', async () => {
+    const sample: PlansResp = {
+      plans: [
+        { id: 'plan_basic', name: 'Basic', amount: '1000', currency: 'NGN', interval: 'monthly' },
+      ],
+      pagination: { has_more: false },
+    };
+    const { fetch } = mockWithJson(sample);
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const data = await assertOk(await sdk.listPlans({ limit: 50 }));
+    const typed: PlansResp = data;
+    expect(typed.plans[0]!.id).toBe('plan_basic');
+    expect(typed.pagination.has_more).toBe(false);
+  });
+
+  it('GET /api/subscriptions round-trips a typed SubscriptionsResponse', async () => {
+    const sample: SubResp = {
+      subscriptions: [
+        {
+          id: 'sub_123',
+          plan_id: 'plan_basic',
+          customer: 'cust_42',
+          status: 'active',
+          amount: '1500',
+          interval: 'monthly',
+          next_billing: '2026-12-31T00:00:00Z',
+        },
+      ],
+      pagination: { has_more: true, next_cursor: 'Y3Vyc29yX25leHRfcGFnZQ==' },
+    };
+    const { fetch } = mockWithJson(sample);
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const data = await assertOk(await sdk.listSubscriptions({ cursor: 'abc', limit: 25 }));
+    const typed: SubResp = data;
+    expect(typed.subscriptions[0]!.id).toBe('sub_123');
+    expect(typed.pagination.has_more).toBe(true);
+  });
+
+  it('GET /api/subscriptions/{id} round-trips a typed Subscription', async () => {
+    const sample: Sub = {
+      id: 'sub_xyz',
+      plan_id: 'plan_pro',
+      customer: 'cust_xyz',
+      status: 'active',
+      amount: '5000',
+      interval: 'monthly',
+    };
+    const { fetch } = mockWithJson(sample);
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const data = await assertOk(await sdk.getSubscription('sub_xyz'));
+    const typed: Sub = data;
+    expect(typed.id).toBe('sub_xyz');
+    expect(typed.plan_id).toBe('plan_pro');
+  });
+
+  it('GET /api/v1/idempotency/{key} round-trips a typed IdempotencyKeyRecord', async () => {
+    const sample: Idemp = {
+      key: 'order-abc-123',
+      used_at: '2026-07-27T10:00:00Z',
+      expires_at: '2026-07-28T10:00:00Z',
+      status_code: 201,
+      request_fingerprint: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    };
+    const { fetch } = mockWithJson(sample);
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const data = await assertOk(await sdk.inspectIdempotencyKey('order-abc-123'));
+    const typed: Idemp = data;
+    expect(typed.key).toBe('order-abc-123');
+    expect(typed.status_code).toBe(201);
+  });
+
+  it('round-trip with a non-JSON error body returns undefined error data and typed envelope', async () => {
+    const res = new Response('<html>500</html>', { status: 502, headers: { 'content-type': 'text/html' } });
+    const fetch: typeof globalThis.fetch = vi.fn(async () => res);
+    const sdk = createStellarBillClient({ baseUrl: 'https://api.example.com', fetch });
+    const r = await sdk.getHealth();
+    expect(r.status).toBe(502);
+    expect(r.error).toBeUndefined();
+    expect(r.data).toBeUndefined();
+    expect(r.requestMethod).toBe('GET');
+    expect(r.requestUrl).toContain('/api/health');
+  });
+});

--- a/sdks/ts/test/version.test.ts
+++ b/sdks/ts/test/version.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { SDK_VERSION, defaultUserAgent } from '../src/index.js';
+
+describe('SDK versioning', () => {
+  it('SDK_VERSION matches semver', () => {
+    expect(SDK_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+  it('defaultUserAgent includes the SDK version', () => {
+    const ua = defaultUserAgent('20.10.0');
+    expect(ua).toContain(`@stellabill/sdk/${SDK_VERSION}`);
+    expect(ua).toContain('node/20.10.0');
+  });
+  it('defaultUserAgent uses process.versions.node by default', () => {
+    const ua = defaultUserAgent();
+    expect(ua).toMatch(/node\/\d+\.\d+\.\d+/);
+  });
+});

--- a/sdks/ts/tsconfig.build.json
+++ b/sdks/ts/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*", "types/**/*"],
+  "exclude": ["dist", "node_modules", "coverage", "test", "scripts"]
+}

--- a/sdks/ts/tsconfig.json
+++ b/sdks/ts/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "types/**/*", "scripts/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules", "coverage"]
+}

--- a/sdks/ts/tsup.config.ts
+++ b/sdks/ts/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  target: 'node20',
+  outExtension({ format }) {
+    return { js: format === 'cjs' ? '.cjs' : '.js' };
+  },
+  // Keep openapi-fetch as a peer-style dependency so we don't bundle it
+  // (peer-deps tree stays clean and consumers share a single copy).
+  external: ['openapi-fetch'],
+});

--- a/sdks/ts/vitest.config.ts
+++ b/sdks/ts/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/version.ts'],
+      thresholds: {
+        statements: 95,
+        branches: 95,
+        functions: 95,
+        lines: 95,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Publishes a typed TypeScript SDK to npm on every GitHub release. Downstream
frontends can install `@stellabill/sdk` and consume a fully-typed client
without hand-writing one. Generated from `openapi/openapi.yaml` using
[`openapi-typescript`](https://openapi-ts.dev) +
[`openapi-fetch`](https://openapi-ts.dev/openapi-fetch/).

Closes #472.

## What ships

### SDK (`sdks/ts/`)

- `src/client.ts` — `createStellarBillClient()` factory + ergonomic typed
  wrappers for every documented operation:
  - `getHealth()`
  - `listPlans({ cursor?, limit? })`
  - `listSubscriptions({ cursor?, limit? })`
  - `getSubscription(id: string)`
  - `inspectIdempotencyKey(key: string)`
- `src/types/api.gen.ts` — generated by `openapi-typescript` from
  `openapi/openapi.yaml`; **committed** so consumers see full types in
  their IDE without running a build step.
- `src/auth.ts` — `TokenHolder` with runtime `setToken()` for rotation.
- `src/errors.ts` — `StellarBillError` + `StellarBillConfigError` with
  full status / body / request URL metadata.
- Build: dual **ESM + CJS + dts** via `tsup`. `openapi-fetch` is
  externalized so consumers share a single copy.

### Security highlights

- Caller-supplied `Authorization` headers are explicitly stripped; the
  SDK's `token` / `setToken()` is the *sole* source of auth (smuggling
  prevention).
- HTTPS-only warning when `baseUrl` is `http://` outside `localhost`.
- User-agent is auto-injected (`@stellabill/sdk/<version> node/<node>`).
- Path parameters are URL-encoded via `encodeURIComponent`.
- Token whitespace sanitization at every entry point.

### Codegen + tooling

- `scripts/generate.ts` — `node --experimental-strip-types` script that
  reads `openapi/openapi.yaml` and writes the generated types file.
- `pnpm-onlyBuiltDependencies` allowlist keeps the install
  reproducible while still letting esbuild's binary compile.
- `tsup.config.ts` + dual `exports` map (`import` / `require` / `types`).

### Tests (`sdks/ts/test/`)

- `client.test.ts` — 48 tests covering the factory, all wrappers, error
  paths, token rotation, middleware ordering, the warning branches, and
  every `safeParseErrorBody` edge case (array/null/string/invalid-JSON/
  empty/throw).
- `errors.test.ts` — `StellarBillError` + `StellarBillConfigError`.
- `auth.test.ts` — `sanitizeToken` invalid (empty/whitespace/non-string)
  and valid paths.
- `version.test.ts` — `SDK_VERSION` and `defaultUserAgent`.
- **`roundtrip.test.ts` — round-trip sample requests** for every
  documented operation, asserting generated `paths`/`components` types
  match the runtime responses.

### Coverage gate (enforced)

```
 % Coverage report from v8
-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------|---------|----------|---------|---------|-------------------
All files    |   99.14 |    98.05 |     100 |   99.14 |
 src         |   99.14 |    98.03 |     100 |   99.14 |
  auth.ts    |     100 |      100 |     100 |     100 |
  client.ts  |    98.9 |    97.53 |     100 |    98.9 | 104-105
  errors.ts  |     100 |      100 |     100 |     100 |
  index.ts   |     100 |      100 |     100 |     100 |
-------------|---------|----------|---------|---------|-------------------
```

All four metrics ≥95%; vitest threshold gate `enforced` in
`vitest.config.ts`. 66 / 66 tests pass.

### Release workflow (`.github/workflows/release.yml`)

- Triggers on `release: published` and on `workflow_dispatch` (with
  `tag` input for back-fills).
- Two jobs:
  1. `test-sdk` — `pnpm install` → `pnpm generate` → `pnpm build` →
     `pnpm typecheck` → `pnpm test` (with coverage gate) → upload
     artifacts. Uses `pnpm/action-setup@v4` (v10, matches lockfile).
  2. `publish-sdk` — downloads the built dist artifact, checks out the
     same tag, runs `npm pkg set version=<tag>` (atomic, no side-effects
     on failure), validates `package.json` shape, then runs
     `npm publish --provenance --access public` (falls back to
     `NPM_TOKEN` if OIDC trusted-publishing not configured at npmjs.com).
- Permissions narrowed to `id-token: write` + `contents: read` only
  (no PR-write, no `pull-requests: write`).

## Verification

```sh
cd sdks/ts
pnpm install
pnpm generate   # writes src/types/api.gen.ts
pnpm build      # emits dist/{index.js,index.cjs,index.d.ts,index.d.cts}
pnpm typecheck  # tsc --noEmit, clean
pnpm test       # 66/66 pass, coverage >=95% on all four metrics

# CI workflow
gh workflow view release.yml --repo Stellabill/stellabill-backend
```

## Security notes

- The release workflow does **not** receive secrets in code. It uses
  `NPM_TOKEN` (or OIDC trusted-publishing if configured) injected via
  the GitHub Actions secrets manager.
- Caller-supplied `Authorization` is stripped — see
  `sdks/ts/src/client.ts` (`extraHeaders` construction). Tests assert
  this in client.test.ts → "rejects caller-supplied Authorization
  header (auth bypass prevention)".
- The SDK does **not** log tokens, request bodies, or response bodies.

## Versioning

- SDK `package.json` version is bumped by the release workflow on every
  GitHub release. It tracks `info.version` in
  `openapi/openapi.yaml`.
- Breaking spec changes require a major SDK bump; additive (new
  optional headers / endpoints) ship as minor; type-preserving fixes as
  patch.
- `publishConfig.provenance: true` is set; provenance is only generated
  when OIDC trusted-publishing is configured at npmjs.com. Without it,
  publishing falls back to `NPM_TOKEN` auth without provenance.

## Files added

```
.github/workflows/release.yml
sdks/ts/CHANGELOG.md
sdks/ts/LICENSE
sdks/ts/README.md
sdks/ts/package.json
sdks/ts/pnpm-lock.yaml
sdks/ts/.gitignore
sdks/ts/.npmignore
sdks/ts/.npmrc
sdks/ts/scripts/generate.ts
sdks/ts/src/auth.ts
sdks/ts/src/client.ts
sdks/ts/src/errors.ts
sdks/ts/src/index.ts
sdks/ts/src/version.ts
sdks/ts/src/types/api.gen.ts         (generated, committed)
sdks/ts/test/auth.test.ts
sdks/ts/test/client.test.ts
sdks/ts/test/errors.test.ts
sdks/ts/test/roundtrip.test.ts
sdks/ts/test/version.test.ts
sdks/ts/tsconfig.build.json
sdks/ts/tsconfig.json
sdks/ts/tsup.config.ts
sdks/ts/vitest.config.ts
```

## Test output

```
 RUN  v2.1.9 /workspaces/stellabill-backend/sdks/ts
      Coverage enabled with v8
 ✓ test/client.test.ts (48 tests) 45ms
 ✓ test/roundtrip.test.ts (6 tests) 21ms
 ✓ test/errors.test.ts (4 tests) 5ms
 ✓ test/auth.test.ts (5 tests) 5ms
 ✓ test/version.test.ts (3 tests) 6ms

 Test Files  5 passed (5)
      Tests  66 passed (66)
   Duration  1.75s
```

Ready for review.