### PR TITLE
docs: update OpenAPI examples and lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           test -z "$(gofumpt -l .)"
       - name: OpenAPI validation
         run: go run ./cmd/openapi-validate
+      - name: OpenAPI examples lint
+        run: go run ./tools/openapi-lint
       - name: Migration Safety Validation
         run: go run ./cmd/validate-migrations
       - name: ADR lint (unique numbers + index)

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /dist/
 /build/
 out/
+# Project-local compiled binaries (go build output at repo root)
+/openapi-lint
+/stellarbill-backend
 
 # Go workspace and test
 *.test

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -31,6 +31,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: "ok"
+                service: "stellarbill-backend"
   /api/v1/plans:
     get:
       tags: [Plans]
@@ -60,6 +63,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PlansResponse"
+              example:
+                plans:
+                  - id: "plan_basic"
+                    name: "Basic"
+                    amount: "1000"
+                    currency: "NGN"
+                    interval: "monthly"
+                    description: "Starter plan"
+                  - id: "plan_pro"
+                    name: "Pro"
+                    amount: "5000"
+                    currency: "NGN"
+                    interval: "monthly"
+                    description: "Professional plan"
+                pagination:
+                  has_more: false
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -93,6 +112,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SubscriptionsResponse"
+              example:
+                subscriptions:
+                  - id: "sub_123"
+                    plan_id: "plan_basic"
+                    customer: "customer_123"
+                    status: "active"
+                    amount: "1000"
+                    interval: "monthly"
+                    next_billing: "2026-08-01T00:00:00Z"
+                pagination:
+                  has_more: false
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -119,6 +149,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Subscription"
+              example:
+                id: "sub_123"
+                plan_id: "plan_basic"
+                customer: "customer_123"
+                status: "active"
+                amount: "1000"
+                interval: "monthly"
+                next_billing: "2026-08-01T00:00:00Z"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":

--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -25,6 +25,21 @@ func loadFromData(data []byte) (*openapi3.T, error) {
 	return doc, nil
 }
 
+// LoadFromBytes parses and validates an OpenAPI document from a raw byte slice.
+// This is intended for tooling (e.g. openapi-lint) that reads the spec from an
+// arbitrary file path rather than the embedded default.
+func LoadFromBytes(data []byte) (*openapi3.T, error) {
+	return loadFromData(data)
+}
+
+// LoadFromBytesRaw parses an OpenAPI document without running schema-level
+// validation (e.g. example validation).  This is useful in tests that
+// deliberately construct documents with invalid examples to verify lint logic.
+func LoadFromBytesRaw(data []byte) (*openapi3.T, error) {
+	loader := openapi3.NewLoader()
+	return loader.LoadFromData(data)
+}
+
 func RawYAML() []byte {
 	return specYAML
 }

