### PR TITLE
Feat/continuous profiling

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"stellarbill-backend/internal/auth"
 	"stellarbill-backend/internal/config"
 	"stellarbill-backend/internal/routes"
+	"stellarbill-backend/internal/worker"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	_ "github.com/lib/pq"
 )
 
 var listenAndServe = func(srv *http.Server) error {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,9 +17,16 @@ import (
 	_ "github.com/lib/pq"
 )
 
-var listenAndServe = func(srv *http.Server) error {
-	return srv.ListenAndServe()
-}
+var (
+	listenAndServe = func(srv *http.Server) error {
+		return srv.ListenAndServe()
+	}
+
+	// openDB is a variable so tests can inject a mock.
+	openDB = func(driver, connStr string) (*sql.DB, error) {
+		return sql.Open(driver, connStr)
+	}
+)
 
 func main() {
 	cfg, err := config.Load()
@@ -30,6 +37,21 @@ func main() {
 
 	if cfg.Env == "production" {
 		gin.SetMode(gin.ReleaseMode)
+	}
+
+	// Database connection — required for KPI metrics and other background jobs.
+	var db *sql.DB
+	if cfg.DBConn != "" {
+		db, err = openDB("postgres", cfg.DBConn)
+		if err != nil {
+			log.Fatalf("failed to open database: %v", err)
+		}
+		defer db.Close()
+		db.SetMaxOpenConns(cfg.DBPoolMaxConns)
+		db.SetMaxIdleConns(cfg.DBPoolMinConns)
+		db.SetConnMaxLifetime(time.Duration(cfg.DBPoolMaxConnLifetime) * time.Second)
+		db.SetConnMaxIdleTime(time.Duration(cfg.DBPoolMaxConnIdleTime) * time.Second)
+		log.Println("database connection established")
 	}
 
 	// Initialize SPIFFE Verifier for cross-service mesh auth
@@ -43,10 +65,27 @@ func main() {
 		}
 	}
 
+	// Start KPI metrics refresh worker when a database is available.
+	var kpiJob *worker.KpiRefreshJob
+	if db != nil {
+		kpiJob = worker.NewKpiRefreshJob(db, worker.DefaultKpiRefreshConfig(), stdLogger{})
+		kpiJob.Start()
+		log.Println("KPI metrics refresh worker started (hourly)")
+	}
+
 	router := gin.New()
 	router.Use(gin.Recovery())
 
 	routes.Register(router)
+
+	// Stop the KPI worker on server shutdown.
+	if kpiJob != nil {
+		defer func() {
+			if err := kpiJob.Stop(); err != nil {
+				log.Printf("KPI refresh worker stop: %v", err)
+			}
+		}()
+	}
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	srv := &http.Server{
@@ -65,4 +104,11 @@ func main() {
 
 func printConfigError(err error) {
 	fmt.Fprintf(os.Stderr, "%v\n", err)
+}
+
+// stdLogger adapts the standard log package to the worker's logger interface.
+type stdLogger struct{}
+
+func (stdLogger) Error(msg string, keysAndValues ...any) {
+	log.Println(append([]any{"ERROR: " + msg}, keysAndValues...)...)
 }

--- a/docs/ops/kpi-dashboards.md
+++ b/docs/ops/kpi-dashboards.md
@@ -1,0 +1,119 @@
+# Business KPI Dashboards
+
+The `/metrics` endpoint exposes three business-health gauges alongside the
+existing system metrics (`http_request_duration_seconds`, `db_pool_stats`, etc.)
+so operators can graph business KPIs on the same dashboard as infrastructure
+metrics.
+
+## Available Metrics
+
+| Metric | Type | Labels | Description |
+| --- | --- | --- | --- |
+| `mrr_cents_total` | Gauge | — | Monthly Recurring Revenue in cents across all active subscriptions. Divide by 100 to get dollars. |
+| `active_subscribers_total` | GaugeVec | `plan_id`, `plan_name` | Number of active subscriptions, broken down by plan. |
+| `churn_rate_24h` | Gauge | — | Fraction of subscriptions cancelled in the last 24 hours relative to the active + recently-cancelled base. Range: `0.0` – `1.0`. Multiply by 100 for percentage. |
+
+## Refresh Cadence
+
+All three metrics are computed on a **fixed 1-hour schedule** by
+`internal/worker.KpiRefreshJob` to avoid expensive aggregation queries at
+scrape time. On server startup the job runs immediately so the dashboard shows
+data within seconds; subsequent refreshes fire every hour.
+
+## Example PromQL Queries
+
+### Monthly Recurring Revenue (USD)
+
+```promql
+mrr_cents_total / 100
+```
+
+### Active Subscribers by Plan (stacked area)
+
+```promql
+sum by (plan_id, plan_name) (active_subscribers_total)
+```
+
+### Churn Rate Percentage
+
+```promql
+churn_rate_24h * 100
+```
+
+### Churn Rate Alert (warning at 5 %, critical at 10 %)
+
+```promql
+churn_rate_24h * 100 > 5
+```
+
+### New Subscribers This Hour (delta)
+
+```promql
+delta(mrr_cents_total[1h]) / 100
+```
+
+## Security
+
+The `/metrics` endpoint does not require authentication because:
+
+1. **Network-level access control** is expected — Kubernetes `NetworkPolicy`,
+   a sidecar auth-proxy, or cloud load-balancer ACLs restrict who can reach
+   `/metrics`.
+2. **No PII** is exposed. MRR, subscriber counts, and churn rate are
+   aggregates; no individual customer or subscription identifiers appear in
+   the metric labels.
+
+If your deployment requires HTTP-level auth for `/metrics`, add a
+metrics-specific middleware in `routes.Register`:
+
+```go
+r.GET("/metrics", metricsAuthMiddleware, gin.WrapH(promhttp.Handler()))
+```
+
+## Configuration
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `PollInterval` | `1h` | How often KPI metrics are recomputed. |
+| `QueryTimeout` | `30s` | Context timeout for the three aggregation queries. |
+| `ShutdownTimeout` | `30s` | Max time to wait for in-flight computation on graceful shutdown. |
+
+## Visibility
+
+The job exposes its own health and statistics via `Health()` and `GetStats()`.
+Refer to the [elevated-errors runbook](./elevated-errors-runbook.md) for
+alerting on worker failures: consistently failing KPI refreshes (5+
+consecutive errors) will cause `Health()` to return an error and should
+trigger a PagerDuty alert.
+
+## Suggested Grafana Panels
+
+### Panel 1: MRR (USD)
+
+- Query: `mrr_cents_total / 100`
+- Type: Stat (current value) + Time series
+- Unit: USD
+- Threshold: $0 (red if zero)
+
+### Panel 2: Active Subscribers
+
+- Query: `sum by (plan_name) (active_subscribers_total)`
+- Type: Stacked bar or stacked area
+- Legend: `{{plan_name}}`
+
+### Panel 3: Churn Rate
+
+- Query: `churn_rate_24h * 100`
+- Type: Stat (current %) + Time series
+- Unit: Percent (0-100)
+- Alert: Warning at 5 %, Critical at 10 %
+
+## Maintainability
+
+- **Gauges are defined in `internal/metrics/metrics.go`** via `promauto` so
+  they auto-register with the default Prometheus registry.
+- **The store interface** (`kpiStore` in `internal/worker/kpi_refresh_job.go`)
+  makes the SQL layer testable with `go-sqlmock` without a real database.
+- **The job lifecycle** (Start/Stop/Health/GetStats) follows the same pattern
+  as `FeeRevenueRefreshJob` and `StatementArchiveJob`, keeping the codebase
+  consistent.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -58,6 +58,33 @@ var (
 		},
 		[]string{"stat"},
 	)
+
+	// MrrCents reports the total Monthly Recurring Revenue in cents across all
+	// active subscriptions. Updated hourly by the KPI refresh worker.
+	MrrCents = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "mrr_cents_total",
+		Help: "Monthly Recurring Revenue in cents across all active subscriptions",
+	})
+
+	// ActiveSubscribersTotal reports the number of active subscriptions broken
+	// down by plan. The plan_id and plan_name labels are set from the
+	// subscription's current plan. Updated hourly by the KPI refresh worker.
+	ActiveSubscribersTotal = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "active_subscribers_total",
+			Help: "Number of active subscriptions by plan",
+		},
+		[]string{"plan_id", "plan_name"},
+	)
+
+	// ChurnRate24h reports the proportion of subscriptions that were cancelled
+	// in the last 24 hours relative to the active + recently-cancelled base.
+	// A value of 0.05 means 5 % of subscribers churned in the rolling window.
+	// Updated hourly by the KPI refresh worker.
+	ChurnRate24h = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "churn_rate_24h",
+		Help: "Churn rate over the last 24 hours (0.0 to 1.0)",
+	})
 )
 
 func MetricsMiddleware() gin.HandlerFunc {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -18,6 +18,7 @@ import (
 	"stellarbill-backend/internal/tracing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
@@ -89,6 +90,10 @@ func Register(r *gin.Engine) {
 	v1.GET("/health", h.LivenessProbe)
 	api.GET("/liveness", h.LivenessProbe)
 	api.GET("/readiness", h.ReadinessProbe)
+
+	// Prometheus metrics — no auth required; network-level access control is
+	// expected (e.g. Kubernetes NetworkPolicy or reverse-auth proxy).
+	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
 	// V1 routes are all protected
 	v1.Use(authMiddleware)

--- a/internal/worker/kpi_refresh_job.go
+++ b/internal/worker/kpi_refresh_job.go
@@ -1,0 +1,340 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"stellarbill-backend/internal/metrics"
+)
+
+// kpiLogger is the minimal logging surface the KPI refresh job needs.
+type kpiLogger interface {
+	Error(msg string, keysAndValues ...any)
+}
+
+// KpiRefreshConfig configures the business-KPI metrics refresh job.
+type KpiRefreshConfig struct {
+	// PollInterval: how often KPI metrics are recomputed (default: 1h).
+	PollInterval time.Duration
+	// QueryTimeout: context timeout for a single metrics computation (default: 30s).
+	QueryTimeout time.Duration
+	// ShutdownTimeout: max time to wait for in-flight work on Stop() (default: 30s).
+	ShutdownTimeout time.Duration
+}
+
+// DefaultKpiRefreshConfig returns production-safe defaults: an hourly
+// refresh as required for business KPI monitoring.
+func DefaultKpiRefreshConfig() KpiRefreshConfig {
+	return KpiRefreshConfig{
+		PollInterval:    1 * time.Hour,
+		QueryTimeout:    30 * time.Second,
+		ShutdownTimeout: 30 * time.Second,
+	}
+}
+
+// withDefaults fills any zero-valued fields with their defaults.
+func (c KpiRefreshConfig) withDefaults() KpiRefreshConfig {
+	d := DefaultKpiRefreshConfig()
+	if c.PollInterval <= 0 {
+		c.PollInterval = d.PollInterval
+	}
+	if c.QueryTimeout <= 0 {
+		c.QueryTimeout = d.QueryTimeout
+	}
+	if c.ShutdownTimeout <= 0 {
+		c.ShutdownTimeout = d.ShutdownTimeout
+	}
+	return c
+}
+
+// kpiStore abstracts the database operations the KPI refresh job needs.
+type kpiStore interface {
+	// ComputeMRRInCents returns the total monthly recurring revenue of all
+	// active subscriptions, expressed in cents. Returns 0 when there are no
+	// active subscriptions.
+	ComputeMRRInCents(ctx context.Context) (int64, error)
+	// CountActiveSubscribersPerPlan returns the number of active subscriptions
+	// grouped by plan_id and plan_name. Returns an empty map when there are no
+	// active subscriptions.
+	CountActiveSubscribersPerPlan(ctx context.Context) (map[KpiPlanKey]int64, error)
+	// ComputeChurnRate24h returns the churn rate over the last 24 hours:
+	// subscriptions cancelled in the window divided by the base of active +
+	// recently-cancelled subscriptions. Returns 0.0 when the base is empty.
+	ComputeChurnRate24h(ctx context.Context) (float64, error)
+}
+
+// KpiPlanKey identifies a plan in the active-subscribers breakdown.
+type KpiPlanKey struct {
+	ID   string
+	Name string
+}
+
+// KpiRefreshJob periodically computes business KPI metrics (MRR, active
+// subscribers, churn) and pushes them to Prometheus gauges so operators can
+// graph business health on the same dashboard as system health.
+//
+// Computations run on a scheduled worker to avoid heavy aggregation queries
+// at scrape time.
+type KpiRefreshJob struct {
+	store  kpiStore
+	config KpiRefreshConfig
+	logger kpiLogger
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	running atomic.Int32
+
+	// stats
+	mu              sync.RWMutex
+	refreshCount    int64
+	failedCount     int64
+	lastRunTime     time.Time
+	lastRunError    error
+	consecutiveErrs int
+}
+
+// NewKpiRefreshJob constructs a KPI refresh job backed by the given database.
+func NewKpiRefreshJob(db *sql.DB, config KpiRefreshConfig, l kpiLogger) *KpiRefreshJob {
+	return newKpiRefreshJob(&sqlKpiStore{db: db}, config, l)
+}
+
+// newKpiRefreshJob is the store-injecting constructor used by tests.
+func newKpiRefreshJob(store kpiStore, config KpiRefreshConfig, l kpiLogger) *KpiRefreshJob {
+	return &KpiRefreshJob{
+		store:  store,
+		config: config.withDefaults(),
+		logger: l,
+	}
+}
+
+// Start begins the refresh loop. It is safe to call Start only once.
+func (j *KpiRefreshJob) Start() {
+	j.ctx, j.cancel = context.WithCancel(context.Background())
+	j.running.Store(1)
+
+	j.wg.Add(1)
+	go j.refreshLoop()
+}
+
+// Stop signals the refresh loop to exit and waits up to ShutdownTimeout for
+// in-flight work to drain.
+func (j *KpiRefreshJob) Stop() error {
+	if j.cancel == nil {
+		return nil
+	}
+	j.cancel()
+
+	done := make(chan struct{})
+	go func() {
+		j.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		j.running.Store(0)
+		return nil
+	case <-time.After(j.config.ShutdownTimeout):
+		j.running.Store(0)
+		return fmt.Errorf("KPI refresh job shutdown timed out after %v", j.config.ShutdownTimeout)
+	}
+}
+
+// Health returns nil if the job is running and not stuck in a failure loop.
+func (j *KpiRefreshJob) Health() error {
+	if j.running.Load() != 1 {
+		return errors.New("KPI refresh job is not running")
+	}
+
+	j.mu.RLock()
+	consec := j.consecutiveErrs
+	j.mu.RUnlock()
+
+	if consec > 5 {
+		return fmt.Errorf("KPI refresh job has %d consecutive errors", consec)
+	}
+	return nil
+}
+
+// KpiRefreshStats reports KPI refresh job statistics.
+type KpiRefreshStats struct {
+	Refreshed      int64
+	Failed         int64
+	LastRunTime    time.Time
+	LastRunError   string
+	ConsecutiveErr int
+}
+
+// GetStats returns a snapshot of the job's statistics.
+func (j *KpiRefreshJob) GetStats() KpiRefreshStats {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+
+	errMsg := ""
+	if j.lastRunError != nil {
+		errMsg = j.lastRunError.Error()
+	}
+	return KpiRefreshStats{
+		Refreshed:      j.refreshCount,
+		Failed:         j.failedCount,
+		LastRunTime:    j.lastRunTime,
+		LastRunError:   errMsg,
+		ConsecutiveErr: j.consecutiveErrs,
+	}
+}
+
+// refreshLoop runs the main refresh loop.
+func (j *KpiRefreshJob) refreshLoop() {
+	defer j.wg.Done()
+
+	ticker := time.NewTicker(j.config.PollInterval)
+	defer ticker.Stop()
+
+	// Compute immediately on startup so the dashboard shows data promptly.
+	j.refreshOnce()
+
+	for {
+		select {
+		case <-j.ctx.Done():
+			return
+		case <-ticker.C:
+			j.refreshOnce()
+		}
+	}
+}
+
+// refreshOnce performs a single KPI computation and pushes results to
+// Prometheus gauges. Errors are recorded via recordError.
+func (j *KpiRefreshJob) refreshOnce() {
+	ctx, cancel := context.WithTimeout(j.ctx, j.config.QueryTimeout)
+	defer cancel()
+
+	mrr, err := j.store.ComputeMRRInCents(ctx)
+	if err != nil {
+		j.recordError(fmt.Errorf("compute MRR: %w", err))
+		return
+	}
+
+	planCounts, err := j.store.CountActiveSubscribersPerPlan(ctx)
+	if err != nil {
+		j.recordError(fmt.Errorf("count active subscribers: %w", err))
+		return
+	}
+
+	churnRate, err := j.store.ComputeChurnRate24h(ctx)
+	if err != nil {
+		j.recordError(fmt.Errorf("compute churn rate: %w", err))
+		return
+	}
+
+	// Push metrics to Prometheus gauges.
+	metrics.MrrCents.Set(float64(mrr))
+
+	// Reset the gauge vec to clear stale plan labels, then set current values.
+	metrics.ActiveSubscribersTotal.Reset()
+	for key, count := range planCounts {
+		metrics.ActiveSubscribersTotal.WithLabelValues(key.ID, key.Name).Set(float64(count))
+	}
+
+	metrics.ChurnRate24h.Set(churnRate)
+
+	now := time.Now().UTC()
+	j.mu.Lock()
+	j.refreshCount++
+	j.lastRunTime = now
+	j.lastRunError = nil
+	j.consecutiveErrs = 0
+	j.mu.Unlock()
+}
+
+func (j *KpiRefreshJob) recordError(err error) {
+	j.mu.Lock()
+	j.failedCount++
+	j.lastRunError = err
+	j.consecutiveErrs++
+	j.mu.Unlock()
+
+	if j.logger != nil {
+		j.logger.Error("KPI refresh job error", "error", err.Error())
+	}
+}
+
+// sqlKpiStore is the production kpiStore backed by *sql.DB.
+type sqlKpiStore struct {
+	db *sql.DB
+}
+
+func (s *sqlKpiStore) ComputeMRRInCents(ctx context.Context) (int64, error) {
+	var cents sql.NullInt64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(amount * 100), 0)::bigint FROM subscriptions WHERE status = 'active'`,
+	).Scan(&cents)
+	if err != nil {
+		return 0, err
+	}
+	if cents.Valid {
+		return cents.Int64, nil
+	}
+	return 0, nil
+}
+
+type planCountRow struct {
+	PlanID   string
+	PlanName string
+	Count    int64
+}
+
+func (s *sqlKpiStore) CountActiveSubscribersPerPlan(ctx context.Context) (map[KpiPlanKey]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT plan_id, COALESCE(plan_name, plan_id), COUNT(*)::bigint
+		 FROM subscriptions
+		 WHERE status = 'active'
+		 GROUP BY plan_id, plan_name
+		 ORDER BY plan_id`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[KpiPlanKey]int64)
+	for rows.Next() {
+		var row planCountRow
+		if err := rows.Scan(&row.PlanID, &row.PlanName, &row.Count); err != nil {
+			return nil, err
+		}
+		result[KpiPlanKey{ID: row.PlanID, Name: row.PlanName}] = row.Count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *sqlKpiStore) ComputeChurnRate24h(ctx context.Context) (float64, error) {
+	var rate sql.NullFloat64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT
+		   COUNT(*) FILTER (WHERE status = 'cancelled' AND cancelled_at >= NOW() - INTERVAL '24 hours')::float
+		   /
+		   NULLIF(
+		     COUNT(*) FILTER (WHERE status IN ('active', 'cancelled')), 0
+		   )::float
+		 FROM subscriptions
+		 WHERE status IN ('active', 'cancelled')`,
+	).Scan(&rate)
+	if err != nil {
+		return 0, err
+	}
+	if rate.Valid {
+		return rate.Float64, nil
+	}
+	return 0, nil
+}

--- a/internal/worker/kpi_refresh_job_test.go
+++ b/internal/worker/kpi_refresh_job_test.go
@@ -1,0 +1,610 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"stellarbill-backend/internal/metrics"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// fakeKpiStore is an in-memory kpiStore for testing the refresh job without
+// Postgres. Each method returns pre-configured values or errors.
+type fakeKpiStore struct {
+	mu sync.Mutex
+
+	mrrCents         int64
+	mrrErr           error
+	planCounts       map[KpiPlanKey]int64
+	planErr          error
+	churnRate        float64
+	churnErr         error
+
+	computeMRRCalls           int
+	countActiveCalls          int
+	computeChurnCalls         int
+}
+
+func (f *fakeKpiStore) ComputeMRRInCents(_ context.Context) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.computeMRRCalls++
+	return f.mrrCents, f.mrrErr
+}
+
+func (f *fakeKpiStore) CountActiveSubscribersPerPlan(_ context.Context) (map[KpiPlanKey]int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.countActiveCalls++
+	if f.planCounts == nil {
+		return map[KpiPlanKey]int64{}, f.planErr
+	}
+	out := make(map[KpiPlanKey]int64, len(f.planCounts))
+	for k, v := range f.planCounts {
+		out[k] = v
+	}
+	return out, f.planErr
+}
+
+func (f *fakeKpiStore) ComputeChurnRate24h(_ context.Context) (float64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.computeChurnCalls++
+	return f.churnRate, f.churnErr
+}
+
+func resetKpiGauges() {
+	metrics.MrrCents.Set(0)
+	metrics.ActiveSubscribersTotal.Reset()
+	metrics.ChurnRate24h.Set(0)
+}
+
+// recordingKpiLogger counts Error calls.
+type recordingKpiLogger struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (r *recordingKpiLogger) Error(string, ...any) {
+	r.mu.Lock()
+	r.n++
+	r.mu.Unlock()
+}
+
+func (r *recordingKpiLogger) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.n
+}
+
+func TestKpiRefreshConfig_Defaults(t *testing.T) {
+	c := KpiRefreshConfig{}.withDefaults()
+	if c.PollInterval != time.Hour {
+		t.Errorf("PollInterval default = %v, want 1h", c.PollInterval)
+	}
+	if c.QueryTimeout != 30*time.Second {
+		t.Errorf("QueryTimeout default = %v, want 30s", c.QueryTimeout)
+	}
+	if c.ShutdownTimeout != 30*time.Second {
+		t.Errorf("ShutdownTimeout default = %v, want 30s", c.ShutdownTimeout)
+	}
+}
+
+func TestKpiRefreshConfig_PartialOverride(t *testing.T) {
+	c := KpiRefreshConfig{PollInterval: 10 * time.Minute}.withDefaults()
+	if c.PollInterval != 10*time.Minute {
+		t.Errorf("PollInterval = %v, want 10m", c.PollInterval)
+	}
+	if c.QueryTimeout != 30*time.Second {
+		t.Errorf("QueryTimeout should be default, got %v", c.QueryTimeout)
+	}
+}
+
+func TestKpiRefreshOnce_Success(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:   1234500,
+		planCounts: map[KpiPlanKey]int64{{ID: "plan_a", Name: "Plan A"}: 10, {ID: "plan_b", Name: "Plan B"}: 5},
+		churnRate:  0.03,
+	}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	stats := j.GetStats()
+	if stats.Refreshed != 1 {
+		t.Errorf("Refreshed = %d, want 1", stats.Refreshed)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", stats.Failed)
+	}
+	if stats.ConsecutiveErr != 0 {
+		t.Errorf("ConsecutiveErr = %d, want 0", stats.ConsecutiveErr)
+	}
+
+	if got := testutil.ToFloat64(metrics.MrrCents); got != 1234500 {
+		t.Errorf("MrrCents = %f, want 1234500", got)
+	}
+	if got := testutil.ToFloat64(metrics.ActiveSubscribersTotal.WithLabelValues("plan_a", "Plan A")); got != 10 {
+		t.Errorf("active_subscribers_total{plan_a} = %f, want 10", got)
+	}
+	if got := testutil.ToFloat64(metrics.ActiveSubscribersTotal.WithLabelValues("plan_b", "Plan B")); got != 5 {
+		t.Errorf("active_subscribers_total{plan_b} = %f, want 5", got)
+	}
+	if got := testutil.ToFloat64(metrics.ChurnRate24h); got != 0.03 {
+		t.Errorf("ChurnRate24h = %f, want 0.03", got)
+	}
+}
+
+func TestKpiRefreshOnce_EmptyPlans(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:   0,
+		planCounts: map[KpiPlanKey]int64{},
+		churnRate:  0,
+	}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	stats := j.GetStats()
+	if stats.Failed != 0 {
+		t.Errorf("Failed = %d, want 0 (empty data should not error)", stats.Failed)
+	}
+}
+
+func TestKpiRefreshOnce_PlanCountsNil(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:  50000,
+		planCounts: nil,
+		churnRate:  0,
+	}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	if stats := j.GetStats(); stats.Failed != 0 {
+		t.Errorf("Failed = %d, want 0 (nil plan counts should be treated as empty)", stats.Failed)
+	}
+}
+
+func TestKpiRefreshOnce_ComputeMRRError(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{mrrErr: errors.New("mrr query failed")}
+	rec := &recordingKpiLogger{}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, rec)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	stats := j.GetStats()
+	if stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+	if stats.ConsecutiveErr != 1 {
+		t.Errorf("ConsecutiveErr = %d, want 1", stats.ConsecutiveErr)
+	}
+	if rec.count() == 0 {
+		t.Error("logger.Error should have been called")
+	}
+}
+
+func TestKpiRefreshOnce_CountActiveError(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents: 1000,
+		planErr:  errors.New("plan query failed"),
+	}
+	rec := &recordingKpiLogger{}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, rec)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	if stats := j.GetStats(); stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+func TestKpiRefreshOnce_ChurnRateError(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:   1000,
+		planCounts: map[KpiPlanKey]int64{{ID: "p1", Name: "P1"}: 5},
+		churnErr:   errors.New("churn query failed"),
+	}
+	rec := &recordingKpiLogger{}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, rec)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	if stats := j.GetStats(); stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+func TestKpiRefreshJob_StartStopHealth(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:   50000,
+		planCounts: map[KpiPlanKey]int64{{ID: "basic", Name: "Basic"}: 3},
+		churnRate:  0.01,
+	}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{PollInterval: time.Hour}, nil)
+
+	if err := j.Health(); err == nil {
+		t.Error("Health should fail before Start")
+	}
+
+	j.Start()
+	time.Sleep(50 * time.Millisecond)
+
+	if err := j.Health(); err != nil {
+		t.Errorf("Health should pass while running: %v", err)
+	}
+	if got := j.GetStats().Refreshed; got < 1 {
+		t.Errorf("expected at least one startup refresh, got %d", got)
+	}
+
+	if err := j.Stop(); err != nil {
+		t.Errorf("Stop returned error: %v", err)
+	}
+	if err := j.Health(); err == nil {
+		t.Error("Health should fail after Stop")
+	}
+}
+
+func TestKpiRefreshJob_StopWithoutStart(t *testing.T) {
+	j := newKpiRefreshJob(&fakeKpiStore{}, KpiRefreshConfig{}, nil)
+	if err := j.Stop(); err != nil {
+		t.Errorf("Stop without Start should be a no-op, got %v", err)
+	}
+}
+
+func TestKpiRefreshJob_TickerFires(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:   100,
+		planCounts: map[KpiPlanKey]int64{{ID: "x", Name: "X"}: 1},
+		churnRate:  0,
+	}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{PollInterval: 20 * time.Millisecond}, nil)
+
+	j.Start()
+	defer j.Stop()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if j.GetStats().Refreshed >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := j.GetStats().Refreshed; got < 2 {
+		t.Errorf("expected >=2 refreshes from ticker, got %d", got)
+	}
+}
+
+// blockingKpiStore blocks all methods until the block channel is closed.
+type blockingKpiStore struct {
+	block chan struct{}
+}
+
+func (s *blockingKpiStore) ComputeMRRInCents(_ context.Context) (int64, error) {
+	<-s.block
+	return 0, nil
+}
+func (s *blockingKpiStore) CountActiveSubscribersPerPlan(_ context.Context) (map[KpiPlanKey]int64, error) {
+	<-s.block
+	return map[KpiPlanKey]int64{}, nil
+}
+func (s *blockingKpiStore) ComputeChurnRate24h(_ context.Context) (float64, error) {
+	<-s.block
+	return 0, nil
+}
+
+func TestKpiRefreshJob_ShutdownTimeout_Blocking(t *testing.T) {
+	store := &blockingKpiStore{block: make(chan struct{})}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{
+		PollInterval:    time.Hour,
+		ShutdownTimeout: 30 * time.Millisecond,
+	}, nil)
+
+	j.Start()
+	time.Sleep(20 * time.Millisecond)
+
+	err := j.Stop()
+	if err == nil {
+		t.Error("expected shutdown timeout error while refresh is blocked")
+	}
+	close(store.block)
+}
+
+func TestKpiRefreshJob_HealthUnhealthyAfterConsecutiveErrors(t *testing.T) {
+	store := &fakeKpiStore{mrrErr: errors.New("boom")}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+	j.running.Store(1)
+
+	for i := 0; i < 6; i++ {
+		j.refreshOnce()
+	}
+	if err := j.Health(); err == nil {
+		t.Error("Health should fail after >5 consecutive errors")
+	}
+}
+
+func TestKpiRefreshJob_RecordsMultipleRefreshCalls(t *testing.T) {
+	resetKpiGauges()
+	store := &fakeKpiStore{
+		mrrCents:   100,
+		planCounts: map[KpiPlanKey]int64{{ID: "p", Name: "P"}: 2},
+		churnRate:  0.5,
+	}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+	j.refreshOnce()
+	j.refreshOnce()
+
+	stats := j.GetStats()
+	if stats.Refreshed != 3 {
+		t.Errorf("Refreshed = %d, want 3", stats.Refreshed)
+	}
+	if stats.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", stats.Failed)
+	}
+}
+
+func TestKpiRefreshJob_GetStatsLastRunError(t *testing.T) {
+	store := &fakeKpiStore{mrrErr: errors.New("disk full")}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+
+	j.refreshOnce()
+
+	stats := j.GetStats()
+	if stats.LastRunError != "compute MRR: disk full" {
+		t.Errorf("LastRunError = %q, want %q", stats.LastRunError, "compute MRR: disk full")
+	}
+}
+
+func TestKpiRefreshJob_NilLoggerDoesNotPanic(t *testing.T) {
+	store := &fakeKpiStore{mrrErr: errors.New("oops")}
+	j := newKpiRefreshJob(store, KpiRefreshConfig{}, nil)
+	j.ctx = context.Background()
+
+	// Should not panic despite nil logger.
+	j.refreshOnce()
+
+	if stats := j.GetStats(); stats.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", stats.Failed)
+	}
+}
+
+// ---- SQL store tests with go-sqlmock ----
+
+func newKpiSQLMock(t *testing.T) (*sqlKpiStore, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	return &sqlKpiStore{db: db}, mock, func() { _ = db.Close() }
+}
+
+func TestSQLKpiStore_ComputeMRRInCents_Success(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("SELECT COALESCE\\(SUM\\(amount \\* 100\\), 0\\)::bigint FROM subscriptions WHERE status = 'active'").
+		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(int64(50000)))
+
+	cents, err := store.ComputeMRRInCents(context.Background())
+	if err != nil {
+		t.Fatalf("ComputeMRRInCents: %v", err)
+	}
+	if cents != 50000 {
+		t.Errorf("got %d, want 50000", cents)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestSQLKpiStore_ComputeMRRInCents_Empty(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("SELECT COALESCE\\(SUM\\(amount \\* 100\\), 0\\)::bigint").
+		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(nil))
+
+	cents, err := store.ComputeMRRInCents(context.Background())
+	if err != nil {
+		t.Fatalf("ComputeMRRInCents: %v", err)
+	}
+	if cents != 0 {
+		t.Errorf("got %d, want 0 for empty result", cents)
+	}
+}
+
+func TestSQLKpiStore_ComputeMRRInCents_Error(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("SELECT COALESCE").WillReturnError(errors.New("connection refused"))
+
+	if _, err := store.ComputeMRRInCents(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSQLKpiStore_CountActiveSubscribersPerPlan_Success(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery(`SELECT plan_id, COALESCE\(plan_name, plan_id\), COUNT\(\*\)::bigint FROM subscriptions WHERE status = 'active' GROUP BY plan_id, plan_name ORDER BY plan_id`).
+		WillReturnRows(sqlmock.NewRows([]string{"plan_id", "plan_name", "count"}).
+			AddRow("plan_a", "Plan A", int64(10)).
+			AddRow("plan_b", "Plan B", int64(5)))
+
+	counts, err := store.CountActiveSubscribersPerPlan(context.Background())
+	if err != nil {
+		t.Fatalf("CountActiveSubscribersPerPlan: %v", err)
+	}
+	if len(counts) != 2 {
+		t.Fatalf("expected 2 plans, got %d", len(counts))
+	}
+	if counts[KpiPlanKey{ID: "plan_a", Name: "Plan A"}] != 10 {
+		t.Errorf("plan_a count = %d, want 10", counts[KpiPlanKey{ID: "plan_a", Name: "Plan A"}])
+	}
+	if counts[KpiPlanKey{ID: "plan_b", Name: "Plan B"}] != 5 {
+		t.Errorf("plan_b count = %d, want 5", counts[KpiPlanKey{ID: "plan_b", Name: "Plan B"}])
+	}
+}
+
+func TestSQLKpiStore_CountActiveSubscribersPerPlan_Empty(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("SELECT plan_id, COALESCE").
+		WillReturnRows(sqlmock.NewRows([]string{"plan_id", "plan_name", "count"}))
+
+	counts, err := store.CountActiveSubscribersPerPlan(context.Background())
+	if err != nil {
+		t.Fatalf("CountActiveSubscribersPerPlan: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(counts))
+	}
+}
+
+func TestSQLKpiStore_CountActiveSubscribersPerPlan_Error(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("SELECT plan_id, COALESCE").WillReturnError(errors.New("timeout"))
+
+	if _, err := store.CountActiveSubscribersPerPlan(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSQLKpiStore_CountActiveSubscribersPerPlan_ScanError(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	// Return a row with an incompatible type to trigger a scan error.
+	mock.ExpectQuery("SELECT plan_id, COALESCE").
+		WillReturnRows(sqlmock.NewRows([]string{"plan_id", "plan_name", "count"}).
+			AddRow("p1", "P1", "not_a_number"))
+
+	if _, err := store.CountActiveSubscribersPerPlan(context.Background()); err == nil {
+		t.Fatal("expected scan error")
+	}
+}
+
+func TestSQLKpiStore_CountActiveSubscribersPerPlan_RowsError(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("SELECT plan_id, COALESCE").
+		WillReturnRows(sqlmock.NewRows([]string{"plan_id", "plan_name", "count"}).
+			AddRow("p1", "P1", int64(1)).
+			RowError(0, errors.New("row iteration failed")))
+
+	if _, err := store.CountActiveSubscribersPerPlan(context.Background()); err == nil {
+		t.Fatal("expected row iteration error")
+	}
+}
+
+func TestSQLKpiStore_ComputeChurnRate24h_Success(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery(`COUNT\(\*\) FILTER`).
+		WillReturnRows(sqlmock.NewRows([]string{"float8"}).AddRow(0.05))
+
+	rate, err := store.ComputeChurnRate24h(context.Background())
+	if err != nil {
+		t.Fatalf("ComputeChurnRate24h: %v", err)
+	}
+	if rate != 0.05 {
+		t.Errorf("got %f, want 0.05", rate)
+	}
+}
+
+func TestSQLKpiStore_ComputeChurnRate24h_NoChurn(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("COUNT\\(\\*\\) FILTER").
+		WillReturnRows(sqlmock.NewRows([]string{"float8"}).AddRow(0.0))
+
+	rate, err := store.ComputeChurnRate24h(context.Background())
+	if err != nil {
+		t.Fatalf("ComputeChurnRate24h: %v", err)
+	}
+	if rate != 0.0 {
+		t.Errorf("got %f, want 0.0", rate)
+	}
+}
+
+func TestSQLKpiStore_ComputeChurnRate24h_NullResult(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	// NULLIF causes a null result when there are no matching rows.
+	mock.ExpectQuery("COUNT\\(\\*\\) FILTER").
+		WillReturnRows(sqlmock.NewRows([]string{"float8"}).AddRow(nil))
+
+	rate, err := store.ComputeChurnRate24h(context.Background())
+	if err != nil {
+		t.Fatalf("ComputeChurnRate24h: %v", err)
+	}
+	if rate != 0.0 {
+		t.Errorf("got %f, want 0.0 for null (empty base)", rate)
+	}
+}
+
+func TestSQLKpiStore_ComputeChurnRate24h_Error(t *testing.T) {
+	store, mock, done := newKpiSQLMock(t)
+	defer done()
+
+	mock.ExpectQuery("COUNT\\(\\*\\) FILTER").WillReturnError(errors.New("db down"))
+
+	if _, err := store.ComputeChurnRate24h(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewKpiRefreshJob_Constructor(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	j := NewKpiRefreshJob(db, KpiRefreshConfig{}, nil)
+	if j == nil {
+		t.Fatal("expected non-nil job")
+	}
+	if _, ok := j.store.(*sqlKpiStore); !ok {
+		t.Errorf("expected sqlKpiStore, got %T", j.store)
+	}
+	if j.config.PollInterval != time.Hour {
+		t.Errorf("PollInterval = %v, want 1h", j.config.PollInterval)
+	}
+}


### PR DESCRIPTION
Close: #429
Here's a summary of all changes made:
Files created
- internal/worker/kpi_refresh_job.go — KpiRefreshJob following the same loop pattern as FeeRevenueRefreshJob. Exposes Start(), Stop(), Health(), GetStats(). SQL store handles divide-by-zero via NULLIF and COALESCE. Three store methods: ComputeMRRInCents, CountActiveSubscribersPerPlan, ComputeChurnRate24h.
- internal/worker/kpi_refresh_job_test.go — 22 tests covering config defaults, success path, empty tenants, nil-safe compute, per-method error propagation, start/stop lifecycle, shutdown timeout, ticker firing, consecutive error health check, and go-sqlmock SQL store tests (including NULL/null/scan-error/row-error edge cases).
- docs/ops/kpi-dashboards.md — Documents the three gauges, refresh cadence, example PromQL queries, Grafana panel suggestions, security model, configuration, and maintainability notes.
Files modified
- internal/metrics/metrics.go — Added MrrCents, ActiveSubscribersTotal{plan_id,plan_name}, ChurnRate24h via promauto auto-registration.
- internal/routes/routes.go — Added /metrics endpoint (public, behind network-level ACL).
- cmd/server/main.go — Added database connection setup (when DBConn configured), KpiRefreshJob instantiation/startup, graceful shutdown via defer, and stdLogger adapter.
Key design decisions
- Gauges are reset each refresh to avoid stale plan-label cardinality
- Churn uses NULLIF denominator to return 0.0 on empty base (divide-by-zero safe)
- COALESCE ensures MRR returns 0 on empty subscriptions table
- Worker only starts if a DB connection is configured, maintaining backward compatibility with mock-only deployments