### PR TITLE
feat: drain DB pool gracefully on SIGTERM

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"stellarbill-backend/internal/auth"
 	"stellarbill-backend/internal/config"
+	"stellarbill-backend/internal/db"
+	"stellarbill-backend/internal/metrics"
 	"stellarbill-backend/internal/routes"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -27,7 +33,6 @@ func main() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
-	// Initialize SPIFFE Verifier for cross-service mesh auth
 	spiffeVerifier, err := auth.NewSpiffeVerifier(context.Background(), cfg.SpiffeSocketPath, cfg.SpiffeTrustDomain, cfg.Env)
 	if err != nil {
 		log.Fatalf("failed to initialize SPIFFE verifier: %v", err)
@@ -52,10 +57,64 @@ func main() {
 		IdleTimeout:  time.Duration(cfg.IdleTimeout) * time.Second,
 	}
 
-	log.Printf("server listening on %s", addr)
-	if err := listenAndServe(srv); err != nil && err != http.ErrServerClosed {
+	pool, err := db.NewPool(context.Background(), cfg)
+	if err != nil {
+		log.Fatalf("failed to create database pool: %v", err)
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+
+	shutdownTimeout := time.Duration(cfg.GracefulShutdownTimeout) * time.Second
+	if err := runHTTPServer(context.Background(), sig, srv, shutdownTimeout, func(ctx context.Context) error {
+		if pool != nil {
+			pool.Close()
+		}
+		return nil
+	}); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+func runHTTPServer(ctx context.Context, sig chan os.Signal, srv *http.Server, shutdownTimeout time.Duration, cleanup func(context.Context) error) error {
+	start := time.Now()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- listenAndServe(srv)
+	}()
+
+	select {
+	case <-ctx.Done():
+	case s := <-sig:
+		log.Printf("received signal %v, initiating graceful shutdown", s)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		select {
+		case <-sig:
+			_ = srv.Close()
+			return fmt.Errorf("forced shutdown after second signal: %w", err)
+		default:
+		}
+		return fmt.Errorf("http server shutdown: %w", err)
+	}
+
+	if err := <-serveErr; err != nil && err != http.ErrServerClosed {
+		return err
+	}
+
+	if cleanup != nil {
+		if err := cleanup(context.Background()); err != nil {
+			return fmt.Errorf("cleanup: %w", err)
+		}
+	}
+
+	metrics.ShutdownDuration.Observe(time.Since(start).Seconds())
+	return nil
 }
 
 func printConfigError(err error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,11 @@ type Config struct {
 	DBPoolConnectTimeout    int // seconds
 	DBPoolHealthCheckPeriod int // seconds
 	DBPoolMetricsInterval   int // seconds
+
+	// GracefulShutdownTimeout controls how long the server waits for in-flight
+	// requests to complete and the DB pool to drain before force-closing.
+	// Coordinate with Kubernetes terminationGracePeriodSeconds.
+	GracefulShutdownTimeout int // seconds; default 30
 }
 
 // ValidationResult holds the result of configuration validation
@@ -139,6 +144,10 @@ const (
 	DefaultDBPoolConnectTimeout    = 5    // 5 s per dial attempt
 	DefaultDBPoolHealthCheckPeriod = 30   // 30 s proactive idle-conn check
 	DefaultDBPoolMetricsInterval   = 15   // 15 s Prometheus scrape cadence
+
+	// Graceful shutdown defaults — coordinate with k8s terminationGracePeriodSeconds.
+	DefaultGracefulShutdownTimeout = 30   // 30 s to drain in-flight requests and pool
+
 
 	// Validation bounds
 	MinDBPoolMaxConns = 1
@@ -215,7 +224,8 @@ func Load(opts ...Option) (Config, error) {
 		DBPoolMaxConnIdleTime:   DefaultDBPoolMaxConnIdleTime,
 		DBPoolConnectTimeout:    DefaultDBPoolConnectTimeout,
 		DBPoolHealthCheckPeriod: DefaultDBPoolHealthCheckPeriod,
-		DBPoolMetricsInterval:   DefaultDBPoolMetricsInterval,
+		DBPoolMetricsInterval:         DefaultDBPoolMetricsInterval,
+		GracefulShutdownTimeout:       getEnvInt("GRACEFUL_SHUTDOWN_TIMEOUT", DefaultGracefulShutdownTimeout),
 	}
 
 	// Resolve secrets through the provider
@@ -504,6 +514,20 @@ func (c *Config) validate(resolvedSecrets map[string]string, secretErrs map[stri
 
 	if svcName := os.Getenv("TRACING_SERVICE_NAME"); svcName != "" {
 		c.TracingServiceName = svcName
+	}
+
+	// Validate GRACEFUL_SHUTDOWN_TIMEOUT
+	if val := os.Getenv("GRACEFUL_SHUTDOWN_TIMEOUT"); val != "" {
+		if timeout, err := strconv.Atoi(val); err == nil && timeout >= MinTimeoutSeconds && timeout <= MaxTimeoutSeconds {
+			c.GracefulShutdownTimeout = timeout
+		} else {
+			result.Errors = append(result.Errors, ConfigError{
+				Type:    ErrInvalidValue,
+				Key:     "GRACEFUL_SHUTDOWN_TIMEOUT",
+				Message: fmt.Sprintf("must be between %d and %d seconds", MinTimeoutSeconds, MaxTimeoutSeconds),
+				Value:   val,
+			})
+		}
 	}
 
 	// Validate DB pool configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,6 +193,36 @@ func TestLoadProviderErrorsAreClassified(t *testing.T) {
 	})
 }
 
+func TestLoadRejectsShutdownTimeoutOutOfRange(t *testing.T) {
+	withEnvVars(t, map[string]string{
+		"ENV":                       "development",
+		"GRACEFUL_SHUTDOWN_TIMEOUT": "0",
+	}, func() {
+		_, err := Load(WithSecretsProvider(newValidProvider()))
+		if err == nil {
+			t.Fatal("expected invalid shutdown timeout error")
+		}
+		if !strings.Contains(err.Error(), "GRACEFUL_SHUTDOWN_TIMEOUT") {
+			t.Fatalf("expected GRACEFUL_SHUTDOWN_TIMEOUT in error, got: %v", err)
+		}
+	})
+}
+
+func TestLoadShutdownTimeoutDefault(t *testing.T) {
+	withEnvVars(t, map[string]string{
+		"ENV": "development",
+	}, func() {
+		cfg, err := Load(WithSecretsProvider(newValidProvider()))
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if cfg.GracefulShutdownTimeout != DefaultGracefulShutdownTimeout {
+			t.Fatalf("expected default shutdown timeout %d, got %d",
+				DefaultGracefulShutdownTimeout, cfg.GracefulShutdownTimeout)
+		}
+	})
+}
+
 func TestIsValidSecretRequiresSpecialCharacter(t *testing.T) {
 	if isValidSecret("NoSpecialChars123") {
 		t.Fatal("expected secret without special char to fail")

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -136,6 +136,15 @@ var CacheHitsTotal = promauto.NewCounterVec(
 	[]string{"layer", "op", "result"},
 )
 
+// ShutdownDuration tracks the time taken to shut down gracefully in seconds.
+var ShutdownDuration = promauto.NewHistogram(
+	prometheus.HistogramOpts{
+		Name:    "shutdown_duration_seconds",
+		Help:    "Time taken to shut down gracefully in seconds",
+		Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10, 25, 30},
+	},
+)
+
 func sanitizeLabel(value string) string {
 	if value == "" {
 		return "unknown"


### PR DESCRIPTION
## Description

On SIGTERM, stop accepting new requests, wait for in-flight to complete up to a bounded grace, then close the DB pool cleanly before exit. Removes half-open connections that today block startup of the next replica.

## Changes

### `cmd/server/main.go`
- Added `runHTTPServer` — reusable graceful-shutdown loop that:
  - Starts serving on the configured address
  - Blocks on ctx cancellation or first OS signal (SIGTERM/SIGINT)
  - Initiates HTTP graceful shutdown with configurable timeout
  - Force-closes on a second signal
  - Runs a cleanup hook (DB pool drain) after the server stops
- Updated `main()` to create the DB pool and pass pool.Close as the cleanup hook

### `internal/config/config.go`
- Added `GracefulShutdownTimeout` field (default 30s, env `GRACEFUL_SHUTDOWN_TIMEOUT`)
- Validation: 1–600s range

### `internal/metrics/metrics.go`
- Added `shutdown_duration_seconds` histogram metric to track graceful shutdown latency

### `internal/config/config_test.go`
- Added tests: `TestLoadRejectsShutdownTimeoutOutOfRange` and `TestLoadShutdownTimeoutDefault`

## Grace-period defaults

Configure via `GRACEFUL_SHUTDOWN_TIMEOUT` env var (default 30 seconds). Coordinate with Kubernetes `terminationGracePeriodSeconds` so that `terminationGracePeriodSeconds > GRACEFUL_SHUTDOWN_TIMEOUT` to allow the full drain window.

## Closes

Closes #483