### PR TITLE
Adopt structured problem-domain error codes with stable identifiers 

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,165 @@
+# Error Codes
+
+Every error response from the Stellabill API includes a stable `code` field
+that clients can use to branch programmatically. Error codes follow the format
+`<domain>/<operation-error>` and are defined in the central registry at
+`internal/errcode/registry.go`.
+
+**Rule:** never match on the human-readable `message` string — it may change
+without notice. Always switch on `code`.
+
+## Response envelope
+
+```json
+{
+  "code": "subscription/not-found",
+  "message": "The requested subscription was not found",
+  "trace_id": "550e8400-e29b-41d4-a716-446655440000",
+  "details": {}
+}
+```
+
+| Field      | Type     | Description |
+|------------|----------|-------------|
+| `code`     | string   | Stable error identifier from the registry. |
+| `message`  | string   | Human-readable explanation (may change). |
+| `trace_id` | string   | Correlation ID for debugging. |
+| `details`  | object   | Optional additional context. |
+
+## Error code registry
+
+### Subscription domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `subscription/not-found` | 404 | The requested subscription was not found. |
+| `subscription/soft-deleted` | 410 | The requested subscription has been deleted. |
+| `subscription/forbidden` | 403 | Caller does not have permission to access the subscription. |
+| `subscription/invalid-status` | 422 | The provided status value is not a valid subscription status. |
+| `subscription/invalid-state-transition` | 409 | The requested status transition is not allowed by the state machine. |
+| `subscription/unknown-current-state` | 409 | The subscription has an unrecognized current status. |
+
+### Billing domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `billing/parse-error` | 500 | Internal error while parsing billing data. |
+
+### Statement domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `statement/not-found` | 404 | The requested statement was not found. |
+| `statement/forbidden` | 403 | Caller does not have permission to access the statement. |
+
+### Plan domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `plan/not-found` | 404 | The requested plan was not found. |
+
+### Swap domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `swap/insufficient-liquidity` | 422 | Insufficient liquidity for the requested swap. |
+| `swap/invalid-amount` | 400 | The provided swap amount is invalid. |
+
+### Export domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `export/in-progress` | 409 | An export is already in progress for this tenant. |
+
+### Webhook domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `webhook/invalid-payload` | 400 | The webhook payload is malformed or missing required fields. |
+| `webhook/unknown-event-type` | 422 | The webhook event type is not recognized. |
+| `webhook/missing-field` | 400 | A required field is missing from the webhook payload. |
+
+### Authentication / authorization domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `auth/missing-credentials` | 401 | Authentication credentials are required. |
+| `auth/invalid-token` | 401 | The provided authentication credentials are invalid. |
+| `auth/forbidden` | 403 | You do not have permission to perform this action. |
+| `auth/insufficient-permissions` | 403 | Your role does not have the required permission. |
+
+### Validation domain
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `validation/failed` | 400 | The request failed validation. |
+| `validation/unknown-field` | 400 | The request contains an unrecognized field. |
+
+### Client errors (generic)
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `client/bad-request` | 400 | The request is malformed or contains invalid parameters. |
+| `client/not-found` | 404 | The requested resource was not found. |
+| `client/conflict` | 409 | The request conflicts with the current state of the resource. |
+| `client/rate-limited` | 429 | Too many requests; please retry later. |
+| `client/payload-too-large` | 413 | The request payload exceeds the maximum allowed size. |
+
+### Server errors (generic)
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `system/internal-error` | 500 | An unexpected internal error occurred. |
+| `system/service-unavailable` | 503 | The service is temporarily unavailable. |
+
+## Adding a new error code
+
+1. Open `internal/errcode/registry.go`.
+2. Add a `const` declaration for the new code in the appropriate domain section.
+3. Add a `mustRegister(...)` call in the `init()` function with the default
+   message and HTTP status.
+4. Add a test in `internal/errcode/registry_test.go` covering the new code.
+5. Reference the code in handlers via `errcode.CodeXxxYyy` (or the `errcode`
+   package import if used directly).
+
+The registry panics at init time if a code is registered twice or if an empty
+code is provided, so misconfiguration will be caught immediately on startup.
+
+## Mapping service errors
+
+`handlers.MapServiceErrorToResponse` translates domain errors from the service
+layer to the appropriate HTTP status and error code:
+
+| Service error | HTTP | Error code |
+|---------------|------|------------|
+| `ErrNotFound` | 404 | `subscription/not-found` |
+| `ErrDeleted` | 410 | `subscription/soft-deleted` |
+| `ErrForbidden` | 403 | `subscription/forbidden` |
+| `ErrBillingParse` | 500 | `billing/parse-error` |
+| `ErrInvalidTransition` | 409 | `subscription/invalid-state-transition` |
+| `ErrUnknownCurrentState` | 409 | `subscription/unknown-current-state` |
+| `ErrInvalidStatus` | 422 | `subscription/invalid-status` |
+| `ErrExportInProgress` | 409 | `export/in-progress` |
+| default | 500 | `system/internal-error` |
+
+## Client-side handling example
+
+```typescript
+const response = await fetch("/api/v1/subscriptions/123", { headers: auth });
+if (!response.ok) {
+  const body = await response.json();
+  switch (body.code) {
+    case "subscription/not-found":
+      // Show "subscription not found" UI
+      break;
+    case "subscription/forbidden":
+      // Show "access denied" UI
+      break;
+    case "subscription/soft-deleted":
+      // Show "subscription was cancelled" UI
+      break;
+    default:
+      // Generic error handling
+  }
+}
+```

