### PR TITLE
refactor: inject clock interface for deterministic time-sensitive tests

### DIFF
--- a/docs/clock-injection.md
+++ b/docs/clock-injection.md
@@ -1,0 +1,55 @@
+# Clock injection for deterministic time-sensitive tests
+
+`internal/timeutil.Clock` abstracts wall-clock reads so job scheduling, TTL
+expiry, and archival-cutoff logic can be tested deterministically instead of
+depending on `time.Now()` and real sleeps.
+
+```go
+type Clock interface {
+    Now() time.Time // always normalized to UTC
+}
+```
+
+- `timeutil.SystemClock` is the production implementation (backed by
+  `timeutil.NowUTC()`). It's the default for every constructor below — no
+  behavior changes for existing callers.
+- `timeutil.NewFakeClock(start)` returns a `*FakeClock` for tests, with
+  `Set(t)` to jump to an absolute time and `Advance(d)` to move forward (or
+  backward, for negative `d`) by a duration. Both operate on the absolute
+  instant, so they behave correctly across daylight-saving-time transitions
+  even if seeded from a non-UTC `time.Time`.
+
+## Where it's wired in
+
+| Type | Constructor | Test hook |
+|---|---|---|
+| `worker.Scheduler` | `NewScheduler(store)` | `(*Scheduler).SetClock(c)` |
+| `worker.MemoryStore` | `NewMemoryStore()` | `NewMemoryStoreWithClock(c)` |
+| `worker.StatementArchiveJob` | `NewStatementArchiveJob(...)` | `(*StatementArchiveJob).SetClock(c)` |
+| `worker.FeeRevenueRefreshJob` | `NewFeeRevenueRefreshJob(...)` | `(*FeeRevenueRefreshJob).SetClock(c)` |
+
+Call `SetClock`/use the `WithClock` constructor **before** `Start()` — these
+jobs read the clock field from their own background goroutine, so setting it
+before the goroutine is spawned is race-free without extra locking.
+
+## Example
+
+```go
+clock := timeutil.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+store := worker.NewMemoryStoreWithClock(clock)
+_, _ = store.AcquireLock("job-1", "worker-a", 5*time.Minute)
+
+clock.Advance(5*time.Minute + time.Second) // past the TTL
+ok, _ := store.AcquireLock("job-1", "worker-b", 5*time.Minute) // ok == true
+```
+
+## Not migrated
+
+`internal/service/quiet_hours.go`'s `IsQuietHours()` is an unimplemented
+stub (`return false`, no time comparison, no callers) — there is no
+time-dependent logic there yet to inject a clock into. When quiet-hours
+enforcement is implemented against `model.NotificationPreferences`'
+`QuietStart`/`QuietEnd`/`Timezone` fields, it should take a `timeutil.Clock`
+(or an explicit `now time.Time`) as a parameter from the start, following the
+pattern above.

