### PR TITLE
feat: add RFC 5988 Link header pagination to list endpoints

### DIFF
--- a/docs/link-header-pagination.md
+++ b/docs/link-header-pagination.md
@@ -1,0 +1,54 @@
+# RFC 5988 Link header pagination
+
+Cursor-paginated list endpoints emit a standard `Link` response header
+(RFC 5988 / RFC 8288) alongside the existing JSON cursor fields
+(`next_cursor`, `has_more`), so generic HTTP clients can walk a collection
+without parsing the response body.
+
+```
+Link: <https://api.example.com/api/v1/plans?limit=20>; rel="first",
+      <https://api.example.com/api/v1/plans?limit=20&cursor=xyz>; rel="prev",
+      <https://api.example.com/api/v1/plans?limit=20&cursor=abc>; rel="next"
+```
+
+- `rel="first"` is always present: a stable link back to the first page.
+- `rel="prev"` is present only when the request was not itself for the first
+  page (i.e. it supplied a non-empty `cursor`).
+- `rel="next"` is present only when more results exist.
+- Link targets are absolute and preserve every other query parameter from the
+  request (filters, `limit`, etc.) — only the `cursor` parameter is
+  added/replaced.
+
+## Implementation
+
+- `internal/pagination/link_header.go`: `LinkHeader(baseURL string, params LinkParams) string`
+  is the framework-agnostic helper that builds the header value. It returns
+  `""` (no header) if `baseURL` isn't a valid absolute URL, so a bad base can
+  never produce a malformed or misleading `Link` header.
+- `internal/pagination/cursor.go`: `PaginateSlice` now also returns
+  `Page.PreviousCursor`, computed from the same in-memory slice used for
+  forward pagination — no new backward-pagination mechanism was introduced.
+- `internal/handlers/pagination_links.go`: `requestBaseURL` reconstructs the
+  absolute request URL from the Gin context (nil-safe: handlers are sometimes
+  invoked in tests with `c.Request == nil`, in which case no header is set).
+  `setPaginationLinkHeader` wires a `pagination.Page` into `LinkHeader` and
+  sets the response header.
+
+## Wired endpoints
+
+| Endpoint | Links |
+|---|---|
+| `GET /api/v1/plans`, `GET /api/plans` | first, prev, next |
+| `GET /api/subscriptions` | first, prev, next |
+| `GET /api/v1/statements` | first only (see below) |
+
+## Statements: first-only
+
+`GET /api/v1/statements` does not get `rel="next"`/`rel="prev"` links. Its
+repository layer (`repository.StatementQuery.StartingAfter`/`EndingBefore`)
+defines cursor fields but no repository implementation reads them, and the
+handler doesn't accept them as query parameters — there is no working
+keyset-pagination mechanism to link to today. Emitting `next`/`prev` links
+here would point at a URL that returns the same first page again. Wiring
+real cursor pagination through to the statements repository is a separate,
+larger change.