--- a/tools/openapi-lint/examples.go
+++ b/tools/openapi-lint/examples.go
@@ -1,0 +1,266 @@
+// This file is part of the openapi-lint tool (package main).
+//
+// It provides the core linting logic that verifies every OpenAPI operation has
+// at least one request/response example and that every example validates
+// against its declared schema.
+//
+// # Design
+//
+// The linter is intentionally dependency-light: it uses only the already-
+// vendored kin-openapi library (already required by the main module) plus the
+// standard library.  No code-generation or external tools are needed; the
+// check is a plain `go run ./tools/openapi-lint`.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Violation describes a single linting problem for one operation.
+type Violation struct {
+	// OperationID is the operationId field, or "METHOD path" when absent.
+	OperationID string
+	// Path is the URL path of the operation.
+	Path string
+	// Method is the HTTP method (upper-case).
+	Method string
+	// Message is a human-readable description of the problem.
+	Message string
+}
+
+func (v Violation) String() string {
+	return fmt.Sprintf("[%s %s (%s)] %s", v.Method, v.Path, v.OperationID, v.Message)
+}
+
+// LintResult is the aggregated output of a lint run.
+type LintResult struct {
+	Violations []Violation
+}
+
+// OK returns true when no violations were found.
+func (r LintResult) OK() bool { return len(r.Violations) == 0 }
+
+// LintDoc validates all operations in doc.  It checks:
+//  1. Every non-4xx/5xx response has at least one example.
+//  2. Every request body (when present) has at least one example.
+//  3. Every example value validates against the schema for its media type.
+//
+// Non-content responses (e.g. 204 No Content) are excluded from the example
+// requirement because they carry no body.  Shared error responses ($ref to
+// components/responses) are not checked per-operation because they are defined
+// once and may be reused by many operations; checking them per-operation would
+// produce duplicate noise.
+func LintDoc(doc *openapi3.T) LintResult {
+	var result LintResult
+
+	if doc == nil || doc.Paths == nil {
+		return result
+	}
+
+	for path, pathItem := range doc.Paths.Map() {
+		if pathItem == nil {
+			continue
+		}
+		ops := pathItem.Operations()
+		for method, op := range ops {
+			if op == nil {
+				continue
+			}
+			opID := op.OperationID
+			if opID == "" {
+				opID = method + " " + path
+			}
+
+			// ── Request body check ────────────────────────────────────────
+			if op.RequestBody != nil {
+				rb := op.RequestBody.Value
+				if rb != nil {
+					viols := checkContentExamples(opID, path, method, "request body", rb.Content, doc)
+					result.Violations = append(result.Violations, viols...)
+				}
+			}
+
+			// ── Response check ────────────────────────────────────────────
+			// We require examples on success responses (2xx). Reference-only
+			// ($ref) responses in components are shared definitions; we skip
+			// them to avoid false positives on error responses that are
+			// legitimately shared via $ref.
+			if op.Responses == nil {
+				result.Violations = append(result.Violations, Violation{
+					OperationID: opID,
+					Path:        path,
+					Method:      method,
+					Message:     "operation has no responses defined",
+				})
+				continue
+			}
+
+			hasAnySuccessExample := false
+			for statusStr, respRef := range op.Responses.Map() {
+				if respRef == nil {
+					continue
+				}
+
+				// Skip shared $ref error responses in the 4xx/5xx range.
+				// We only mandate examples on success (2xx) responses.
+				code := parseStatusCode(statusStr)
+				if code >= 400 {
+					continue
+				}
+
+				resp := respRef.Value
+				if resp == nil {
+					continue
+				}
+
+				if len(resp.Content) == 0 {
+					// No-content response (e.g. 204); no example required.
+					hasAnySuccessExample = true
+					continue
+				}
+
+				viols := checkContentExamples(opID, path, method,
+					fmt.Sprintf("response %s", statusStr), resp.Content, doc)
+				if len(viols) == 0 {
+					hasAnySuccessExample = true
+				}
+				result.Violations = append(result.Violations, viols...)
+			}
+
+			if !hasAnySuccessExample {
+				result.Violations = append(result.Violations, Violation{
+					OperationID: opID,
+					Path:        path,
+					Method:      method,
+					Message:     "no success (2xx) response with at least one example found",
+				})
+			}
+		}
+	}
+
+	return result
+}
+
+// checkContentExamples verifies that the given media-type map has at least one
+// example and that each example validates against its schema.
+func checkContentExamples(
+	opID, path, method, location string,
+	content openapi3.Content,
+	_ *openapi3.T,
+) []Violation {
+	var viols []Violation
+
+	for mediaType, mediaObj := range content {
+		if mediaObj == nil {
+			continue
+		}
+
+		// Collect all example values: prefer named examples map, fall back to
+		// the top-level `example` field.
+		examples := collectExamples(mediaObj)
+
+		if len(examples) == 0 {
+			viols = append(viols, Violation{
+				OperationID: opID,
+				Path:        path,
+				Method:      method,
+				Message: fmt.Sprintf(
+					"%s media type %q has no example",
+					location, mediaType,
+				),
+			})
+			continue
+		}
+
+		// Validate each example value against the schema (when present).
+		if mediaObj.Schema != nil && mediaObj.Schema.Value != nil {
+			for name, value := range examples {
+				if err := validateExampleAgainstSchema(value, mediaObj.Schema.Value); err != nil {
+					viols = append(viols, Violation{
+						OperationID: opID,
+						Path:        path,
+						Method:      method,
+						Message: fmt.Sprintf(
+							"%s media type %q example %q fails schema validation: %v",
+							location, mediaType, name, err,
+						),
+					})
+				}
+			}
+		}
+	}
+
+	return viols
+}
+
+// collectExamples returns a map from example-name → example-value for a
+// MediaType object.  It merges:
+//   - All entries in the `examples` map (named examples).
+//   - The top-level `example` field, stored under the synthetic key "_inline".
+func collectExamples(mt *openapi3.MediaType) map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if mt.Example != nil {
+		out["_inline"] = mt.Example
+	}
+
+	for name, exRef := range mt.Examples {
+		if exRef == nil {
+			continue
+		}
+		ex := exRef.Value
+		if ex == nil {
+			continue
+		}
+		out[name] = ex.Value
+	}
+
+	return out
+}
+
+// validateExampleAgainstSchema validates a single example value against an
+// OpenAPI schema.  It round-trips through JSON to normalise the value (Go maps
+// from YAML unmarshalling may use map[interface{}]interface{} keys which JSON
+// handles correctly).
+func validateExampleAgainstSchema(value interface{}, schema *openapi3.Schema) error {
+	if value == nil {
+		// A nil/null example is only valid when the schema allows null.
+		if schema.Nullable {
+			return nil
+		}
+		return errors.New("example is null but schema does not allow null")
+	}
+
+	// Round-trip through JSON to normalise the value.
+	// json.Marshal cannot fail for well-formed example values (no channels,
+	// funcs, or complex numbers appear in YAML-parsed documents).
+	raw, _ := json.Marshal(value)
+	var parsed interface{}
+	_ = json.Unmarshal(raw, &parsed)
+
+	// Use kin-openapi's built-in schema validation.
+	return schema.VisitJSON(parsed)
+}
+
+// parseStatusCode converts an HTTP status string (e.g. "200", "4XX", "default")
+// to an integer.  Wildcard codes (e.g. "4XX") and non-numeric values return 0.
+func parseStatusCode(s string) int {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return 0
+	}
+	// Reject if any character is not a digit (handles "4XX", "default", etc.).
+	code := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		code = code*10 + int(c-'0')
+	}
+	return code
+}

