### PR TITLE
devops: add Go x Postgres CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,20 @@ name: CI
 
 on:
   push:
+    branches: [main, master, develop]
   pull_request:
+    branches: [main, master, develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  lint:
+    name: Lint & Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,14 +27,65 @@ jobs:
         run: |
           go install mvdan.cc/gofumpt@latest
           test -z "$(gofumpt -l .)"
-      - name: Unit + contract tests
-        run: go test ./...
       - name: OpenAPI validation
         run: go run ./cmd/openapi-validate
       - name: Migration Safety Validation
         run: go run ./cmd/validate-migrations
       - name: ADR lint (unique numbers + index)
         run: make docs-lint
+
+  test:
+    name: Test (Go ${{ matrix.go }}, PG ${{ matrix.postgres }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.22', '1.23']
+        postgres: ['15', '16', '17']
+    services:
+      postgres:
+        image: postgres:${{ matrix.postgres }}-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: Run tests (JUnit XML)
+        run: |
+          gotestsum --junitfile test-results.xml --format standard-verbose -- ./...
+        env:
+          DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-go${{ matrix.go }}-pg${{ matrix.postgres }}
+          path: test-results.xml
+
+  coverage:
+    name: Coverage (>= 95%)
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Coverage (>= 95% for non-cmd packages)
         shell: bash
         run: |
@@ -54,7 +115,7 @@ jobs:
       - name: Run baseline benchmarks
         run: |
           go test ./internal/handlers/... -bench=. -benchmem -benchtime=1s -count=1 | tee baseline.txt
-      
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
@@ -62,17 +123,17 @@ jobs:
       - name: Run current benchmarks
         run: |
           go test ./internal/handlers/... -bench=. -benchmem -benchtime=1s -count=1 | tee current.txt
-      
+
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest
-      
+
       - name: Compare benchmarks
         run: |
           echo "## Benchmark Comparison" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           benchstat baseline.txt current.txt | tee -a $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-      
+
       - name: Check for regressions
         run: |
           REGRESSION_PCT=20

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Go (Gin) API backend for Stellabill - subscription and billing plans API. This repo is backend-only; a separate frontend consumes these APIs.
 
+[![CI](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml)
+
+| Go \ Postgres | 15 | 16 | 17 |
+|:---:|:---:|:---:|:---:|
+| **1.22** | [![test](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml) | [![test](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml) | [![test](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml) |
+| **1.23** | [![test](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml) | [![test](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml) | [![test](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/Stellabill/stellabill-backend/actions/workflows/ci.yml) |
+
 ---
 
 ## Table of contents
@@ -254,6 +261,19 @@ router.GET("/feature", middleware.RequireAnyFeatureFlags("flag1", "flag2"), hand
 > See **[docs/dev-test-guide.md](docs/dev-test-guide.md)** for the full local
 > development and test execution guide, including common failure
 > troubleshooting.
+
+### CI matrix
+
+CI runs a **Go x Postgres** matrix on every push and PR:
+
+| Go \ Postgres | 15 | 16 | 17 |
+|:---:|:---:|:---:|:---:|
+| **1.22** | ✅ | ✅ | ✅ |
+| **1.23** | ✅ | ✅ | ✅ |
+
+Each matrix cell publishes a JUnit XML report as a build artifact. Lint and
+formatting checks run once (not per matrix cell). Coverage is enforced at
+**>= 95%** for non-cmd packages.
 
 ### Unit tests
 


### PR DESCRIPTION
## Summary

Adds a Go x Postgres version matrix to CI for catching drift before runtime upgrades, with JUnit XML reports and parallel job execution.

## Changes

**Workflow split** — monolithic CI job split into 4 parallel jobs:
- **lint** — formatting, OpenAPI validation, migration safety, ADR lint (runs once)
- **test** — Go x Postgres matrix with JUnit XML output
- **coverage** — >= 95% enforcement for non-cmd packages (runs once)
- **benchmark-thresholds** — existing regression detection (unchanged)

**Matrix configuration:**
| Go \ Postgres | 15 | 16 | 17 |
|:---:|:---:|:---:|:---:|
| **1.22** | ✅ | ✅ | ✅ |
| **1.23** | ✅ | ✅ | ✅ |

- ail-fast: false — all matrix cells run to completion
- Postgres service containers with health checks
- JUnit XML reports uploaded as artifacts per matrix cell
- Concurrency groups cancel stale runs on the same branch

**README** — CI badge added; matrix table and documentation in Testing section.

## Closes

Closes #469