--- a/internal/errcode/registry.go
+++ b/internal/errcode/registry.go
@@ -1,0 +1,268 @@
+// Package errcode provides a stable, structured error code registry for the
+// Stellabill API. Every error response emitted by the API carries a code from
+// this registry, enabling clients to branch on stable identifiers rather than
+// fragile human-readable message strings.
+//
+// Codes follow the pattern <domain>/<operation-error> and are grouped by
+// problem domain. The registry is validated at init time so that:
+//   - every code is unique across the entire registry,
+//   - no code is the empty string.
+//
+// New error codes MUST be registered in this file before they can be used by
+// handlers. This keeps the public contract auditable and prevents typos from
+// reaching production responses.
+package errcode
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Code is a stable error identifier returned in every API error response body.
+// Clients should switch on Code, never on the human-readable message string.
+type Code string
+
+// Entry describes a single registered error code with its default message and
+// HTTP status code.
+type Entry struct {
+	Code       Code   `json:"code"`
+	Message    string `json:"message"`
+	HTTPStatus int    `json:"http_status"`
+}
+
+// Registry holds all known error codes. It is safe for concurrent reads but
+// writes (Register) must only happen during init or test setup.
+type Registry struct {
+	mu    sync.RWMutex
+	codes map[Code]Entry
+}
+
+// New creates an empty Registry.
+func New() *Registry {
+	return &Registry{codes: make(map[Code]Entry)}
+}
+
+// Register adds a code to the registry. It panics if the code is empty or has
+// already been registered, which makes misconfiguration fail at startup.
+func (r *Registry) Register(code Code, message string, httpStatus int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if code == "" {
+		panic("errcode: empty code")
+	}
+	if _, exists := r.codes[code]; exists {
+		panic(fmt.Sprintf("errcode: duplicate code %q", code))
+	}
+	r.codes[code] = Entry{Code: code, Message: message, HTTPStatus: httpStatus}
+}
+
+// Lookup returns the Entry for the given code, or an empty Entry and false if
+// the code is not registered.
+func (r *Registry) Lookup(code Code) (Entry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.codes[code]
+	return e, ok
+}
+
+// Codes returns all registered codes in sorted order.
+func (r *Registry) Codes() []Code {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Code, 0, len(r.codes))
+	for c := range r.codes {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// Len returns the number of registered codes.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.codes)
+}
+
+// All returns all registered entries in sorted order by code.
+func (r *Registry) All() []Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Entry, 0, len(r.codes))
+	for _, e := range r.codes {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Code < out[j].Code })
+	return out
+}
+
+// Default is the global error code registry populated at init time. All
+// application code should reference codes from this registry.
+var Default = New()
+
+// --- Registration helper ---
+
+func mustRegister(code Code, message string, httpStatus int) {
+	Default.Register(code, message, httpStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Subscription domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeSubscriptionNotFound         Code = "subscription/not-found"
+	CodeSubscriptionSoftDeleted      Code = "subscription/soft-deleted"
+	CodeSubscriptionForbidden        Code = "subscription/forbidden"
+	CodeSubscriptionInvalidStatus    Code = "subscription/invalid-status"
+	CodeSubscriptionInvalidTransition Code = "subscription/invalid-state-transition"
+	CodeSubscriptionUnknownState     Code = "subscription/unknown-current-state"
+)
+
+// ---------------------------------------------------------------------------
+// Billing domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeBillingParseError Code = "billing/parse-error"
+)
+
+// ---------------------------------------------------------------------------
+// Statement domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeStatementNotFound Code = "statement/not-found"
+	CodeStatementForbidden Code = "statement/forbidden"
+)
+
+// ---------------------------------------------------------------------------
+// Plan domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodePlanNotFound Code = "plan/not-found"
+)
+
+// ---------------------------------------------------------------------------
+// Swap domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeSwapInsufficientLiquidity Code = "swap/insufficient-liquidity"
+	CodeSwapInvalidAmount         Code = "swap/invalid-amount"
+)
+
+// ---------------------------------------------------------------------------
+// Export domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeExportInProgress Code = "export/in-progress"
+)
+
+// ---------------------------------------------------------------------------
+// Webhook domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeWebhookInvalidPayload   Code = "webhook/invalid-payload"
+	CodeWebhookUnknownEventType Code = "webhook/unknown-event-type"
+	CodeWebhookMissingField     Code = "webhook/missing-field"
+)
+
+// ---------------------------------------------------------------------------
+// Authentication / authorization domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeAuthMissing         Code = "auth/missing-credentials"
+	CodeAuthInvalid         Code = "auth/invalid-token"
+	CodeAuthForbidden       Code = "auth/forbidden"
+	CodeAuthInsufficientPerm Code = "auth/insufficient-permissions"
+)
+
+// ---------------------------------------------------------------------------
+// Validation domain
+// ---------------------------------------------------------------------------
+
+const (
+	CodeValidationFailed Code = "validation/failed"
+	CodeValidationUnknownField Code = "validation/unknown-field"
+)
+
+// ---------------------------------------------------------------------------
+// Client errors (generic)
+// ---------------------------------------------------------------------------
+
+const (
+	CodeBadRequest      Code = "client/bad-request"
+	CodeNotFound        Code = "client/not-found"
+	CodeConflict        Code = "client/conflict"
+	CodeRateLimited     Code = "client/rate-limited"
+	CodePayloadTooLarge Code = "client/payload-too-large"
+)
+
+// ---------------------------------------------------------------------------
+// Server errors (generic)
+// ---------------------------------------------------------------------------
+
+const (
+	CodeInternalError      Code = "system/internal-error"
+	CodeServiceUnavailable Code = "system/service-unavailable"
+)
+
+func init() {
+	// Subscription
+	mustRegister(CodeSubscriptionNotFound, "The requested subscription was not found", 404)
+	mustRegister(CodeSubscriptionSoftDeleted, "The requested subscription has been deleted", 410)
+	mustRegister(CodeSubscriptionForbidden, "You do not have permission to access this subscription", 403)
+	mustRegister(CodeSubscriptionInvalidStatus, "The provided status value is not valid", 422)
+	mustRegister(CodeSubscriptionInvalidTransition, "The requested status transition is not allowed", 409)
+	mustRegister(CodeSubscriptionUnknownState, "The subscription has an unrecognized current status", 409)
+
+	// Billing
+	mustRegister(CodeBillingParseError, "An internal error occurred while processing billing data", 500)
+
+	// Statement
+	mustRegister(CodeStatementNotFound, "The requested statement was not found", 404)
+	mustRegister(CodeStatementForbidden, "You do not have permission to access this statement", 403)
+
+	// Plan
+	mustRegister(CodePlanNotFound, "The requested plan was not found", 404)
+
+	// Swap
+	mustRegister(CodeSwapInsufficientLiquidity, "Insufficient liquidity for the requested swap", 422)
+	mustRegister(CodeSwapInvalidAmount, "The provided swap amount is invalid", 400)
+
+	// Export
+	mustRegister(CodeExportInProgress, "An export is already in progress for this tenant", 409)
+
+	// Webhook
+	mustRegister(CodeWebhookInvalidPayload, "The webhook payload is malformed or missing required fields", 400)
+	mustRegister(CodeWebhookUnknownEventType, "The webhook event type is not recognized", 422)
+	mustRegister(CodeWebhookMissingField, "A required field is missing from the webhook payload", 400)
+
+	// Auth
+	mustRegister(CodeAuthMissing, "Authentication credentials are required", 401)
+	mustRegister(CodeAuthInvalid, "The provided authentication credentials are invalid", 401)
+	mustRegister(CodeAuthForbidden, "You do not have permission to perform this action", 403)
+	mustRegister(CodeAuthInsufficientPerm, "Your role does not have the required permission", 403)
+
+	// Validation
+	mustRegister(CodeValidationFailed, "The request failed validation", 400)
+	mustRegister(CodeValidationUnknownField, "The request contains an unrecognized field", 400)
+
+	// Client (generic)
+	mustRegister(CodeBadRequest, "The request is malformed or contains invalid parameters", 400)
+	mustRegister(CodeNotFound, "The requested resource was not found", 404)
+	mustRegister(CodeConflict, "The request conflicts with the current state of the resource", 409)
+	mustRegister(CodeRateLimited, "Too many requests; please retry later", 429)
+	mustRegister(CodePayloadTooLarge, "The request payload exceeds the maximum allowed size", 413)
+
+	// Server (generic)
+	mustRegister(CodeInternalError, "An unexpected internal error occurred", 500)
+	mustRegister(CodeServiceUnavailable, "The service is temporarily unavailable", 503)
+}

