### PR TITLE
devops: add PDB and topology spread constraints

### DIFF
--- a/deploy/helm/IMPLEMENTATION_SUMMARY.md
+++ b/deploy/helm/IMPLEMENTATION_SUMMARY.md
@@ -1,8 +1,97 @@
-# NetworkPolicy Implementation Summary
+# Helm Chart Implementation Summary
 
 ## Overview
 
-This document summarizes the Kubernetes NetworkPolicy implementation for Stellabill, which restricts pod-to-pod traffic according to the required connectivity matrix.
+This document summarizes the Helm chart implementation for Stellabill, covering NetworkPolicies, PodDisruptionBudgets (PDB), topology spread constraints, and HorizontalPodAutoscalers (HPA).
+
+**Git Branch**: `devops/pdb-topology`  
+**Status**: ✅ Complete - `helm template` validates successfully
+
+---
+
+## PDB & Topology Spread Implementation
+
+### PodDisruptionBudgets (`pdb.yaml`)
+
+Guarantees minimum availability during voluntary disruptions (e.g., node maintenance, cluster upgrades).
+
+**Templates**: Both `api` and `worker` components get their own PDB.
+
+**Default behavior**:
+- `minAvailable: 1` (with HPA `minReplicas=2`, allows 1 pod to be disrupted)
+- `maxUnavailable: null` (not set by default)
+
+**Single-node dev cluster override**:
+```bash
+helm install stellabill ./deploy/helm/stellabill \
+  --set api.podDisruptionBudget.minAvailable=0 \
+  --set api.podDisruptionBudget.maxUnavailable=1 \
+  --set worker.podDisruptionBudget.minAvailable=0 \
+  --set worker.podDisruptionBudget.maxUnavailable=1
+```
+
+Renders `maxUnavailable: 1` instead of `minAvailable: 1`.
+
+**Key design decision**: `minAvailable` must always respect HPA `minReplicas`. Default `minReplicas=2` → `minAvailable=1` ensures at least one replica stays up during disruptions.
+
+### Topology Spread Constraints (`deployment.yaml`)
+
+Spreads replicas across zones/nodes to achieve high availability during infrastructure failures.
+
+**Default configuration**:
+- `maxSkew: 1` — even distribution (at most 1 replica difference between zones)
+- `topologyKey: topology.kubernetes.io/zone` — spread across availability zones
+- `whenUnsatisfiable: ScheduleAnyway` — still schedule pods even if spread can't be achieved
+
+**Node-level spread** (override for smaller clusters):
+```yaml
+topologySpread:
+  topologyKey: kubernetes.io/hostname
+```
+
+Both API and Worker deployments include topology spread constraints with label selectors scoped to their component.
+
+### HorizontalPodAutoscalers (`hpa.yaml`)
+
+Autoscaling v2 with CPU and memory utilization targets.
+
+**Default configuration**:
+- `minReplicas: 2` — minimum two replicas for HA
+- `maxReplicas: 20` — upper bound for cost control
+- `targetCPUUtilizationPercentage: 80` — scale up at 80% CPU
+- `targetMemoryUtilizationPercentage: 80` — scale up at 80% memory
+- Configurable `behavior` block for advanced scaling policies
+
+**PDB alignment**: `minAvailable: 1` is deliberately < `minReplicas: 2` so that HPA can scale down without violating PDB constraints.
+
+### Common Labels (`_helpers.tpl`)
+
+Reusable template functions:
+- `stellabill.labels` — standard Kubernetes recommended labels (name, instance, version, managed-by)
+- `stellabill.selectorLabels` — name + instance for pod selectors
+- `stellabill.componentLabels` — selectorLabels + component label
+- `stellabill.componentSelectorLabels` — scoped selector for component-specific matching
+- `stellabill.componentName` — resolves to the component's configured name
+
+### Files Created/Modified
+
+**New templates**:
+- `deploy/helm/stellabill/templates/_helpers.tpl` — reusable label/selector definitions
+- `deploy/helm/stellabill/templates/deployment.yaml` — deployments with topology spread constraints
+- `deploy/helm/stellabill/templates/hpa.yaml` — HorizontalPodAutoscaler definitions
+- `deploy/helm/stellabill/templates/pdb.yaml` — PodDisruptionBudget definitions
+
+**Updated**:
+- `deploy/helm/stellabill/values.yaml` — added image, autoscaling, PDB, topology spread, resource, and probe configuration sections
+- `deploy/helm/stellabill/Chart.yaml` — updated description to reflect PDB and topology spread
+
+## NetworkPolicy Implementation
+
+The following sections cover the previously implemented NetworkPolicy components.
+
+### Overview
+
+This Kubernetes NetworkPolicy implementation restricts pod-to-pod traffic according to the required connectivity matrix.
 
 **Git Branch**: `devops/network-policies`  
 **Commit**: `5c7b135b003d7d1744353a8af032933f44fb70de`  