--- a/internal/timeutil/clock.go
+++ b/internal/timeutil/clock.go
@@ -1,0 +1,61 @@
+package timeutil
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock abstracts wall-clock access so time-sensitive code (job schedulers,
+// TTL expiry, archival cutoffs) can be driven deterministically in tests
+// instead of depending on the real system clock.
+type Clock interface {
+	// Now returns the clock's current time, normalized to UTC.
+	Now() time.Time
+}
+
+// realClock is the production Clock, backed by NowUTC.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return NowUTC() }
+
+// SystemClock is the default production Clock. Services should use this
+// unless a Clock is explicitly injected (e.g. via a constructor or SetClock)
+// for testing.
+var SystemClock Clock = realClock{}
+
+// FakeClock is a manually-controlled Clock for deterministic tests. It is
+// safe for concurrent use. The zero value is not usable; construct one with
+// NewFakeClock.
+type FakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewFakeClock returns a FakeClock fixed at start. start is normalized to UTC,
+// matching the contract of Clock.Now.
+func NewFakeClock(start time.Time) *FakeClock {
+	return &FakeClock{now: NormalizeUTC(start)}
+}
+
+// Now returns the clock's current fixed time.
+func (f *FakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+// Set moves the clock to t (normalized to UTC).
+func (f *FakeClock) Set(t time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = NormalizeUTC(t)
+}
+
+// Advance moves the clock forward by d. A negative d moves it backward. This
+// operates on the absolute instant (like time.Time.Add), so it is safe to use
+// across daylight-saving-time transitions without introducing skew.
+func (f *FakeClock) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}

--- a/internal/timeutil/clock_test.go
+++ b/internal/timeutil/clock_test.go
@@ -1,0 +1,131 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSystemClock_ReturnsCurrentTimeInUTC(t *testing.T) {
+	before := time.Now().UTC()
+	got := SystemClock.Now()
+	after := time.Now().UTC()
+
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC location, got %v", got.Location())
+	}
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("SystemClock.Now() = %v, want between %v and %v", got, before, after)
+	}
+}
+
+func TestFakeClock_SetAndNow(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	c := NewFakeClock(start)
+
+	if got := c.Now(); !got.Equal(start) {
+		t.Fatalf("Now() = %v, want %v", got, start)
+	}
+
+	next := time.Date(2026, 6, 15, 12, 30, 0, 0, time.UTC)
+	c.Set(next)
+	if got := c.Now(); !got.Equal(next) {
+		t.Fatalf("after Set, Now() = %v, want %v", got, next)
+	}
+}
+
+func TestFakeClock_SetNormalizesToUTC(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	local := time.Date(2026, 1, 1, 8, 0, 0, 0, loc)
+	c := NewFakeClock(local)
+
+	got := c.Now()
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC location, got %v", got.Location())
+	}
+	if !got.Equal(local) {
+		t.Fatalf("Now() = %v, want same instant as %v", got, local)
+	}
+}
+
+func TestFakeClock_Advance(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	c := NewFakeClock(start)
+
+	c.Advance(90 * time.Minute)
+	want := start.Add(90 * time.Minute)
+	if got := c.Now(); !got.Equal(want) {
+		t.Fatalf("after Advance(+90m), Now() = %v, want %v", got, want)
+	}
+
+	c.Advance(-30 * time.Minute)
+	want = want.Add(-30 * time.Minute)
+	if got := c.Now(); !got.Equal(want) {
+		t.Fatalf("after Advance(-30m), Now() = %v, want %v", got, want)
+	}
+}
+
+// TestFakeClock_AdvanceAcrossSpringForward verifies that Advance operates on
+// the absolute instant, so it does not lose or gain time across a
+// daylight-saving "spring forward" transition, even when the FakeClock was
+// seeded from a local (non-UTC) time.Time.
+func TestFakeClock_AdvanceAcrossSpringForward(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	// 2024-03-10 01:30 EST is 30 minutes before the 02:00 -> 03:00 jump.
+	before := time.Date(2024, 3, 10, 1, 30, 0, 0, loc)
+	c := NewFakeClock(before)
+
+	c.Advance(2 * time.Hour)
+
+	wantUTC := before.UTC().Add(2 * time.Hour)
+	got := c.Now()
+	if !got.Equal(wantUTC) {
+		t.Fatalf("Advance across spring-forward: got %v, want %v (absolute instant)", got, wantUTC)
+	}
+
+	// The wall-clock gap means local time reads 04:30, not 03:30: the clock
+	// skipped the nonexistent 02:00-03:00 hour, confirming no manual
+	// component-based arithmetic snuck in.
+	gotLocal := got.In(loc)
+	wantLocal := time.Date(2024, 3, 10, 4, 30, 0, 0, loc)
+	if !gotLocal.Equal(wantLocal) {
+		t.Fatalf("local reading after spring-forward = %v, want %v", gotLocal, wantLocal)
+	}
+}
+
+// TestFakeClock_AdvanceAcrossFallBack verifies correct absolute-instant
+// arithmetic across a daylight-saving "fall back" transition, where a local
+// wall-clock hour repeats.
+func TestFakeClock_AdvanceAcrossFallBack(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	// 2024-11-03 00:30 EDT is 90 minutes before the 02:00 -> 01:00 fall-back.
+	before := time.Date(2024, 11, 3, 0, 30, 0, 0, loc)
+	c := NewFakeClock(before)
+
+	c.Advance(2 * time.Hour)
+
+	wantUTC := before.UTC().Add(2 * time.Hour)
+	got := c.Now()
+	if !got.Equal(wantUTC) {
+		t.Fatalf("Advance across fall-back: got %v, want %v (absolute instant)", got, wantUTC)
+	}
+
+	// The repeated hour means local time reads 01:30 (EST, the second time
+	// through 01:00-02:00), i.e. only 1 wall-clock hour appears to have
+	// passed even though a full 2 hours elapsed in absolute terms.
+	gotLocal := got.In(loc)
+	wantLocal := time.Date(2024, 11, 3, 1, 30, 0, 0, loc)
+	if !gotLocal.Equal(wantLocal) {
+		t.Fatalf("local reading after fall-back = %v, want %v", gotLocal, wantLocal)
+	}
+}