--- a/internal/handlers/pagination_links.go
+++ b/internal/handlers/pagination_links.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"stellarbill-backend/internal/pagination"
+
+	"github.com/gin-gonic/gin"
+)
+
+// requestBaseURL reconstructs the absolute URL the client used to reach this
+// handler (scheme + host + path + existing query string), so pagination Link
+// headers can round-trip through the same route and filters.
+//
+// Scheme detection: a TLS-terminated connection reports "https" directly.
+// For requests proxied over plain HTTP to this service (e.g. behind a
+// TLS-terminating load balancer) we fall back to X-Forwarded-Proto. That
+// header is only used to choose "http" vs "https" for a Link header value —
+// never to authorize, route, or make trust decisions — so a spoofed value at
+// worst produces a link with the wrong scheme, not a security issue.
+func requestBaseURL(c *gin.Context) string {
+	if c.Request == nil || c.Request.URL == nil {
+		return ""
+	}
+
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	} else if proto := c.GetHeader("X-Forwarded-Proto"); proto == "https" || proto == "http" {
+		scheme = proto
+	}
+
+	// Build from Path/RawQuery explicitly rather than c.Request.URL.String():
+	// an absolute-form request target (e.g. relayed through a proxy, or as
+	// constructed by some test helpers) can leave Scheme/Host set on
+	// c.Request.URL itself, and String() would then render a second
+	// scheme://host prefix ahead of the one we're adding here.
+	path := c.Request.URL.Path
+	if rq := c.Request.URL.RawQuery; rq != "" {
+		path += "?" + rq
+	}
+	return scheme + "://" + c.Request.Host + path
+}
+
+// setPaginationLinkHeader builds and sets the RFC 5988 Link header for a
+// cursor-paginated list endpoint from a pagination.Page. hasPrev must be true
+// whenever the current request supplied a non-empty incoming cursor (i.e.
+// this is not the first page) — see pagination.LinkParams.HasPrev.
+func setPaginationLinkHeader[T any](c *gin.Context, page pagination.Page[T], hasPrev bool) {
+	header := pagination.LinkHeader(requestBaseURL(c), pagination.LinkParams{
+		Next:    page.NextCursor,
+		Prev:    page.PreviousCursor,
+		HasPrev: hasPrev,
+	})
+	if header != "" {
+		c.Header("Link", header)
+	}
+}

--- a/internal/handlers/pagination_links_test.go
+++ b/internal/handlers/pagination_links_test.go
@@ -1,0 +1,171 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newPlans(n int) []Plan {
+	plans := make([]Plan, 0, n)
+	names := []string{"a", "b", "c", "d", "e", "f"}
+	for i := 0; i < n; i++ {
+		plans = append(plans, Plan{ID: "plan_" + names[i], Name: names[i], Amount: "10.00", Currency: "USD", Interval: "month"})
+	}
+	return plans
+}
+
+func TestListPlans_LinkHeader_FirstPage_OmitsPrevIncludesNext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockSvc := new(MockPlanService)
+	h := &Handler{Plans: mockSvc}
+	mockSvc.On("ListPlans", mock.Anything).Return(newPlans(6), nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "https://api.example.com/api/v1/plans?limit=2", nil)
+
+	h.ListPlans(c)
+
+	link := w.Header().Get("Link")
+	assert.NotEmpty(t, link)
+	assert.Contains(t, link, `rel="first"`)
+	assert.Contains(t, link, `rel="next"`)
+	assert.NotContains(t, link, `rel="prev"`)
+}
+
+func TestListPlans_LinkHeader_LastPage_OmitsNextIncludesPrev(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	plans := newPlans(3)
+	mockSvc := new(MockPlanService)
+	h := &Handler{Plans: mockSvc}
+	mockSvc.On("ListPlans", mock.Anything).Return(plans, nil)
+
+	// First, fetch page 1 to obtain a real cursor into page 2 (the last page
+	// given limit=2 and 3 items).
+	w1 := httptest.NewRecorder()
+	c1, _ := gin.CreateTestContext(w1)
+	c1.Request = httptest.NewRequest(http.MethodGet, "https://api.example.com/api/v1/plans?limit=2", nil)
+	h.ListPlans(c1)
+
+	cursor := extractNextCursorFromLink(t, w1.Header().Get("Link"))
+
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Request = httptest.NewRequest(http.MethodGet, "https://api.example.com/api/v1/plans?limit=2&cursor="+cursor, nil)
+	h.ListPlans(c2)
+
+	link := w2.Header().Get("Link")
+	assert.NotEmpty(t, link)
+	assert.Contains(t, link, `rel="first"`)
+	assert.Contains(t, link, `rel="prev"`)
+	assert.NotContains(t, link, `rel="next"`)
+}
+
+func TestListPlans_LinkHeader_EmptyResult_OnlyFirst(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockSvc := new(MockPlanService)
+	h := &Handler{Plans: mockSvc}
+	mockSvc.On("ListPlans", mock.Anything).Return([]Plan{}, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "https://api.example.com/api/v1/plans", nil)
+
+	h.ListPlans(c)
+
+	link := w.Header().Get("Link")
+	assert.Contains(t, link, `rel="first"`)
+	assert.NotContains(t, link, `rel="next"`)
+	assert.NotContains(t, link, `rel="prev"`)
+}
+
+func TestListPlans_LinkHeader_PreservesQueryFilters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockSvc := new(MockPlanService)
+	h := &Handler{Plans: mockSvc}
+	mockSvc.On("ListPlans", mock.Anything).Return(newPlans(4), nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "https://api.example.com/api/v1/plans?limit=2&currency=usd", nil)
+
+	h.ListPlans(c)
+
+	link := w.Header().Get("Link")
+	assert.Contains(t, link, "limit=2")
+	assert.Contains(t, link, "currency=usd")
+}
+
+func TestListPlans_LinkHeader_AbsentWhenNoRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockSvc := new(MockPlanService)
+	h := &Handler{Plans: mockSvc}
+	mockSvc.On("ListPlans", mock.Anything).Return(newPlans(1), nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w) // c.Request is left nil, as some existing tests do
+
+	assert.NotPanics(t, func() { h.ListPlans(c) })
+	assert.Empty(t, w.Header().Get("Link"))
+}
+
+func TestListSubscriptions_LinkHeader_FirstPage_OmitsPrev(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	subs := []Subscription{
+		{ID: "sub_1", Customer: "a"}, {ID: "sub_2", Customer: "b"}, {ID: "sub_3", Customer: "c"},
+	}
+	mockSvc := new(MockSubscriptionService)
+	h := &Handler{Subscriptions: mockSvc}
+	mockSvc.On("ListSubscriptions", mock.Anything).Return(subs, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "https://api.example.com/api/v1/subscriptions?limit=2", nil)
+
+	h.ListSubscriptions(c)
+
+	link := w.Header().Get("Link")
+	assert.Contains(t, link, `rel="first"`)
+	assert.Contains(t, link, `rel="next"`)
+	assert.NotContains(t, link, `rel="prev"`)
+}
+
+// extractNextCursorFromLink pulls the cursor query parameter out of the
+// rel="next" link target, so a test can follow it to the next page.
+func extractNextCursorFromLink(t *testing.T, link string) string {
+	t.Helper()
+	for _, part := range strings.Split(link, ", ") {
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end < 0 {
+			t.Fatalf("malformed link part: %q", part)
+		}
+		target := part[start+1 : end]
+		idx := strings.Index(target, "cursor=")
+		if idx < 0 {
+			t.Fatalf("no cursor param in next link: %q", target)
+		}
+		cursorAndRest := target[idx+len("cursor="):]
+		if amp := strings.Index(cursorAndRest, "&"); amp >= 0 {
+			return cursorAndRest[:amp]
+		}
+		return cursorAndRest
+	}
+	t.Fatalf("no rel=next link found in %q", link)
+	return ""
+}