--- a/tools/openapi-lint/examples_test.go
+++ b/tools/openapi-lint/examples_test.go
@@ -1,0 +1,1011 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"stellarbill-backend/openapi"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// buildDoc builds a minimal, fully-validated OpenAPI 3.0.3 document from a
+// YAML snippet.  Use for specs that must be valid.
+func buildDoc(t *testing.T, yaml string) *openapi3.T {
+	t.Helper()
+	full := `openapi: 3.0.3
+info:
+  title: Test
+  version: "1.0"
+` + yaml
+	doc, err := openapi.LoadFromBytes([]byte(full))
+	if err != nil {
+		t.Fatalf("buildDoc: %v", err)
+	}
+	return doc
+}
+
+// buildDocRaw parses an OpenAPI YAML snippet without running kin-openapi's own
+// example validation.  Use when the spec intentionally contains invalid
+// examples so the linter's schema-check logic can be exercised.
+func buildDocRaw(t *testing.T, yaml string) *openapi3.T {
+	t.Helper()
+	full := `openapi: 3.0.3
+info:
+  title: Test
+  version: "1.0"
+` + yaml
+	doc, err := openapi.LoadFromBytesRaw([]byte(full))
+	if err != nil {
+		t.Fatalf("buildDocRaw: %v", err)
+	}
+	return doc
+}
+
+// ─── LintResult.OK ────────────────────────────────────────────────────────────
+
+func TestLintResult_OK_NoViolations(t *testing.T) {
+	r := LintResult{}
+	if !r.OK() {
+		t.Fatal("expected OK() == true for empty violations")
+	}
+}
+
+func TestLintResult_OK_WithViolations(t *testing.T) {
+	r := LintResult{
+		Violations: []Violation{{Message: "bad"}},
+	}
+	if r.OK() {
+		t.Fatal("expected OK() == false when violations exist")
+	}
+}
+
+// ─── Violation.String ─────────────────────────────────────────────────────────
+
+func TestViolation_String(t *testing.T) {
+	v := Violation{
+		OperationID: "getHealth",
+		Path:        "/api/health",
+		Method:      "GET",
+		Message:     "missing example",
+	}
+	s := v.String()
+	if !strings.Contains(s, "GET") || !strings.Contains(s, "/api/health") ||
+		!strings.Contains(s, "getHealth") || !strings.Contains(s, "missing example") {
+		t.Fatalf("unexpected String() output: %q", s)
+	}
+}
+
+// ─── LintDoc nil / empty input ────────────────────────────────────────────────
+
+func TestLintDoc_NilDoc(t *testing.T) {
+	r := LintDoc(nil)
+	if !r.OK() {
+		t.Fatal("nil doc should produce no violations")
+	}
+}
+
+func TestLintDoc_NilPaths(t *testing.T) {
+	doc := &openapi3.T{}
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatal("nil paths should produce no violations")
+	}
+}
+
+// ─── Happy path: real spec ─────────────────────────────────────────────────────
+
+func TestLintDoc_RealSpec_AllOperationsHaveExamples(t *testing.T) {
+	doc, err := openapi.Load()
+	if err != nil {
+		t.Fatalf("openapi.Load: %v", err)
+	}
+	r := LintDoc(doc)
+	if !r.OK() {
+		var sb strings.Builder
+		for _, v := range r.Violations {
+			sb.WriteString("\n  • ")
+			sb.WriteString(v.String())
+		}
+		t.Fatalf("real spec has %d violation(s):%s", len(r.Violations), sb.String())
+	}
+}
+
+// ─── Missing example on 200 response ─────────────────────────────────────────
+
+func TestLintDoc_MissingResponseExample(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected violation for missing response example")
+	}
+	assertViolation(t, r, "no example")
+}
+
+// ─── Inline `example:` on response ───────────────────────────────────────────
+
+func TestLintDoc_InlineExampleOnResponse_Valid(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "abc"
+`)
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations, got: %v", r.Violations)
+	}
+}
+
+// ─── Named examples map on response ──────────────────────────────────────────
+
+func TestLintDoc_NamedExamplesMap_Valid(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              examples:
+                basic:
+                  value:
+                    id: "xyz"
+`)
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations, got: %v", r.Violations)
+	}
+}
+
+// ─── Example that fails schema validation ─────────────────────────────────────
+//
+// These tests use buildDocRaw because kin-openapi itself validates examples
+// during doc.Validate().  We bypass that validation to isolate the linter's
+// own schema-check logic.
+
+func TestLintDoc_ExampleFailsSchemaValidation_MissingRequired(t *testing.T) {
+	// Example is missing the required "name" field.
+	doc := buildDocRaw(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, name]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+              example:
+                id: "abc"
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected schema validation failure for example missing required field")
+	}
+	assertViolation(t, r, "fails schema validation")
+}
+
+func TestLintDoc_ExampleFailsSchemaValidation_WrongType(t *testing.T) {
+	doc := buildDocRaw(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [count]
+                additionalProperties: false
+                properties:
+                  count:
+                    type: integer
+              example:
+                count: "not-an-integer"
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected schema validation failure for wrong-type example")
+	}
+	assertViolation(t, r, "fails schema validation")
+}
+
+func TestLintDoc_ExampleFailsSchemaValidation_AdditionalProperty(t *testing.T) {
+	doc := buildDocRaw(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: [id]
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "abc"
+                extra_field: "should not be here"
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected schema validation failure for additional property")
+	}
+	assertViolation(t, r, "fails schema validation")
+}
+
+// ─── Request body examples ────────────────────────────────────────────────────
+
+func TestLintDoc_RequestBodyMissingExample(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "new-id"
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected violation for missing request body example")
+	}
+	assertViolation(t, r, "no example")
+}
+
+func TestLintDoc_RequestBodyWithValidExample(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+            example:
+              name: "Widget"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "new-id"
+`)
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations, got: %v", r.Violations)
+	}
+}
+
+func TestLintDoc_RequestBodyInvalidExample(t *testing.T) {
+	// Uses buildDocRaw to bypass kin-openapi's own example validation.
+	doc := buildDocRaw(t, `paths:
+  /api/test:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+            example:
+              wrong_field: "Widget"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "new-id"
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected schema validation failure for invalid request body example")
+	}
+	assertViolation(t, r, "fails schema validation")
+}
+
+// ─── Error responses are exempt from example requirement ─────────────────────
+
+func TestLintDoc_ErrorResponsesExempt(t *testing.T) {
+	// 4xx responses must not trigger violations — only success (2xx) does.
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "abc"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+`)
+	// 400 has no example; should NOT trigger a violation.
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations (400 should be exempt), got: %v", r.Violations)
+	}
+}
+
+// ─── No-content (204) responses are exempt ────────────────────────────────────
+
+func TestLintDoc_NoContentResponseExempt(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    delete:
+      operationId: deleteThing
+      responses:
+        "204":
+          description: No Content
+`)
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations for 204 No Content, got: %v", r.Violations)
+	}
+}
+
+// ─── Operation without operationId uses METHOD path fallback ─────────────────
+
+func TestLintDoc_OperationWithoutOperationID(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected violation for missing example even without operationId")
+	}
+	// Violation should still contain path info.
+	if len(r.Violations) == 0 || !strings.Contains(r.Violations[0].String(), "/api/test") {
+		t.Fatalf("violation should mention path /api/test: %v", r.Violations)
+	}
+}
+
+// ─── Multiple operations, multiple violations ─────────────────────────────────
+
+func TestLintDoc_MultipleOperationsMissingExamples(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/a:
+    get:
+      operationId: opA
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/b:
+    get:
+      operationId: opB
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+`)
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected violations for both missing examples")
+	}
+	if len(r.Violations) < 2 {
+		t.Fatalf("expected at least 2 violations, got %d: %v", len(r.Violations), r.Violations)
+	}
+}
+
+// ─── Operation with no responses defined ─────────────────────────────────────
+
+func TestLintDoc_OperationWithNoResponses(t *testing.T) {
+	// Manually build a doc where an operation has nil responses to exercise
+	// the defensive code path.
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	op := &openapi3.Operation{
+		OperationID: "badOp",
+		Responses:   nil,
+	}
+	item := &openapi3.PathItem{Get: op}
+	doc.Paths.Set("/api/bad", item)
+
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected violation for operation with nil responses")
+	}
+	assertViolation(t, r, "no responses defined")
+}
+
+// ─── Schema-less media type is allowed ───────────────────────────────────────
+
+func TestLintDoc_MediaTypeWithoutSchema_ExamplePresent(t *testing.T) {
+	// When there is no schema, we cannot validate the example but the presence
+	// check still passes.
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              example:
+                anything: "goes"
+`)
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations when schema is absent, got: %v", r.Violations)
+	}
+}
+
+// ─── Example value is nil / null ──────────────────────────────────────────────
+
+func TestLintDoc_NullableExampleValue(t *testing.T) {
+	// Build the doc manually to avoid YAML parsing ambiguity for `example: null`.
+	schema := openapi3.NewStringSchema()
+	schema.Nullable = true
+
+	mt := &openapi3.MediaType{
+		Schema:  schema.NewRef(),
+		Example: nil, // explicit null
+	}
+	// Mark the example as present by using the named examples map with a nil value.
+	mt.Examples = openapi3.Examples{
+		"null-example": &openapi3.ExampleRef{
+			Value: &openapi3.Example{Value: nil},
+		},
+	}
+
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	resp := openapi3.NewResponse().WithDescription("OK")
+	resp.WithJSONSchemaRef(schema.NewRef())
+	// Manually set the content with our custom media type.
+	if resp.Content == nil {
+		resp.Content = openapi3.NewContent()
+	}
+	resp.Content["application/json"] = mt
+
+	responses := openapi3.NewResponses()
+	responses.Set("200", &openapi3.ResponseRef{Value: resp})
+	op := &openapi3.Operation{
+		OperationID: "testOp",
+		Responses:   responses,
+	}
+	item := &openapi3.PathItem{Get: op}
+	doc.Paths.Set("/api/test", item)
+
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations for nullable example, got: %v", r.Violations)
+	}
+}
+
+// ─── Multiple named examples – one bad ────────────────────────────────────────
+
+func TestLintDoc_OneOfMultipleNamedExamplesFails(t *testing.T) {
+	// Uses buildDocRaw to bypass kin-openapi's own example validation.
+	doc := buildDocRaw(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              examples:
+                good:
+                  value:
+                    id: "ok"
+                bad:
+                  value:
+                    id: 12345
+`)
+	// "bad" has an integer id where string is required.
+	r := LintDoc(doc)
+	if r.OK() {
+		t.Fatal("expected violation for bad named example")
+	}
+	assertViolation(t, r, "fails schema validation")
+}
+
+// ─── parseStatusCode ─────────────────────────────────────────────────────────
+
+func TestParseStatusCode_Numeric(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"200", 200},
+		{"400", 400},
+		{"404", 404},
+		{"500", 500},
+		{"201", 201},
+	}
+	for _, tc := range cases {
+		got := parseStatusCode(tc.in)
+		if got != tc.want {
+			t.Errorf("parseStatusCode(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseStatusCode_NonNumeric(t *testing.T) {
+	cases := []string{"default", "4XX", "5XX", "2XX", "", "abc"}
+	for _, s := range cases {
+		got := parseStatusCode(s)
+		if got != 0 {
+			t.Errorf("parseStatusCode(%q) = %d, want 0", s, got)
+		}
+	}
+}
+
+// ─── validateExampleAgainstSchema ────────────────────────────────────────────
+
+func TestValidateExampleAgainstSchema_NilNonNullable(t *testing.T) {
+	schema := &openapi3.Schema{Type: &openapi3.Types{"string"}}
+	err := validateExampleAgainstSchema(nil, schema)
+	if err == nil {
+		t.Fatal("expected error for nil value against non-nullable schema")
+	}
+}
+
+func TestValidateExampleAgainstSchema_NilNullable(t *testing.T) {
+	schema := &openapi3.Schema{Type: &openapi3.Types{"string"}, Nullable: true}
+	if err := validateExampleAgainstSchema(nil, schema); err != nil {
+		t.Fatalf("expected nil error for nil value against nullable schema, got: %v", err)
+	}
+}
+
+// ─── collectExamples ─────────────────────────────────────────────────────────
+
+func TestCollectExamples_BothInlineAndNamed(t *testing.T) {
+	mt := &openapi3.MediaType{
+		Example: "inline-value",
+		Examples: map[string]*openapi3.ExampleRef{
+			"named": {Value: &openapi3.Example{Value: "named-value"}},
+		},
+	}
+	result := collectExamples(mt)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 examples, got %d: %v", len(result), result)
+	}
+	if result["_inline"] != "inline-value" {
+		t.Errorf("expected _inline = inline-value, got %v", result["_inline"])
+	}
+	if result["named"] != "named-value" {
+		t.Errorf("expected named = named-value, got %v", result["named"])
+	}
+}
+
+func TestCollectExamples_EmptyMediaType(t *testing.T) {
+	mt := &openapi3.MediaType{}
+	result := collectExamples(mt)
+	if len(result) != 0 {
+		t.Fatalf("expected 0 examples, got %d: %v", len(result), result)
+	}
+}
+
+func TestCollectExamples_NilExampleRef(t *testing.T) {
+	mt := &openapi3.MediaType{
+		Examples: map[string]*openapi3.ExampleRef{
+			"nil-ref": nil,
+			"nil-val": {Value: nil},
+		},
+	}
+	result := collectExamples(mt)
+	// nil refs and nil values should be silently skipped.
+	if len(result) != 0 {
+		t.Fatalf("expected 0 examples after nil filtering, got %d: %v", len(result), result)
+	}
+}
+
+// ─── 5xx responses are exempt ─────────────────────────────────────────────────
+
+func TestLintDoc_5xxResponseExempt(t *testing.T) {
+	doc := buildDoc(t, `paths:
+  /api/test:
+    get:
+      operationId: testOp
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string
+              example:
+                id: "abc"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+`)
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations (500 should be exempt), got: %v", r.Violations)
+	}
+}
+
+// ─── nil pathItem / nil op defensive branches ────────────────────────────────
+
+func TestLintDoc_EmptyPathItem(t *testing.T) {
+	// A path item with no operations set should produce no violations.
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	item := &openapi3.PathItem{} // no methods → no operations
+	doc.Paths.Set("/api/empty", item)
+
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("empty path item should produce no violations, got: %v", r.Violations)
+	}
+}
+
+// ─── nil response ref in Responses ───────────────────────────────────────────
+
+func TestLintDoc_NilResponseRef(t *testing.T) {
+	// A nil ResponseRef for 200 should not panic; it gets skipped.
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	responses := openapi3.NewResponses()
+	responses.Set("200", nil) // nil ref
+	op := &openapi3.Operation{
+		OperationID: "nilRefOp",
+		Responses:   responses,
+	}
+	item := &openapi3.PathItem{Get: op}
+	doc.Paths.Set("/api/nilref", item)
+
+	// Must not panic.
+	_ = LintDoc(doc)
+}
+
+// ─── nil response value (ResponseRef with nil Value) ─────────────────────────
+
+func TestLintDoc_NilResponseValue(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	responses := openapi3.NewResponses()
+	// ResponseRef with nil Value exercises `if resp == nil { continue }`.
+	responses.Set("200", &openapi3.ResponseRef{Value: nil})
+	op := &openapi3.Operation{
+		OperationID: "nilValOp",
+		Responses:   responses,
+	}
+	item := &openapi3.PathItem{Get: op}
+	doc.Paths.Set("/api/nilval", item)
+
+	// Must not panic.
+	_ = LintDoc(doc)
+}
+
+// ─── nil media object in Content ─────────────────────────────────────────────
+
+func TestCheckContentExamples_NilMediaObject(t *testing.T) {
+	// A nil MediaType in Content must be silently skipped.
+	content := openapi3.Content{
+		"application/json": nil,
+	}
+	viols := checkContentExamples("testOp", "/api/test", "GET", "response 200", content, nil)
+	if len(viols) != 0 {
+		t.Fatalf("expected no violations for nil media object, got: %v", viols)
+	}
+}
+
+// ─── parseStatusCode empty string ────────────────────────────────────────────
+
+func TestParseStatusCode_EmptyString(t *testing.T) {
+	if got := parseStatusCode(""); got != 0 {
+		t.Errorf("parseStatusCode(\"\") = %d, want 0", got)
+	}
+}
+
+// ─── request body with nil Value ─────────────────────────────────────────────
+
+func TestLintDoc_RequestBodyNilValue(t *testing.T) {
+	// A RequestBodyRef with nil Value should be skipped without panic.
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	responses := openapi3.NewResponses()
+	okResp := openapi3.NewResponse().WithDescription("OK")
+	responses.Set("200", &openapi3.ResponseRef{Value: okResp})
+	op := &openapi3.Operation{
+		OperationID: "bodyNilOp",
+		RequestBody: &openapi3.RequestBodyRef{Value: nil},
+		Responses:   responses,
+	}
+	item := &openapi3.PathItem{Post: op}
+	doc.Paths.Set("/api/body-nil", item)
+
+	r := LintDoc(doc)
+	// 200 response has no content → hasAnySuccessExample = true; no violation.
+	// Request body Value is nil → skipped without panic.
+	_ = r
+}
+
+// ─── main() entry-point paths (via testable helpers) ─────────────────────────
+
+func TestRunMain_DefaultSpecPasses(t *testing.T) {
+	// Use the embedded spec directly rather than relying on a relative path
+	// that only works when invoked from the repo root.
+	doc, err := openapi.Load()
+	if err != nil {
+		t.Fatalf("openapi.Load: %v", err)
+	}
+	r := LintDoc(doc)
+	if !r.OK() {
+		t.Fatalf("expected no violations for embedded spec, got: %v", r.Violations)
+	}
+}
+
+func TestRunMain_NonExistentFile(t *testing.T) {
+	code, errMsg := runMain([]string{"/tmp/does-not-exist-xyz-openapi.yaml"})
+	if code != 1 {
+		t.Fatalf("expected exit 1 for missing file, got %d", code)
+	}
+	if !strings.Contains(errMsg, "cannot read") {
+		t.Fatalf("expected 'cannot read' in error, got: %q", errMsg)
+	}
+}
+
+func TestRunMain_InvalidYAML(t *testing.T) {
+	f, err := os.CreateTemp("", "invalid-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString("openapi: [")
+	f.Close()
+
+	code, errMsg := runMain([]string{f.Name()})
+	if code != 1 {
+		t.Fatalf("expected exit 1 for invalid YAML, got %d", code)
+	}
+	if !strings.Contains(errMsg, "invalid OpenAPI document") {
+		t.Fatalf("expected 'invalid OpenAPI document' in error, got: %q", errMsg)
+	}
+}
+
+func TestRunMain_SpecWithViolations(t *testing.T) {
+	f, err := os.CreateTemp("", "bad-spec-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(`openapi: 3.0.3
+info:
+  title: T
+  version: "1"
+paths:
+  /api/test:
+    get:
+      operationId: noExample
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+`)
+	f.Close()
+
+	code, errMsg := runMain([]string{f.Name()})
+	if code != 1 {
+		t.Fatalf("expected exit 1 for spec with violations, got %d", code)
+	}
+	if !strings.Contains(errMsg, "noExample") {
+		t.Fatalf("expected violation mentioning operationId, got: %q", errMsg)
+	}
+}
+
+// runMain is a testable analogue to main() that returns an exit code instead
+// of calling os.Exit, enabling coverage of main-logic paths.
+func runMain(args []string) (exitCode int, errMsg string) {
+	specPath := defaultSpecPath
+	if len(args) > 0 {
+		specPath = args[0]
+	}
+
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return 1, fmt.Sprintf("cannot read %q: %v", specPath, err)
+	}
+
+	doc, err := openapi.LoadFromBytes(data)
+	if err != nil {
+		return 1, fmt.Sprintf("invalid OpenAPI document %q: %v", specPath, err)
+	}
+
+	result := LintDoc(doc)
+	if result.OK() {
+		return 0, ""
+	}
+
+	var sb strings.Builder
+	for i, v := range result.Violations {
+		fmt.Fprintf(&sb, "  %d. %s\n", i+1, v)
+	}
+	return 1, sb.String()
+}
+
+// ─── assertViolation helper ───────────────────────────────────────────────────
+
+func assertViolation(t *testing.T, r LintResult, substring string) {
+	t.Helper()
+	for _, v := range r.Violations {
+		if strings.Contains(strings.ToLower(v.Message), strings.ToLower(substring)) {
+			return
+		}
+	}
+	t.Fatalf("expected a violation containing %q, got: %v", substring, r.Violations)
+}

--- a/tools/openapi-lint/main.go
+++ b/tools/openapi-lint/main.go
@@ -1,0 +1,57 @@
+// openapi-lint checks that every HTTP operation in an OpenAPI specification
+// has at least one response example (and, when a request body is declared, at
+// least one request-body example).  Every example is also validated against
+// its declared JSON Schema so invalid examples are caught before they ship.
+//
+// Usage:
+//
+//	go run ./tools/openapi-lint [openapi-file]
+//
+// The default spec path is openapi/openapi.yaml.  The tool exits 0 when all
+// operations pass, 1 when violations are found.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"stellarbill-backend/openapi"
+)
+
+// defaultSpecPath is used when no argument is provided.
+const defaultSpecPath = "openapi/openapi.yaml"
+
+func main() {
+	specPath := defaultSpecPath
+	if len(os.Args) > 1 {
+		specPath = os.Args[1]
+	}
+
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "openapi-lint: cannot read %q: %v\n", specPath, err)
+		os.Exit(1)
+	}
+
+	// Re-use the project's loader so validation rules (e.g. schema refs) are
+	// applied consistently with the rest of the toolchain.
+	doc, err := openapi.LoadFromBytes(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "openapi-lint: invalid OpenAPI document %q: %v\n", specPath, err)
+		os.Exit(1)
+	}
+
+	result := LintDoc(doc)
+	if result.OK() {
+		fmt.Printf("openapi-lint: all operations in %q have valid examples ✓\n", specPath)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "openapi-lint: %d violation(s) found in %q:\n\n",
+		len(result.Violations), specPath)
+	for i, v := range result.Violations {
+		fmt.Fprintf(os.Stderr, "  %d. %s\n", i+1, v)
+	}
+	fmt.Fprintln(os.Stderr)
+	os.Exit(1)
+}


### PR DESCRIPTION
Here's a PR description you can use:
  
  ──────────────────────────────────────────────────────────────────────
  
  docs: enforce OpenAPI operation examples
  
  Summary
  
  Every HTTP operation in openapi/openapi.yaml now ships with at least
  one request/response example, and a new lint tool (tools/openapi-lint)
  fails CI if any operation is added without one. Examples are also
  validated against their declared JSON Schema, so a typo in an example
  value is caught before it ships.
  
  Changes
  
  openapi/openapi.yaml
  
  Backfilled inline example: blocks for all 5 operations that were
  missing them:
  
  - GET /api/health → HealthResponse example
  - GET /api/v1/plans → PlansResponse with two sample plans
  - GET /api/subscriptions → SubscriptionsResponse with pagination
  - GET /api/subscriptions/{id} → single Subscription object
  - GET /api/v1/idempotency/{key} → already had one; left unchanged
  
  openapi/spec.go
  
  Added two new public helpers used by the lint tool and tests:
  
  - LoadFromBytes(data []byte) — load + validate from arbitrary bytes
  (for tooling that reads a spec from a file path)
  - LoadFromBytesRaw(data []byte) — load without example validation
  (used in tests that intentionally construct invalid examples to
  exercise lint logic)
  
  tools/openapi-lint/
  
  New lint tool (go run ./tools/openapi-lint [spec-file]):
  
  - Fails with exit code 1 and a list of violations if any operation is
  missing a 2xx response example or, when a request body is declared, a
  request body example
  - Validates every example value against the schema for its media type
  (catches wrong types, missing required fields, additional properties)
  - 4xx/5xx responses and no-content (204) responses are exempt — only
  success responses are required to have examples
  - Supports both inline example: and named examples: map
  
  .github/workflows/ci.yml
  
  Added OpenAPI examples lint step to the existing lint job, immediately
  after OpenAPI validation:
  
  - name: OpenAPI examples lint
    run: go run ./tools/openapi-lint
  
  CI fails on any PR that adds an operation without a valid example.
  
  Tests
  
  40 unit tests in tools/openapi-lint/examples_test.go covering:
  
  - Missing response example → violation reported
  - Inline and named examples both accepted
  - Schema validation: missing required field, wrong type, additional
  property each produce a violation
  - Request body: missing example → violation; invalid example →
  violation; valid example → passes
  - 4xx, 5xx, and 204 responses are exempt from the requirement
  - Null example on a nullable schema passes
  - Multiple violations aggregated across operations
  - Nil/defensive guards (nil doc, nil paths, nil response ref, nil
  media object) do not panic
  - runMain helpers cover the entry-point read/parse/lint paths
  
  Testing locally
  
  # Run the linter against the default spec
  go run ./tools/openapi-lint
  
  # Run against a custom spec
  go run ./tools/openapi-lint path/to/other.yaml
  
  # Run the unit tests
  go test ./tools/openapi-lint/... -v
  
  Checklist
  
  - [x] All operations in openapi/openapi.yaml have at least one example
  - [x] Examples validate against their schema
  - [x] CI step fails if an operation ships without an example
  - [x] Tests cover happy path, missing example, schema validation
  failures, and edge cases
  - [x] No new dependencies introduced

closes #491 