--- a/internal/errcode/registry_test.go
+++ b/internal/errcode/registry_test.go
@@ -1,0 +1,275 @@
+package errcode
+
+import (
+	"sort"
+	"sync"
+	"testing"
+)
+
+func TestNewRegistryIsEmpty(t *testing.T) {
+	r := New()
+	if r.Len() != 0 {
+		t.Fatalf("expected empty registry, got %d codes", r.Len())
+	}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	r := New()
+	r.Register("test/ok", "test message", 200)
+
+	entry, ok := r.Lookup("test/ok")
+	if !ok {
+		t.Fatal("expected code to be found")
+	}
+	if entry.Code != "test/ok" {
+		t.Errorf("expected code test/ok, got %s", entry.Code)
+	}
+	if entry.Message != "test message" {
+		t.Errorf("expected message 'test message', got %q", entry.Message)
+	}
+	if entry.HTTPStatus != 200 {
+		t.Errorf("expected HTTP status 200, got %d", entry.HTTPStatus)
+	}
+}
+
+func TestLookupNotFound(t *testing.T) {
+	r := New()
+	_, ok := r.Lookup("nonexistent/code")
+	if ok {
+		t.Fatal("expected lookup to return false for unregistered code")
+	}
+}
+
+func TestRegisterEmptyCodePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for empty code")
+		}
+	}()
+	r := New()
+	r.Register("", "bad", 400)
+}
+
+func TestRegisterDuplicatePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for duplicate code")
+		}
+	}()
+	r := New()
+	r.Register("dup/code", "first", 400)
+	r.Register("dup/code", "second", 400)
+}
+
+func TestCodesReturnsSortedSlice(t *testing.T) {
+	r := New()
+	r.Register("z/code", "z", 400)
+	r.Register("a/code", "a", 400)
+	r.Register("m/code", "m", 400)
+
+	codes := r.Codes()
+	if len(codes) != 3 {
+		t.Fatalf("expected 3 codes, got %d", len(codes))
+	}
+	if !sort.StringsAreSorted([]string{string(codes[0]), string(codes[1]), string(codes[2])}) {
+		t.Errorf("codes not sorted: %v", codes)
+	}
+}
+
+func TestLen(t *testing.T) {
+	r := New()
+	if r.Len() != 0 {
+		t.Fatalf("expected 0, got %d", r.Len())
+	}
+	r.Register("a/1", "a", 400)
+	if r.Len() != 1 {
+		t.Fatalf("expected 1, got %d", r.Len())
+	}
+	r.Register("b/2", "b", 500)
+	if r.Len() != 2 {
+		t.Fatalf("expected 2, got %d", r.Len())
+	}
+}
+
+func TestAllReturnsSortedEntries(t *testing.T) {
+	r := New()
+	r.Register("z/late", "z", 400)
+	r.Register("a/first", "a", 400)
+
+	all := r.All()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(all))
+	}
+	if all[0].Code != "a/first" {
+		t.Errorf("expected first entry a/first, got %s", all[0].Code)
+	}
+	if all[1].Code != "z/late" {
+		t.Errorf("expected second entry z/late, got %s", all[1].Code)
+	}
+}
+
+func TestConcurrentReads(t *testing.T) {
+	r := New()
+	r.Register("concurrent/test", "test", 400)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, ok := r.Lookup("concurrent/test")
+			if !ok {
+				t.Error("expected code to be found")
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Default registry tests
+// ---------------------------------------------------------------------------
+
+func TestDefaultRegistryIsPopulated(t *testing.T) {
+	if Default.Len() == 0 {
+		t.Fatal("default registry should not be empty after init")
+	}
+}
+
+func TestAllExpectedDomainCodesExist(t *testing.T) {
+	expected := []Code{
+		// Subscription
+		CodeSubscriptionNotFound,
+		CodeSubscriptionSoftDeleted,
+		CodeSubscriptionForbidden,
+		CodeSubscriptionInvalidStatus,
+		CodeSubscriptionInvalidTransition,
+		CodeSubscriptionUnknownState,
+		// Billing
+		CodeBillingParseError,
+		// Statement
+		CodeStatementNotFound,
+		CodeStatementForbidden,
+		// Plan
+		CodePlanNotFound,
+		// Swap
+		CodeSwapInsufficientLiquidity,
+		CodeSwapInvalidAmount,
+		// Export
+		CodeExportInProgress,
+		// Webhook
+		CodeWebhookInvalidPayload,
+		CodeWebhookUnknownEventType,
+		CodeWebhookMissingField,
+		// Auth
+		CodeAuthMissing,
+		CodeAuthInvalid,
+		CodeAuthForbidden,
+		CodeAuthInsufficientPerm,
+		// Validation
+		CodeValidationFailed,
+		CodeValidationUnknownField,
+		// Client generic
+		CodeBadRequest,
+		CodeNotFound,
+		CodeConflict,
+		CodeRateLimited,
+		CodePayloadTooLarge,
+		// Server generic
+		CodeInternalError,
+		CodeServiceUnavailable,
+	}
+
+	for _, code := range expected {
+		entry, ok := Default.Lookup(code)
+		if !ok {
+			t.Errorf("expected code %q to be registered", code)
+			continue
+		}
+		if entry.Code != code {
+			t.Errorf("expected entry code %q, got %q", code, entry.Code)
+		}
+		if entry.Message == "" {
+			t.Errorf("code %q has empty message", code)
+		}
+		if entry.HTTPStatus < 100 || entry.HTTPStatus > 599 {
+			t.Errorf("code %q has invalid HTTP status %d", code, entry.HTTPStatus)
+		}
+	}
+}
+
+func TestDefaultCodesAreUnique(t *testing.T) {
+	codes := Default.Codes()
+	seen := make(map[Code]bool, len(codes))
+	for _, c := range codes {
+		if seen[c] {
+			t.Errorf("duplicate code in default registry: %s", c)
+		}
+		seen[c] = true
+	}
+}
+
+func TestDefaultCodesHaveConsistentFormat(t *testing.T) {
+	for _, code := range Default.Codes() {
+		s := string(code)
+		if len(s) == 0 {
+			t.Error("empty code in default registry")
+			continue
+		}
+		// Must contain exactly one slash separating domain from operation
+		slashCount := 0
+		for _, ch := range s {
+			if ch == '/' {
+				slashCount++
+			}
+		}
+		if slashCount != 1 {
+			t.Errorf("code %q does not follow <domain>/<operation> format (found %d slashes)", code, slashCount)
+		}
+	}
+}
+
+func TestDefaultCodesHaveReasonableHTTPStatuses(t *testing.T) {
+	for _, entry := range Default.All() {
+		status := entry.HTTPStatus
+		if status < 400 || status > 599 {
+			t.Errorf("code %q has non-error HTTP status %d; error codes should be 4xx or 5xx", entry.Code, status)
+		}
+	}
+}
+
+func TestSubscriptionCodesHave4xxStatuses(t *testing.T) {
+	subCodes := []Code{
+		CodeSubscriptionNotFound,
+		CodeSubscriptionSoftDeleted,
+		CodeSubscriptionForbidden,
+		CodeSubscriptionInvalidStatus,
+		CodeSubscriptionInvalidTransition,
+		CodeSubscriptionUnknownState,
+	}
+	for _, code := range subCodes {
+		entry, ok := Default.Lookup(code)
+		if !ok {
+			t.Fatalf("code %q not found", code)
+		}
+		if entry.HTTPStatus < 400 || entry.HTTPStatus > 499 {
+			t.Errorf("subscription code %q should have 4xx status, got %d", code, entry.HTTPStatus)
+		}
+	}
+}
+
+func TestServerCodesHave5xxStatuses(t *testing.T) {
+	serverCodes := []Code{
+		CodeInternalError,
+		CodeBillingParseError,
+	}
+	for _, code := range serverCodes {
+		entry, ok := Default.Lookup(code)
+		if !ok {
+			t.Fatalf("code %q not found", code)
+		}
+		if entry.HTTPStatus < 500 || entry.HTTPStatus > 599 {
+			t.Errorf("server code %q should have 5xx status, got %d", code, entry.HTTPStatus)
+		}
+	}
+}

--- a/internal/handlers/coverage_test.go
+++ b/internal/handlers/coverage_test.go
@@ -81,6 +81,10 @@ func TestCoverage_ErrorResponses(t *testing.T) {
 	_, _, _ = MapServiceErrorToResponse(service.ErrDeleted)
 	_, _, _ = MapServiceErrorToResponse(service.ErrForbidden)
 	_, _, _ = MapServiceErrorToResponse(service.ErrBillingParse)
+	_, _, _ = MapServiceErrorToResponse(service.ErrInvalidTransition)
+	_, _, _ = MapServiceErrorToResponse(service.ErrUnknownCurrentState)
+	_, _, _ = MapServiceErrorToResponse(service.ErrInvalidStatus)
+	_, _, _ = MapServiceErrorToResponse(service.ErrExportInProgress)
 }
 
 func TestCoverage_NewGetSubscriptionHandler(t *testing.T) {

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"stellarbill-backend/internal/errcode"
 	"stellarbill-backend/internal/security"
 	"stellarbill-backend/internal/service"
 
@@ -10,24 +11,29 @@ import (
 	"github.com/google/uuid"
 )
 
-// ErrorCode represents a standardized error code
-type ErrorCode string
+// ErrorCode is an alias for errcode.Code, preserving backward compatibility
+// while delegating to the central error code registry.
+type ErrorCode = errcode.Code
 
+// Canonical error code constants. Each maps to a stable <domain>/<operation>
+// string in the errcode registry. Handlers should prefer the errcode.Code
+// constants directly; these aliases exist for callers that reference the old
+// names.
 const (
 	// Client errors
-	ErrorCodeBadRequest       ErrorCode = "BAD_REQUEST"
-	ErrorCodeUnauthorized     ErrorCode = "UNAUTHORIZED"
-	ErrorCodeForbidden        ErrorCode = "FORBIDDEN"
-	ErrorCodeNotFound         ErrorCode = "NOT_FOUND"
-	ErrorCodeConflict         ErrorCode = "CONFLICT"
-	ErrorCodeValidationFailed ErrorCode = "VALIDATION_FAILED"
+	ErrorCodeBadRequest       = errcode.CodeBadRequest
+	ErrorCodeUnauthorized     = errcode.CodeAuthMissing
+	ErrorCodeForbidden        = errcode.CodeAuthForbidden
+	ErrorCodeNotFound         = errcode.CodeNotFound
+	ErrorCodeConflict         = errcode.CodeConflict
+	ErrorCodeValidationFailed = errcode.CodeValidationFailed
 	// ErrorCodeUnknownField is returned when a mutation request body contains a
 	// field not defined in the API schema. See internal/decoder for details.
-	ErrorCodeUnknownField ErrorCode = "UNKNOWN_FIELD"
+	ErrorCodeUnknownField = errcode.CodeValidationUnknownField
 
 	// Server errors
-	ErrorCodeInternalError      ErrorCode = "INTERNAL_ERROR"
-	ErrorCodeServiceUnavailable ErrorCode = "SERVICE_UNAVAILABLE"
+	ErrorCodeInternalError      = errcode.CodeInternalError
+	ErrorCodeServiceUnavailable = errcode.CodeServiceUnavailable
 )
 
 // ErrorEnvelope represents a standardized error response
@@ -39,12 +45,12 @@ type ErrorEnvelope struct {
 }
 
 // RespondWithError sends a standardized error response
-func RespondWithError(c *gin.Context, statusCode int, code ErrorCode, message string) {
+func RespondWithError(c *gin.Context, statusCode int, code errcode.Code, message string) {
 	RespondWithErrorDetails(c, statusCode, code, message, nil)
 }
 
 // RespondWithErrorDetails sends a standardized error response with additional details
-func RespondWithErrorDetails(c *gin.Context, statusCode int, code ErrorCode, message string, details map[string]interface{}) {
+func RespondWithErrorDetails(c *gin.Context, statusCode int, code errcode.Code, message string, details map[string]interface{}) {
 	c.Header("Content-Type", "application/json; charset=utf-8")
 
 	traceID := c.GetString("traceID")
@@ -74,39 +80,48 @@ func generateTraceID() string {
 	return uuid.New().String()
 }
 
-// MapServiceErrorToResponse maps domain service errors to HTTP status codes and error codes
-func MapServiceErrorToResponse(err error) (int, ErrorCode, string) {
+// MapServiceErrorToResponse maps domain service errors to HTTP status codes
+// and domain-specific error codes from the errcode registry.
+func MapServiceErrorToResponse(err error) (int, errcode.Code, string) {
 	switch err {
 	case service.ErrNotFound:
-		return http.StatusNotFound, ErrorCodeNotFound, "The requested resource was not found"
+		return http.StatusNotFound, errcode.CodeSubscriptionNotFound, "The requested subscription was not found"
 	case service.ErrDeleted:
-		return http.StatusGone, ErrorCodeNotFound, "The requested resource has been deleted"
+		return http.StatusGone, errcode.CodeSubscriptionSoftDeleted, "The requested subscription has been deleted"
 	case service.ErrForbidden:
-		return http.StatusForbidden, ErrorCodeForbidden, "You do not have permission to access this resource"
+		return http.StatusForbidden, errcode.CodeSubscriptionForbidden, "You do not have permission to access this subscription"
 	case service.ErrBillingParse:
-		return http.StatusInternalServerError, ErrorCodeInternalError, "An internal error occurred while processing your request"
+		return http.StatusInternalServerError, errcode.CodeBillingParseError, "An internal error occurred while processing billing data"
+	case service.ErrInvalidTransition:
+		return http.StatusConflict, errcode.CodeSubscriptionInvalidTransition, "The requested status transition is not allowed"
+	case service.ErrUnknownCurrentState:
+		return http.StatusConflict, errcode.CodeSubscriptionUnknownState, "The subscription has an unrecognized current status"
+	case service.ErrInvalidStatus:
+		return http.StatusUnprocessableEntity, errcode.CodeSubscriptionInvalidStatus, "The provided status value is not valid"
+	case service.ErrExportInProgress:
+		return http.StatusConflict, errcode.CodeExportInProgress, "An export is already in progress for this tenant"
 	default:
-		return http.StatusInternalServerError, ErrorCodeInternalError, "An unexpected error occurred"
+		return http.StatusInternalServerError, errcode.CodeInternalError, "An unexpected error occurred"
 	}
 }
 
 // RespondWithValidationError sends a validation error response
 func RespondWithValidationError(c *gin.Context, message string, details map[string]interface{}) {
-	RespondWithErrorDetails(c, http.StatusBadRequest, ErrorCodeValidationFailed, message, details)
+	RespondWithErrorDetails(c, http.StatusBadRequest, errcode.CodeValidationFailed, message, details)
 }
 
 // RespondWithAuthError sends an authentication error response
 func RespondWithAuthError(c *gin.Context, message string) {
-	RespondWithError(c, http.StatusUnauthorized, ErrorCodeUnauthorized, message)
+	RespondWithError(c, http.StatusUnauthorized, errcode.CodeAuthMissing, message)
 }
 
 // RespondWithNotFoundError sends a not found error response
 func RespondWithNotFoundError(c *gin.Context, resource string) {
 	message := fmt.Sprintf("%s not found", resource)
-	RespondWithError(c, http.StatusNotFound, ErrorCodeNotFound, message)
+	RespondWithError(c, http.StatusNotFound, errcode.CodeNotFound, message)
 }
 
 // RespondWithInternalError sends an internal server error response
 func RespondWithInternalError(c *gin.Context, message string) {
-	RespondWithError(c, http.StatusInternalServerError, ErrorCodeInternalError, message)
+	RespondWithError(c, http.StatusInternalServerError, errcode.CodeInternalError, message)
 }

--- a/internal/handlers/errors_test.go
+++ b/internal/handlers/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"stellarbill-backend/internal/errcode"
 	"stellarbill-backend/internal/service"
 	"strings"
 	"testing"
@@ -77,10 +78,10 @@ func TestErrorEnvelope_NotFound(t *testing.T) {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
 
-	if envelope.Code != string(ErrorCodeNotFound) {
-		t.Errorf("Expected error code %s, got %s", ErrorCodeNotFound, envelope.Code)
+	if envelope.Code != string(errcode.CodeSubscriptionNotFound) {
+		t.Errorf("Expected error code %s, got %s", errcode.CodeSubscriptionNotFound, envelope.Code)
 	}
-	if envelope.Message != "The requested resource was not found" {
+	if envelope.Message != "The requested subscription was not found" {
 		t.Errorf("Expected proper message, got %s", envelope.Message)
 	}
 	if envelope.TraceID != "test-trace-123" {
@@ -110,8 +111,8 @@ func TestErrorEnvelope_Deleted(t *testing.T) {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
 
-	if envelope.Code != string(ErrorCodeNotFound) {
-		t.Errorf("Expected error code %s, got %s", ErrorCodeNotFound, envelope.Code)
+	if envelope.Code != string(errcode.CodeSubscriptionSoftDeleted) {
+		t.Errorf("Expected error code %s, got %s", errcode.CodeSubscriptionSoftDeleted, envelope.Code)
 	}
 	if envelope.TraceID == "" {
 		t.Error("Expected trace ID to be present")
@@ -140,10 +141,10 @@ func TestErrorEnvelope_Forbidden(t *testing.T) {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
 
-	if envelope.Code != string(ErrorCodeForbidden) {
-		t.Errorf("Expected error code %s, got %s", ErrorCodeForbidden, envelope.Code)
+	if envelope.Code != string(errcode.CodeSubscriptionForbidden) {
+		t.Errorf("Expected error code %s, got %s", errcode.CodeSubscriptionForbidden, envelope.Code)
 	}
-	if envelope.Message != "You do not have permission to access this resource" {
+	if envelope.Message != "You do not have permission to access this subscription" {
 		t.Errorf("Expected proper message, got %s", envelope.Message)
 	}
 }
@@ -170,8 +171,8 @@ func TestErrorEnvelope_BillingParse(t *testing.T) {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
 
-	if envelope.Code != string(ErrorCodeInternalError) {
-		t.Errorf("Expected error code %s, got %s", ErrorCodeInternalError, envelope.Code)
+	if envelope.Code != string(errcode.CodeBillingParseError) {
+		t.Errorf("Expected error code %s, got %s", errcode.CodeBillingParseError, envelope.Code)
 	}
 }
 
@@ -335,7 +336,7 @@ func TestErrorEnvelope_PIIRedaction(t *testing.T) {
 			"amount":      1234.56,
 			"safe_field":  "ok",
 		}
-		RespondWithErrorDetails(c, http.StatusBadRequest, ErrorCodeBadRequest,
+		RespondWithErrorDetails(c, http.StatusBadRequest, errcode.CodeBadRequest,
 			"Failed processing customer_cust_sensitive123 with amount 1234.56", details)
 	})
 


### PR DESCRIPTION
Closes #496

## Summary
Fixes a logic defect in the score reconciliation job where DB and
on-chain scores were compared using the wrong operator, causing genuine
drift between the two to be silently treated as agreement and never
flagged for correction.

## Root Cause
In `backend/src/services/scoreReconciliationService.ts`, the
`reconcileActiveBorrowerScores` function used an incorrect comparison
operator when checking `dbScore` against `contractScore`, so mismatches
were not detected as divergences.

## Changes
- Corrected the comparison operator so any mismatch between `dbScore`
  and `contractScore` is properly classified as a divergence.
- [add any other lines changed, e.g. added logging/tests]

## Testing
- Forced a mismatch between a stored DB score and the on-chain contract
  score for a test borrower.
- Ran `reconcileActiveBorrowerScores` and confirmed the mismatch is now
  logged (`score_reconciliation.mismatch`) and included in the
  `divergences` array.
- [add: ran `npm test` / added a unit test, if applicable]

## Component
Backend — `backend/src/services/scoreReconciliationService.ts` ->
`reconcileActiveBorrowerScores`