--- a/internal/handlers/plans.go
+++ b/internal/handlers/plans.go
@@ -44,6 +44,7 @@ func (h *Handler) ListPlans(c *gin.Context) {
 
 	// Paginate the slice. In a real DB repo, this would be in the query.
 	page := pagination.PaginateSlice(allPlans, cursor, limit)
+	setPaginationLinkHeader(c, page, cursorStr != "")
 
 	c.JSON(http.StatusOK, gin.H{
 		"plans":       page.Items,

--- a/internal/handlers/statements.go
+++ b/internal/handlers/statements.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"stellarbill-backend/internal/pagination"
 	"stellarbill-backend/internal/repository"
 	"stellarbill-backend/internal/service"
 	"strconv"
@@ -93,6 +94,16 @@ func NewListStatementsHandler(svc service.StatementService) gin.HandlerFunc {
 		}
 		if statements == nil {
 			statements = []*service.StatementDetail{}
+		}
+
+		// NOTE: repository.StatementQuery.StartingAfter/EndingBefore are not
+		// yet wired through to a repository implementation (no server-side
+		// keyset pagination exists for statements today), so only rel="first"
+		// can be emitted correctly here. Emitting rel="next"/"prev" would
+		// require query parameters this endpoint does not yet accept, and
+		// would produce a link that doesn't actually advance the collection.
+		if header := pagination.LinkHeader(requestBaseURL(c), pagination.LinkParams{}); header != "" {
+			c.Header("Link", header)
 		}
 
 		c.JSON(http.StatusOK, gin.H{

--- a/internal/handlers/statements_link_header_test.go
+++ b/internal/handlers/statements_link_header_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"stellarbill-backend/internal/service"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// authedStatementsRouter builds a minimal router that sets the context keys
+// getAuthContext actually reads ("caller_id" as a string, "roles" as
+// []string), independent of the stmtRouter helper elsewhere in this package.
+func authedStatementsRouter(svc service.StatementService, callerID string, roles []string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("caller_id", callerID)
+		c.Set("roles", roles)
+		c.Next()
+	})
+	r.GET("/api/statements", NewListStatementsHandler(svc))
+	return r
+}
+
+func TestListStatements_LinkHeader_FirstOnly_NoNextOrPrev(t *testing.T) {
+	svc := &mockStatementsTestService{
+		listDetail: &service.ListStatementsDetail{Statements: []*service.StatementDetail{}},
+		count:      0,
+	}
+	r := authedStatementsRouter(svc, "cust-1", []string{"customer"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "https://api.example.com/api/statements?customer_id=cust-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	link := w.Header().Get("Link")
+	if !strings.Contains(link, `rel="first"`) {
+		t.Errorf("expected rel=first link, got %q", link)
+	}
+	// Statements has no working keyset-pagination mechanism yet (see
+	// docs/link-header-pagination.md), so next/prev must never be emitted.
+	if strings.Contains(link, `rel="next"`) || strings.Contains(link, `rel="prev"`) {
+		t.Errorf("expected no next/prev link for statements, got %q", link)
+	}
+}
+
+func TestListStatements_LinkHeader_PreservesFilters(t *testing.T) {
+	svc := &mockStatementsTestService{
+		listDetail: &service.ListStatementsDetail{Statements: []*service.StatementDetail{}},
+		count:      0,
+	}
+	r := authedStatementsRouter(svc, "cust-1", []string{"customer"})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "https://api.example.com/api/statements?customer_id=cust-1&status=paid", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	link := w.Header().Get("Link")
+	if !strings.Contains(link, "customer_id=cust-1") || !strings.Contains(link, "status=paid") {
+		t.Errorf("expected first link to preserve filters, got %q", link)
+	}
+}

--- a/internal/handlers/subscriptions.go
+++ b/internal/handlers/subscriptions.go
@@ -50,6 +50,7 @@ func (h *Handler) ListSubscriptions(c *gin.Context) {
 	}
 
 	page := pagination.PaginateSlice(allSubs, cursor, limit)
+	setPaginationLinkHeader(c, page, cursorStr != "")
 
 	c.JSON(http.StatusOK, gin.H{
 		"subscriptions": page.Items,

--- a/internal/pagination/cursor.go
+++ b/internal/pagination/cursor.go
@@ -52,9 +52,18 @@ type Item interface {
 
 // Page represents a standardized paginated response envelope.
 type Page[T any] struct {
-	Items      []T    `json:"items"`
+	Items []T `json:"items"`
+	// NextCursor points at the item following this page; empty when this is
+	// the last page.
 	NextCursor string `json:"next_cursor,omitempty"`
-	HasMore    bool   `json:"has_more"`
+	// PreviousCursor reconstructs the page before this one. It is empty both
+	// when there is no previous page AND when the previous page is the first
+	// page (which has no cursor) — callers that need to distinguish "no
+	// previous page" from "previous page is the first page" should track
+	// whether the incoming request cursor was itself empty (see
+	// pagination.LinkParams.HasPrev).
+	PreviousCursor string `json:"previous_cursor,omitempty"`
+	HasMore        bool   `json:"has_more"`
 }
 
 // PaginateSlice simulates cursor-based pagination over an in-memory slice.
@@ -104,9 +113,31 @@ func PaginateSlice[T Item](items []T, cursor Cursor, limit int) Page[T] {
 		})
 	}
 
+	prevCursorStr := previousCursor(items, startIdx, limit)
+
 	return Page[T]{
-		Items:      pageItems,
-		NextCursor: nextCursorStr,
-		HasMore:    hasMore,
+		Items:          pageItems,
+		NextCursor:     nextCursorStr,
+		PreviousCursor: prevCursorStr,
+		HasMore:        hasMore,
 	}
+}
+
+// previousCursor computes the cursor that, when passed back into
+// PaginateSlice, reproduces the page immediately before the one starting at
+// startIdx. Returns "" both when startIdx is 0 (no previous page) and when
+// the previous page is the first page (which has no cursor of its own) —
+// both cases mean "there is nothing to add a cursor parameter for".
+func previousCursor[T Item](items []T, startIdx, limit int) string {
+	if startIdx <= 0 {
+		return ""
+	}
+
+	prevStart := startIdx - limit
+	if prevStart <= 0 {
+		return ""
+	}
+
+	anchor := items[prevStart-1]
+	return Encode(Cursor{ID: anchor.GetID(), SortValue: anchor.GetSortValue()})
 }

--- a/internal/pagination/link_header.go
+++ b/internal/pagination/link_header.go
@@ -1,0 +1,85 @@
+package pagination
+
+import (
+	"net/url"
+	"strings"
+)
+
+// CursorParam is the query parameter name used to carry the opaque cursor.
+const CursorParam = "cursor"
+
+// LinkParams describes the cursor state needed to build an RFC 5988 (RFC
+// 8288) Link header for a cursor-paginated list endpoint.
+type LinkParams struct {
+	// Next is the opaque cursor for the next page (Page.NextCursor). Empty
+	// means there is no next page, and rel="next" is omitted.
+	Next string
+	// Prev is the opaque cursor that reconstructs the previous page
+	// (Page.PreviousCursor). An empty Prev still produces a valid rel="prev"
+	// link (pointing at the first page, i.e. with no cursor parameter) as
+	// long as HasPrev is true.
+	Prev string
+	// HasPrev must be true only when the current request is not for the
+	// first page (i.e. the incoming request supplied a non-empty cursor).
+	// This is what distinguishes "no previous page" from "the previous page
+	// has no cursor of its own".
+	HasPrev bool
+}
+
+// LinkHeader builds an RFC 5988 Link header value for a cursor-paginated list
+// endpoint:
+//
+//   - rel="first" is always included (a stable link back to the unfiltered
+//     first page's cursor position).
+//   - rel="prev" is included only when params.HasPrev is true.
+//   - rel="next" is included only when params.Next is non-empty.
+//
+// baseURL must be an absolute URL (scheme + host, e.g. as reconstructed from
+// the incoming request) and should already include any filter/limit query
+// parameters that must be preserved across pages; LinkHeader only adds or
+// replaces the cursor parameter, it never invents or drops other query
+// parameters. Returns "" if baseURL is not a valid absolute URL, so a
+// malformed base can never produce a malformed or misleading Link header.
+func LinkHeader(baseURL string, params LinkParams) string {
+	u, err := url.Parse(baseURL)
+	if err != nil || !u.IsAbs() {
+		return ""
+	}
+
+	var b strings.Builder
+	writeLink := func(cursor, rel string) {
+		if b.Len() > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("<")
+		b.WriteString(withCursor(u, cursor))
+		b.WriteString(`>; rel="`)
+		b.WriteString(rel)
+		b.WriteString(`"`)
+	}
+
+	writeLink("", "first")
+	if params.HasPrev {
+		writeLink(params.Prev, "prev")
+	}
+	if params.Next != "" {
+		writeLink(params.Next, "next")
+	}
+
+	return b.String()
+}
+
+// withCursor returns an absolute URL string equal to u with the cursor query
+// parameter set to cursor (or removed, if cursor is empty). u itself is not
+// mutated.
+func withCursor(u *url.URL, cursor string) string {
+	v := *u
+	q := u.Query()
+	if cursor == "" {
+		q.Del(CursorParam)
+	} else {
+		q.Set(CursorParam, cursor)
+	}
+	v.RawQuery = q.Encode()
+	return v.String()
+}

--- a/internal/pagination/link_header_test.go
+++ b/internal/pagination/link_header_test.go
@@ -1,0 +1,200 @@
+package pagination
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// PreviousCursor (PaginateSlice)
+// ---------------------------------------------------------------------------
+
+func TestPaginateSlice_PreviousCursor_FirstPageHasNone(t *testing.T) {
+	items := []dummyItem{{"a", "10"}, {"b", "10"}, {"c", "20"}}
+	page := PaginateSlice(items, Cursor{}, 2)
+	if page.PreviousCursor != "" {
+		t.Errorf("expected empty PreviousCursor on first page, got %q", page.PreviousCursor)
+	}
+}
+
+func TestPaginateSlice_PreviousCursor_SecondPagePointsToFirst(t *testing.T) {
+	items := []dummyItem{
+		{"a", "10"}, {"b", "10"}, {"c", "20"}, {"d", "30"},
+	}
+	page1 := PaginateSlice(items, Cursor{}, 2)
+	next1, _ := Decode(page1.NextCursor)
+
+	page2 := PaginateSlice(items, next1, 2)
+	if page2.PreviousCursor != "" {
+		t.Errorf("expected empty PreviousCursor pointing back at the first page, got %q", page2.PreviousCursor)
+	}
+}
+
+func TestPaginateSlice_PreviousCursor_RoundTripsToPriorPage(t *testing.T) {
+	// Same fixture as TestPaginateSlice_ContinuityAndDuplicates.
+	items := []dummyItem{
+		{"a", "10"},
+		{"b", "10"},
+		{"c", "20"},
+		{"d", "30"},
+		{"e", "30"},
+		{"f", "40"},
+		{"g", "50"},
+	}
+	const limit = 2
+
+	page1 := PaginateSlice(items, Cursor{}, limit)
+	next1, _ := Decode(page1.NextCursor)
+
+	page2 := PaginateSlice(items, next1, limit)
+	next2, _ := Decode(page2.NextCursor)
+
+	page3 := PaginateSlice(items, next2, limit)
+	if page3.PreviousCursor == "" {
+		t.Fatal("expected non-empty PreviousCursor on the third page")
+	}
+
+	// Following page3's PreviousCursor must reproduce page2 exactly.
+	prevCursor, err := Decode(page3.PreviousCursor)
+	if err != nil {
+		t.Fatalf("Decode(PreviousCursor): %v", err)
+	}
+	reconstructed := PaginateSlice(items, prevCursor, limit)
+	if len(reconstructed.Items) != len(page2.Items) {
+		t.Fatalf("reconstructed page has %d items, want %d", len(reconstructed.Items), len(page2.Items))
+	}
+	for i := range page2.Items {
+		if reconstructed.Items[i].id != page2.Items[i].id {
+			t.Errorf("item %d: got %s, want %s", i, reconstructed.Items[i].id, page2.Items[i].id)
+		}
+	}
+}
+
+func TestPaginateSlice_PreviousCursor_EmptyResult(t *testing.T) {
+	page := PaginateSlice([]dummyItem{}, Cursor{}, 10)
+	if page.PreviousCursor != "" {
+		t.Errorf("expected empty PreviousCursor for empty result, got %q", page.PreviousCursor)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LinkHeader
+// ---------------------------------------------------------------------------
+
+func TestLinkHeader_FirstPage_OmitsPrev(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/plans?limit=10", LinkParams{
+		Next:    "next-cursor",
+		HasPrev: false,
+	})
+
+	if strings.Contains(header, `rel="prev"`) {
+		t.Errorf("expected no prev link on first page, got %q", header)
+	}
+	if !strings.Contains(header, `rel="first"`) {
+		t.Errorf("expected first link, got %q", header)
+	}
+	if !strings.Contains(header, `rel="next"`) {
+		t.Errorf("expected next link, got %q", header)
+	}
+}
+
+func TestLinkHeader_LastPage_OmitsNext(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/plans?limit=10", LinkParams{
+		Next:    "",
+		Prev:    "prev-cursor",
+		HasPrev: true,
+	})
+
+	if strings.Contains(header, `rel="next"`) {
+		t.Errorf("expected no next link on last/empty page, got %q", header)
+	}
+	if !strings.Contains(header, `rel="prev"`) {
+		t.Errorf("expected prev link, got %q", header)
+	}
+	if !strings.Contains(header, `rel="first"`) {
+		t.Errorf("expected first link, got %q", header)
+	}
+}
+
+func TestLinkHeader_EmptyPage_OnlyFirst(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/plans?limit=10", LinkParams{})
+
+	if strings.Contains(header, `rel="next"`) || strings.Contains(header, `rel="prev"`) {
+		t.Errorf("expected only a first link for an empty first page, got %q", header)
+	}
+	if !strings.Contains(header, `rel="first"`) {
+		t.Errorf("expected first link, got %q", header)
+	}
+}
+
+func TestLinkHeader_PreservesExistingQueryParams(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/subscriptions?limit=25&status=active", LinkParams{
+		Next: "abc123",
+	})
+
+	for _, want := range []string{"limit=25", "status=active", "cursor=abc123"} {
+		if !strings.Contains(header, want) {
+			t.Errorf("expected header to contain %q, got %q", want, header)
+		}
+	}
+}
+
+func TestLinkHeader_ReplacesExistingCursorParam(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/plans?cursor=stale&limit=10", LinkParams{
+		Next:    "fresh-next",
+		Prev:    "fresh-prev",
+		HasPrev: true,
+	})
+
+	if strings.Contains(header, "stale") {
+		t.Errorf("expected stale cursor to be replaced, got %q", header)
+	}
+	if !strings.Contains(header, "cursor=fresh-next") {
+		t.Errorf("expected next link to carry fresh-next cursor, got %q", header)
+	}
+}
+
+func TestLinkHeader_FirstLinkHasNoCursorParam(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/plans?cursor=xyz&limit=10", LinkParams{
+		HasPrev: true,
+		Prev:    "prev-cursor",
+	})
+
+	// Extract the <...> target for rel="first".
+	start := strings.Index(header, "<")
+	end := strings.Index(header, ">")
+	if start < 0 || end < 0 {
+		t.Fatalf("could not find first link target in %q", header)
+	}
+	firstTarget := header[start+1 : end]
+	if strings.Contains(firstTarget, "cursor=") {
+		t.Errorf("expected rel=first target to have no cursor param, got %q", firstTarget)
+	}
+}
+
+func TestLinkHeader_RejectsRelativeBaseURL(t *testing.T) {
+	header := LinkHeader("/api/v1/plans?limit=10", LinkParams{Next: "abc"})
+	if header != "" {
+		t.Errorf("expected empty header for relative baseURL, got %q", header)
+	}
+}
+
+func TestLinkHeader_RejectsInvalidBaseURL(t *testing.T) {
+	header := LinkHeader("://not a url", LinkParams{Next: "abc"})
+	if header != "" {
+		t.Errorf("expected empty header for invalid baseURL, got %q", header)
+	}
+}
+
+func TestLinkHeader_MultipleLinksAreCommaSeparated(t *testing.T) {
+	header := LinkHeader("https://api.example.com/api/v1/plans?limit=10", LinkParams{
+		Next:    "next-cursor",
+		Prev:    "prev-cursor",
+		HasPrev: true,
+	})
+
+	parts := strings.Split(header, ", ")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 comma-separated links (first, prev, next), got %d: %q", len(parts), header)
+	}
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -53,6 +53,9 @@ paths:
       responses:
         "200":
           description: Plans list