--- a/internal/worker/clock_injection_test.go
+++ b/internal/worker/clock_injection_test.go
@@ -1,0 +1,71 @@
+package worker
+
+import (
+	"stellarbill-backend/internal/timeutil"
+	"testing"
+	"time"
+)
+
+// TestScheduler_UsesInjectedClockForTimestamps verifies that Scheduler derives
+// CreatedAt/UpdatedAt (and the job ID's timestamp component) from an injected
+// Clock rather than the system clock, so job creation timing is deterministic
+// in tests.
+func TestScheduler_UsesInjectedClockForTimestamps(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := timeutil.NewFakeClock(start)
+
+	store := NewMemoryStore()
+	s := NewScheduler(store)
+	s.SetClock(clock)
+
+	job, err := s.ScheduleCharge("sub-1", start.Add(time.Hour), 3, PriorityHigh)
+	if err != nil {
+		t.Fatalf("ScheduleCharge: %v", err)
+	}
+	if !job.CreatedAt.Equal(start) {
+		t.Fatalf("CreatedAt = %v, want %v", job.CreatedAt, start)
+	}
+	if !job.UpdatedAt.Equal(start) {
+		t.Fatalf("UpdatedAt = %v, want %v", job.UpdatedAt, start)
+	}
+
+	// Advancing the clock and scheduling again should reflect the new instant.
+	clock.Advance(90 * time.Minute)
+	want := start.Add(90 * time.Minute)
+
+	job2, err := s.ScheduleInvoice("sub-2", want.Add(time.Hour), 3, PriorityNormal)
+	if err != nil {
+		t.Fatalf("ScheduleInvoice: %v", err)
+	}
+	if !job2.CreatedAt.Equal(want) {
+		t.Fatalf("CreatedAt after advance = %v, want %v", job2.CreatedAt, want)
+	}
+}
+
+// TestMemoryStore_LockExpiryIsDrivenByClock verifies that AcquireLock's TTL
+// expiry is evaluated against the store's injected Clock, so lock takeover
+// after expiry can be tested deterministically without sleeping.
+func TestMemoryStore_LockExpiryIsDrivenByClock(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := timeutil.NewFakeClock(start)
+	store := NewMemoryStoreWithClock(clock)
+
+	ok, err := store.AcquireLock("job-1", "worker-a", 5*time.Minute)
+	if err != nil || !ok {
+		t.Fatalf("AcquireLock(worker-a) = %v, %v, want true, nil", ok, err)
+	}
+
+	// Before expiry, a different worker must not be able to acquire the lock.
+	ok, err = store.AcquireLock("job-1", "worker-b", 5*time.Minute)
+	if err != nil || ok {
+		t.Fatalf("AcquireLock(worker-b) before expiry = %v, %v, want false, nil", ok, err)
+	}
+
+	// Advance past the TTL: the lock should now be takeable by another worker.
+	clock.Advance(5*time.Minute + time.Second)
+
+	ok, err = store.AcquireLock("job-1", "worker-b", 5*time.Minute)
+	if err != nil || !ok {
+		t.Fatalf("AcquireLock(worker-b) after expiry = %v, %v, want true, nil", ok, err)
+	}
+}