--- a/deploy/helm/stellabill/Chart.yaml
+++ b/deploy/helm/stellabill/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: stellabill
-description: Helm chart for Stellabill backend with NetworkPolicies for secure pod-to-pod communication
+description: Helm chart for Stellabill backend with NetworkPolicies, PodDisruptionBudgets, and topology spread constraints
 type: application
 version: 0.1.0
 appVersion: "1.0.0"

--- a/deploy/helm/stellabill/templates/_helpers.tpl
+++ b/deploy/helm/stellabill/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "stellabill.labels" -}}
+helm.sh/chart: {{ include "stellabill.chart" . }}
+{{ include "stellabill.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "stellabill.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stellabill.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "stellabill.componentLabels" -}}
+{{ include "stellabill.selectorLabels" . }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "stellabill.componentSelectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{- define "stellabill.componentName" -}}
+{{ .name }}
+{{- end }}

--- a/deploy/helm/stellabill/templates/deployment.yaml
+++ b/deploy/helm/stellabill/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{- $components := list "api" "worker" -}}
+{{- range $component := $components }}
+{{- $values := index $.Values $component -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $values.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "stellabill.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
+    tier: {{ $values.labels.tier }}
+spec:
+  replicas: {{ $values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "stellabill.componentSelectorLabels" (dict "Chart" $.Chart "Release" $.Release "component" $component) | nindent 6 }}
+      tier: {{ $values.labels.tier }}
+  template:
+    metadata:
+      labels:
+        {{- include "stellabill.componentLabels" (dict "Chart" $.Chart "Release" $.Release "component" $component) | nindent 8 }}
+        tier: {{ $values.labels.tier }}
+        component: {{ $values.labels.component }}
+    spec:
+      {{- with $values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $values.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ $values.topologySpread.maxSkew }}
+          topologyKey: {{ $values.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ $values.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "stellabill.componentSelectorLabels" (dict "Chart" $.Chart "Release" $.Release "component" $component) | nindent 14 }}
+              tier: {{ $values.labels.tier }}
+      {{- end }}
+      containers:
+        - name: {{ $component }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- with $values.container.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.container.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: {{ $values.container.portName }}
+              containerPort: {{ $values.container.port }}
+              protocol: TCP
+          {{- with $values.container.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.container.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml $values.resources | nindent 12 }}
+          {{- with $values.container.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with $values.container.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ $values.serviceAccountName | default (printf "%s-%s" $.Release.Name $component) }}
+{{- end }}

--- a/deploy/helm/stellabill/templates/hpa.yaml
+++ b/deploy/helm/stellabill/templates/hpa.yaml
@@ -1,0 +1,43 @@
+{{- $components := list "api" "worker" -}}
+{{- range $component := $components }}
+{{- $values := index $.Values $component -}}
+{{- if $values.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $values.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "stellabill.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $values.name }}
+  minReplicas: {{ $values.autoscaling.minReplicas }}
+  maxReplicas: {{ $values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with $values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with $values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  {{- with $values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/stellabill/templates/pdb.yaml
+++ b/deploy/helm/stellabill/templates/pdb.yaml
@@ -1,0 +1,25 @@
+{{- $components := list "api" "worker" -}}
+{{- range $component := $components }}
+{{- $values := index $.Values $component -}}
+{{- if $values.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $values.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "stellabill.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $component }}
+spec:
+  {{- if $values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ $values.podDisruptionBudget.maxUnavailable }}
+  {{- else if $values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ $values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "stellabill.componentSelectorLabels" (dict "Chart" $.Chart "Release" $.Release "component" $component) | nindent 6 }}
+      tier: {{ $values.labels.tier }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/stellabill/values.yaml
+++ b/deploy/helm/stellabill/values.yaml
@@ -1,6 +1,12 @@
 # Default values for stellabill
 # This is a YAML-formatted file.
 
+# Global image configuration
+image:
+  repository: stellabill/backend
+  tag: latest
+  pullPolicy: IfNotPresent
+
 # Network Policy Configuration
 networkPolicy:
   enabled: true
@@ -21,6 +27,48 @@ api:
     tier: api
     component: backend
   port: 8080
+  serviceAccountName: ""
+  imagePullSecrets: []
+  container:
+    portName: http
+    port: 8080
+    command: []
+    args: []
+    env: []
+    envFrom: []
+    volumeMounts: []
+    volumes: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  livenessProbe: {}
+  readinessProbe: {}
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    behavior: {}
+  podDisruptionBudget:
+    enabled: true
+    # minAvailable must respect HPA minReplicas (minReplicas=2 => minAvailable=1)
+    # For single-node dev clusters, override with maxUnavailable: 1
+    minAvailable: 1
+    maxUnavailable: null
+  topologySpread:
+    enabled: true
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    # For node-level spread, use: topologyKey: kubernetes.io/hostname
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # Worker Service Configuration
 worker:
@@ -30,6 +78,45 @@ worker:
     app: stellabill
     tier: worker
     component: background-jobs
+  serviceAccountName: ""
+  imagePullSecrets: []
+  container:
+    portName: http
+    port: 8080
+    command: []
+    args: []
+    env: []
+    envFrom: []
+    volumeMounts: []
+    volumes: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  livenessProbe: {}
+  readinessProbe: {}
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+    behavior: {}
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+    maxUnavailable: null
+  topologySpread:
+    enabled: true
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # Database Configuration
 database:


### PR DESCRIPTION
Closes #465  
All tasks complete. Here's a summary of what was done:
✅ Completed Todos
┌───────────────────────────────────────────────────────────────┬──────────────────────────────────────┐
│ Todo                                                          │ Status                               │
├───────────────────────────────────────────────────────────────┼──────────────────────────────────────┤
│ Create _helpers.tpl with common labels/selectors              │ ✅ Done                              │
│ Create deployment.yaml with topology spread constraints       │ ✅ Done                              │
│ Create hpa.yaml with min=2, max=20 defaults                   │ ✅ Done                              │
│ Create pdb.yaml with minAvailable respecting HPA min replicas │ ✅ Done (+ fixed mutual exclusivity) │
│ Update values.yaml with new configuration sections            │ ✅ Done                              │
│ Validate with helm template --dry-run                         │ ✅ Passes                            │
│ Update Chart.yaml & deploy/helm/IMPLEMENTATION_SUMMARY.md     │ ✅ Done                              │
└───────────────────────────────────────────────────────────────┴──────────────────────────────────────┘
Key Fixes Made
1. PDB template — Made  minAvailable / maxUnavailable  mutually exclusive so Kubernetes never rejects a PDB with both fields set
2. Chart.yaml — Updated description to include PDB + topology spread
3. IMPLEMENTATION_SUMMARY.md — Added PDB/topology implementation section, restructured NetworkPolicy section as a clean subsection
Validation Results
┌──────────────────────────────────┬─────────────────────────────────────────────────────┐
│ Scenario                         │ Result                                              │
├──────────────────────────────────┼─────────────────────────────────────────────────────┤
│ helm template (default values)   │ ✅ minAvailable: 1                                  │
│ Dev override (maxUnavailable: 1) │ ✅ maxUnavailable: 1 only                           │
│ Both fields set                  │ ✅ Only maxUnavailable renders (mutual exclusivity) │
│ helm template exit code          │ ✅ 0                                                │
└──────────────────────────────────┴───────────────────────────────────────────────────



- Add PodDisruptionBudget templates for API and Worker with minAvailable respecting HPA minReplicas
- Add deployment templates with topology spread constraints (default: topology.kubernetes.io/zone)
- Add HPA templates with min=2, max=20, CPU/memory targets
- Add _helpers.tpl with common labels/selectors
- Update values.yaml with autoscaling, PDB, topology spread, resources sections
- Update IMPLEMENTATION_SUMMARY.md and Chart.yaml