+          headers:
+            Link:
+              $ref: "#/components/headers/Link"
           content:
             application/json:
               schema:
@@ -83,6 +86,9 @@ paths:
       responses:
         "200":
           description: Subscriptions list
+          headers:
+            Link:
+              $ref: "#/components/headers/Link"
           content:
             application/json:
               schema:
@@ -161,6 +167,17 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 components:
+  headers:
+    Link:
+      description: |
+        RFC 5988 (RFC 8288) Link header for cursor pagination. Always
+        includes rel="first"; includes rel="prev" when the request was not
+        for the first page, and rel="next" when more results are available.
+        Provided alongside the `pagination` object in the response body so
+        generic HTTP clients can walk the collection without parsing JSON.
+      schema:
+        type: string
+      example: '<https://api.example.com/api/v1/plans?limit=20>; rel="first", <https://api.example.com/api/v1/plans?limit=20&cursor=abc>; rel="next"'
   parameters:
     Cursor:
       name: cursor


### PR DESCRIPTION
## Summary

Adds a reusable pagination.LinkHeader helper and wires it into the
cursor-paginated list endpoints so generic HTTP clients can walk a
collection via the Link header (RFC 5988 / RFC 8288) without parsing the
JSON body. The existing next_cursor/has_more JSON fields are unchanged.