--- a/internal/worker/fee_revenue_refresh_job.go
+++ b/internal/worker/fee_revenue_refresh_job.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"stellarbill-backend/internal/timeutil"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -100,6 +101,7 @@ type FeeRevenueRefreshJob struct {
 	store  feeRevenueStore
 	config FeeRevenueRefreshConfig
 	logger feeRevenueLogger
+	clock  timeutil.Clock
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -131,7 +133,15 @@ func newFeeRevenueRefreshJob(store feeRevenueStore, config FeeRevenueRefreshConf
 		store:  store,
 		config: config.withDefaults(),
 		logger: l,
+		clock:  timeutil.SystemClock,
 	}
+}
+
+// SetClock overrides the job's time source, so freshness/staleness behavior
+// can be tested deterministically. Call before Start(); production callers
+// should leave the default SystemClock in place.
+func (j *FeeRevenueRefreshJob) SetClock(c timeutil.Clock) {
+	j.clock = c
 }
 
 // Start begins the refresh loop. It is safe to call Start only once.
@@ -254,7 +264,7 @@ func (j *FeeRevenueRefreshJob) refreshOnce() {
 		return
 	}
 
-	now := time.Now().UTC()
+	now := j.clock.Now()
 	if err := j.store.MarkRefreshed(ctx, now); err != nil {
 		// The view is fresh but we failed to persist the timestamp; surface it
 		// so the report does not silently report stale data.

--- a/internal/worker/scheduler.go
+++ b/internal/worker/scheduler.go
@@ -16,6 +16,7 @@ type Scheduler struct {
 	store   JobStore
 	counter int64
 	mu      sync.Mutex
+	clock   timeutil.Clock
 
 	weights     map[Priority]int
 	totalWeight int
@@ -29,6 +30,7 @@ type Scheduler struct {
 func NewScheduler(store JobStore) *Scheduler {
 	s := &Scheduler{
 		store:           store,
+		clock:           timeutil.SystemClock,
 		weights:         make(map[Priority]int),
 		starvationLimit: 10,
 	}
@@ -37,6 +39,15 @@ func NewScheduler(store JobStore) *Scheduler {
 	}
 	s.recalcWeight()
 	return s
+}
+
+// SetClock overrides the Scheduler's time source. Intended for deterministic
+// tests (e.g. verifying job timestamps or TTL-adjacent behavior); production
+// callers should leave the default SystemClock in place.
+func (s *Scheduler) SetClock(c timeutil.Clock) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clock = c
 }
 
 // SetWeights replaces the lane weights. The caller should ensure each lane
@@ -144,8 +155,13 @@ func (s *Scheduler) laneForIdx(idx int, forceLow bool) Priority {
 
 // jobBase returns fields common to every scheduled job.
 func (s *Scheduler) jobBase(jobType, subscriptionID string, scheduledAt time.Time, maxAttempts int, priority Priority) *Job {
+	s.mu.Lock()
+	clock := s.clock
+	s.mu.Unlock()
+
+	now := clock.Now()
 	return &Job{
-		ID:             generateJobID(jobType),
+		ID:             generateJobID(jobType, now),
 		SubscriptionID: subscriptionID,
 		Type:           jobType,
 		Status:         JobStatusPending,
@@ -153,8 +169,8 @@ func (s *Scheduler) jobBase(jobType, subscriptionID string, scheduledAt time.Tim
 		ScheduledAt:    timeutil.NormalizeUTC(scheduledAt),
 		MaxAttempts:    maxAttempts,
 		Attempts:       0,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 }
 
@@ -191,8 +207,8 @@ func (s *Scheduler) ScheduleReminder(subscriptionID string, scheduledAt time.Tim
 	return job, nil
 }
 
-func generateJobID(jobType string) string {
-	return fmt.Sprintf("%s-%d", jobType, timeutil.NowUTC().UnixNano())
+func generateJobID(jobType string, now time.Time) string {
+	return fmt.Sprintf("%s-%d", jobType, now.UnixNano())
 }
 
 // IdempotencyCleanupJob periodically cleans up expired idempotency keys.

--- a/internal/worker/statement_archive_job.go
+++ b/internal/worker/statement_archive_job.go
@@ -9,6 +9,7 @@ import (
 	"stellarbill-backend/internal/featureflags"
 	"stellarbill-backend/internal/logger"
 	"stellarbill-backend/internal/repository"
+	"stellarbill-backend/internal/timeutil"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -49,6 +50,7 @@ type StatementArchiveJob struct {
 	objStore cache.ObjectStore
 	config   StatementArchiveConfig
 	logger   logger.Logger
+	clock    timeutil.Clock
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -73,7 +75,15 @@ func NewStatementArchiveJob(db *sql.DB, objStore cache.ObjectStore, config State
 		objStore: objStore,
 		config:   config,
 		logger:   l,
+		clock:    timeutil.SystemClock,
 	}
+}
+
+// SetClock overrides the job's time source, so archival-cutoff behavior can
+// be tested deterministically. Call before Start(); production callers
+// should leave the default SystemClock in place.
+func (j *StatementArchiveJob) SetClock(c timeutil.Clock) {
+	j.clock = c
 }
 
 // Start begins the archival loop. It is safe to call Start only once.
@@ -180,7 +190,7 @@ func (j *StatementArchiveJob) archiveBatch() {
 	batchCtx, cancel := context.WithTimeout(j.ctx, j.config.ArchiveTimeout)
 	defer cancel()
 
-	threshold := time.Now().AddDate(0, -j.config.ArchiveThresholdMonths, 0)
+	threshold := j.clock.Now().AddDate(0, -j.config.ArchiveThresholdMonths, 0)
 	thresholdStr := threshold.Format(time.RFC3339)
 
 	tableName := "statements"
@@ -251,14 +261,14 @@ func (j *StatementArchiveJob) archiveBatch() {
 	}
 
 	j.mu.Lock()
-	j.lastRunTime = time.Now()
+	j.lastRunTime = j.clock.Now()
 	j.mu.Unlock()
 }
 
 // archiveStatement archives a single statement to object storage.
 func (j *StatementArchiveJob) archiveStatement(ctx context.Context, stmt *repository.StatementRow) error {
 	// Serialize to JSON
-	now := time.Now().UTC()
+	now := j.clock.Now()
 	payload := &cache.StatementArchivePayload{
 		ID:             stmt.ID,
 		SubscriptionID: stmt.SubscriptionID,

--- a/internal/worker/store_memory.go
+++ b/internal/worker/store_memory.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"errors"
 	"sort"
+	"stellarbill-backend/internal/timeutil"
 	"sync"
 	"time"
 )
@@ -23,13 +24,22 @@ type MemoryStore struct {
 	mu    sync.RWMutex
 	jobs  map[string]*Job
 	locks map[string]*lockInfo
+	clock timeutil.Clock
 }
 
 // NewMemoryStore creates a new in-memory job store
 func NewMemoryStore() *MemoryStore {
+	return NewMemoryStoreWithClock(timeutil.SystemClock)
+}
+
+// NewMemoryStoreWithClock creates a new in-memory job store backed by the
+// given Clock. Intended for deterministic tests of TTL-based lock expiry and
+// scheduled-job visibility; production callers should use NewMemoryStore.
+func NewMemoryStoreWithClock(clock timeutil.Clock) *MemoryStore {
 	return &MemoryStore{
 		jobs:  make(map[string]*Job),
 		locks: make(map[string]*lockInfo),
+		clock: clock,
 	}
 }
 
@@ -41,10 +51,10 @@ func (s *MemoryStore) Create(job *Job) error {
 		return errors.New("job ID is required")
 	}
 	if job.CreatedAt.IsZero() {
-		job.CreatedAt = time.Now()
+		job.CreatedAt = s.clock.Now()
 	}
 	if job.UpdatedAt.IsZero() {
-		job.UpdatedAt = time.Now()
+		job.UpdatedAt = s.clock.Now()
 	}
 
 	// Deep copy to avoid external mutations
@@ -87,7 +97,7 @@ func (s *MemoryStore) Update(job *Job) error {
 		return ErrJobNotFound
 	}
 
-	job.UpdatedAt = time.Now()
+	job.UpdatedAt = s.clock.Now()
 	jobCopy := *job
 	if job.Payload != nil {
 		jobCopy.Payload = make(map[string]interface{})
@@ -104,7 +114,7 @@ func (s *MemoryStore) ListPending(limit int) ([]*Job, error) {
 	defer s.mu.RUnlock()
 
 	var pending []*Job
-	now := time.Now()
+	now := s.clock.Now()
 
 	for _, job := range s.jobs {
 		if job.Status == JobStatusPending && !job.ScheduledAt.After(now) {
@@ -127,7 +137,7 @@ func (s *MemoryStore) ListPendingByPriority(priority Priority, limit int) ([]*Jo
 	defer s.mu.RUnlock()
 
 	var pending []*Job
-	now := time.Now()
+	now := s.clock.Now()
 
 	for _, job := range s.jobs {
 		if job.Priority == priority && job.Status == JobStatusPending && !job.ScheduledAt.After(now) {
@@ -162,7 +172,7 @@ func (s *MemoryStore) LaneDepth(priority Priority) int {
 	defer s.mu.RUnlock()
 
 	count := 0
-	now := time.Now()
+	now := s.clock.Now()
 	for _, job := range s.jobs {
 		if job.Priority == priority && job.Status == JobStatusPending && !job.ScheduledAt.After(now) {
 			count++
@@ -176,7 +186,7 @@ func (s *MemoryStore) QueueDepth() int {
 	defer s.mu.RUnlock()
 
 	count := 0
-	now := time.Now()
+	now := s.clock.Now()
 
 	for _, job := range s.jobs {
 		if job.Status == JobStatusPending && !job.ScheduledAt.After(now) {
@@ -214,7 +224,7 @@ func (s *MemoryStore) AcquireLock(jobID string, workerID string, ttl time.Durati
 
 	// Clean up expired locks
 	if lock, exists := s.locks[jobID]; exists {
-		if time.Now().After(lock.expiresAt) {
+		if s.clock.Now().After(lock.expiresAt) {
 			delete(s.locks, jobID)
 		} else if lock.workerID != workerID {
 			return false, nil
@@ -224,7 +234,7 @@ func (s *MemoryStore) AcquireLock(jobID string, workerID string, ttl time.Durati
 	// Acquire or renew lock
 	s.locks[jobID] = &lockInfo{
 		workerID:  workerID,
-		expiresAt: time.Now().Add(ttl),
+		expiresAt: s.clock.Now().Add(ttl),
 	}
 	return true, nil
 }
@@ -251,7 +261,7 @@ func (s *MemoryStore) OldestPending() *Job {
 	defer s.mu.RUnlock()
 
 	var oldest *Job
-	now := time.Now()
+	now := s.clock.Now()
 
 	for _, job := range s.jobs {
 		if job.Status == JobStatusPending && !job.ScheduledAt.After(now) {


### PR DESCRIPTION
## Summary

Adds `timeutil.Clock` and migrates worker code off direct `time.Now()`
calls so job scheduling, TTL expiry, archival cutoffs, and materialized-view
freshness checks can be tested deterministically. No public API signatures
changed — every migration is additive (new constructor or `SetClock`
method), so existing callers keep the current behavior by default.

## Changes

- `internal/timeutil/clock.go`: new `Clock` interface, `SystemClock`
  (production, backed by `NowUTC()`), and `FakeClock` (test-controllable via
  `Set`/`Advance`; operates on absolute instants so it stays correct across
  DST transitions).
- `internal/worker/scheduler.go`: `Scheduler.SetClock()`; job
  `CreatedAt`/`UpdatedAt`/ID timestamp now derive from the injected clock.
- `internal/worker/store_memory.go`: new `NewMemoryStoreWithClock()`; lock
  TTL expiry and scheduled-job visibility now clock-driven.
- `internal/worker/statement_archive_job.go`: `SetClock()`; archival cutoff
  threshold now clock-driven.
- `internal/worker/fee_revenue_refresh_job.go`: `SetClock()`; refresh
  freshness timestamp now clock-driven.
- `internal/worker/clock_injection_test.go`: deterministic tests for
  scheduler timestamps and lock-TTL expiry (no sleeping).
- `internal/timeutil/clock_test.go`: FakeClock unit tests, including
  explicit DST spring-forward and fall-back boundary cases.
- `docs/clock-injection.md`: usage guide and a table of what's wired where.

## Not touched

`internal/service/quiet_hours.go`'s `IsQuietHours()` is currently an
unimplemented stub (`return false`, no time comparison, no callers), so
there's no existing time-dependent logic to inject a clock into. Documented
this so a future real implementation (against `model.NotificationPreferences`'
`QuietStart`/`QuietEnd`/`Timezone`) builds clock-aware from the start.

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./internal/timeutil/... ./internal/worker/... -race -count=1`
- [x] Reviewed all diffs by hand for correctness (no Go toolchain available
      in the environment these changes were authored in)

Closes #455