### PR TITLE
devops: adopt distroless base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+docs
+*.md
+LICENSE
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ── Build stage ───────────────────────────────────────────────────────────────
+FROM golang:1.25-bookworm AS build
+
+WORKDIR /src
+
+# Cache dependency downloads
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-s -w" \
+    -trimpath \
+    -o /server \
+    ./cmd/server
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /server /server
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/server"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,26 @@ curl -X POST http://localhost:8080/api/outbox/test
 
 ---
 
+## Docker
+
+The Dockerfile uses a **multi-stage build** with
+`gcr.io/distroless/static-debian12:nonroot` as the runtime base. The final
+image contains only the statically-linked binary — no shell, no package manager,
+minimal CVE surface.
+
+```bash
+# Build
+docker build -t stellabill-backend .
+
+# Run
+docker run --rm -e DATABASE_URL=... -p 8080:8080 stellabill-backend
+```
+
+The image runs as the `nonroot` user (UID 65534) by default. The binary is
+compiled with `CGO_ENABLED=0` for a fully static executable.
+
+---
+
 ## Configuration
 
 > **Quick start:** copy [`.env.example`](.env.example) to `.env`, fill in the


### PR DESCRIPTION
## Summary

Replaces the bare Go build with a multi-stage Dockerfile using `gcr.io/distroless/static-debian12:nonroot` as the runtime base. The final image contains only the statically-linked binary - no shell, no package manager, minimal CVE surface.

## Changes

- **Multi-stage Dockerfile** - `golang:1.25-bookworm` build stage, `distroless/static-debian12:nonroot` runtime
- **Static binary** - `CGO_ENABLED=0`, `-ldflags="-s -w"`, `-trimpath`
- **Non-root** - runs as `nonroot` user (UID 65534) by default
- **`.dockerignore`** - excludes `.git`, `.github`, `docs`, `*.md`, `Makefile` from build context
- **README** - Docker section with build/run instructions

## Security

- No shell or package manager in final image, reduced CVE surface
- Non-root user by default
- Distroless images receive regular security patches from Google

## Closes

Closes #470