## Changes

- `internal/pagination/link_header.go`: `LinkHeader(baseURL string, params
  LinkParams) string`. Emits rel="first" always, rel="prev" only when the
  request wasn't for the first page, rel="next" only when more results
  exist. Returns "" for a non-absolute/invalid baseURL rather than emitting
  a malformed header. Preserves every other query parameter on the base URL
  and only adds/replaces `cursor`.
- `internal/pagination/cursor.go`: `Page[T]` gains `PreviousCursor`,
  computed by `PaginateSlice` from the same in-memory slice used for
  forward pagination (no new backward-pagination mechanism needed — it's
  derived, not invented).
- `internal/handlers/pagination_links.go`: `requestBaseURL` reconstructs the
  absolute request URL from the Gin context. Nil-safe (some existing tests
  invoke handlers with `c.Request == nil`) and deliberately builds from
  `URL.Path`/`RawQuery` rather than `URL.String()`, since an absolute-form
  request target can leave Scheme/Host set on `c.Request.URL` and double up
  the prefix. `setPaginationLinkHeader` wires a `pagination.Page` into
  `LinkHeader` and sets the response header.
- `internal/handlers/plans.go`, `internal/handlers/subscriptions.go`: wired
  in — full first/prev/next support.
- `internal/handlers/statements.go`: rel="first" only. Its
  `StartingAfter`/`EndingBefore` cursor fields exist on
  `repository.StatementQuery` but no repository implementation reads them
  and the handler doesn't accept them as query params, so there is no
  working keyset pagination to link to yet. Emitting next/prev here would
  point at a URL that returns the same page again — documented in
  `docs/link-header-pagination.md` rather than faked.
- `openapi/openapi.yaml`: added a reusable `components.headers.Link` and
  referenced it on the two documented paginated responses (`/api/v1/plans`,
  `/api/subscriptions`).
- Tests: `internal/pagination/link_header_test.go` (first/next/prev
  presence rules, query-param preservation, cursor replacement, relative/
  invalid baseURL rejection), `internal/pagination/cursor.go`'s
  `PreviousCursor` (first-page-has-none, round-trips to the exact prior
  page), and handler-level tests in
  `internal/handlers/pagination_links_test.go` and
  `internal/handlers/statements_link_header_test.go`.

## Note: pre-existing issue found, not touched

While testing statements, found that `internal/handlers/statements_test.go`'s
`stmtRouter` helper sets context key `"callerID"` and never sets `"roles"`,
but `getAuthContext` (in `statements.go`) reads `"caller_id"` and `"roles"`.
That mismatch means every `TestListStatements_*` test using `stmtRouter`
gets a 401 instead of the status code it asserts — pre-existing, unrelated
to this change. Left alone since it's out of scope here; my new statements
tests use a correctly-keyed router instead of `stmtRouter`.

## Test plan

- [ ] `go test ./internal/pagination/... ./internal/handlers/... -race -count=1`
- [x] Reviewed all diffs by hand for correctness (no Go toolchain available
      in the environment these changes were authored in)
- [x] Verified edge cases by hand: empty page omits next, first page omits
      prev, filters/limit preserved, stale cursor query param replaced

Closes #403