### PR TITLE
feat: automate monthly partition rollover for statements

### DIFF
--- a/internal/worker/partition_rollover_job.go
+++ b/internal/worker/partition_rollover_job.go
@@ -1,0 +1,530 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"stellarbill-backend/internal/timeutil"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// PartitionRolloverConfig configures the monthly partition rollover job for
+// the statements_partitioned table.
+type PartitionRolloverConfig struct {
+	// PollInterval: how often the rollover job runs (default: 24h).
+	PollInterval time.Duration
+	// RolloverTimeout: context timeout for a single rollover run (default: 5m).
+	RolloverTimeout time.Duration
+	// ShutdownTimeout: max time to wait for in-flight work on Stop() (default: 30s).
+	ShutdownTimeout time.Duration
+	// LookaheadMonths: how many future partitions to create in advance (default: 1).
+	LookaheadMonths int
+	// DetachThresholdMonths: partitions older than this many months are detached
+	// (default: 24). Set to 0 to disable detachment.
+	DetachThresholdMonths int
+	// ParentTable: the name of the partitioned parent table (default: "statements_partitioned").
+	ParentTable string
+	// PartitionPrefix: prefix for partition names (default: "statements_p").
+	PartitionPrefix string
+	// Cooldown: minimum interval between runs for idempotency (default: 1h).
+	Cooldown time.Duration
+}
+
+// DefaultPartitionRolloverConfig returns production-safe defaults for the
+// monthly partition rollover job.
+func DefaultPartitionRolloverConfig() PartitionRolloverConfig {
+	return PartitionRolloverConfig{
+		PollInterval:           24 * time.Hour,
+		RolloverTimeout:        5 * time.Minute,
+		ShutdownTimeout:        30 * time.Second,
+		LookaheadMonths:        1,
+		DetachThresholdMonths:  24,
+		ParentTable:            "statements_partitioned",
+		PartitionPrefix:        "statements_p",
+		Cooldown:               1 * time.Hour,
+	}
+}
+
+// withDefaults fills zero-valued fields with sensible defaults so callers can
+// override only what they care about.
+func (c PartitionRolloverConfig) withDefaults() PartitionRolloverConfig {
+	d := DefaultPartitionRolloverConfig()
+	if c.PollInterval <= 0 {
+		c.PollInterval = d.PollInterval
+	}
+	if c.RolloverTimeout <= 0 {
+		c.RolloverTimeout = d.RolloverTimeout
+	}
+	if c.ShutdownTimeout <= 0 {
+		c.ShutdownTimeout = d.ShutdownTimeout
+	}
+	if c.LookaheadMonths <= 0 {
+		c.LookaheadMonths = d.LookaheadMonths
+	}
+	if c.DetachThresholdMonths <= 0 {
+		c.DetachThresholdMonths = d.DetachThresholdMonths
+	}
+	if c.ParentTable == "" {
+		c.ParentTable = d.ParentTable
+	}
+	if c.PartitionPrefix == "" {
+		c.PartitionPrefix = d.PartitionPrefix
+	}
+	if c.Cooldown <= 0 {
+		c.Cooldown = d.Cooldown
+	}
+	return c
+}
+
+// partitionRolloverStore abstracts the database operations the rollover job needs.
+type partitionRolloverStore interface {
+	// LastRolloverAt returns the recorded last rollover time. ok is false when
+	// the job has never run (the seeded row at epoch).
+	LastRolloverAt(ctx context.Context) (at time.Time, ok bool, err error)
+	// MarkRolloverDone records the moment the rollover last completed.
+	MarkRolloverDone(ctx context.Context, at time.Time) error
+	// PartitionExists checks whether a partition with the given name exists
+	// in pg_catalog under the parent table.
+	PartitionExists(ctx context.Context, parentTable, partitionName string) (bool, error)
+	// CreatePartition adds a new monthly partition to the parent table.
+	CreatePartition(ctx context.Context, parentTable, partitionName, fromDate, toDate string) error
+	// DetachPartition detaches a partition from the parent table, converting it
+	// to a standalone table.
+	DetachPartition(ctx context.Context, parentTable, partitionName string) error
+	// ListPartitions returns the names of all partitions belonging to the parent.
+	ListPartitions(ctx context.Context, parentTable string) ([]string, error)
+}
+
+// PartitionRolloverJob creates next-month partitions and detaches partitions
+// older than the archival threshold. This prevents outages when the statements
+// partition graph runs out of children.
+//
+// The job is idempotent and safe to run more than once per hour. It tracks
+// its last successful run time in the partition_rollover_state table and
+// skips if the cooldown period has not elapsed.
+type PartitionRolloverJob struct {
+	store  partitionRolloverStore
+	config PartitionRolloverConfig
+	logger partitionRolloverLogger
+	clock  timeutil.Clock
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	running atomic.Int32
+
+	// stats
+	mu              sync.RWMutex
+	rolloverCount   int64
+	failedCount     int64
+	partitionsAdded int64
+	partitionsGone  int64
+	lastRunTime     time.Time
+	lastRunError    error
+	consecutiveErrs int
+}
+
+// partitionRolloverLogger is the minimal logging surface the rollover job
+// needs. A nil logger is accepted and simply disables logging.
+type partitionRolloverLogger interface {
+	Error(msg string, keysAndValues ...any)
+}
+
+// partitionRolloverMetrics are lazily registered Prometheus metrics for the
+// partition rollover job.
+var (
+	partitionCreatedTotal  prometheus.Counter
+	partitionDetachedTotal prometheus.Counter
+	partitionMetricsOnce   sync.Once
+)
+
+func initPartitionMetrics() {
+	partitionMetricsOnce.Do(func() {
+		partitionCreatedTotal = promauto.NewCounter(prometheus.CounterOpts{
+			Name: "partition_created_total",
+			Help: "Total number of monthly partitions created for the statements table",
+		})
+		partitionDetachedTotal = promauto.NewCounter(prometheus.CounterOpts{
+			Name: "partition_detached_total",
+			Help: "Total number of monthly partitions detached from the statements table",
+		})
+	})
+}
+
+// NewPartitionRolloverJob creates a new partition rollover job backed by the
+// given database connection.
+func NewPartitionRolloverJob(db *sql.DB, config PartitionRolloverConfig, l partitionRolloverLogger) *PartitionRolloverJob {
+	initPartitionMetrics()
+	return newPartitionRolloverJob(&sqlPartitionRolloverStore{db: db}, config, l)
+}
+
+// newPartitionRolloverJob is the store-injecting constructor used by tests.
+func newPartitionRolloverJob(store partitionRolloverStore, config PartitionRolloverConfig, l partitionRolloverLogger) *PartitionRolloverJob {
+	return &PartitionRolloverJob{
+		store:  store,
+		config: config.withDefaults(),
+		logger: l,
+		clock:  timeutil.SystemClock,
+	}
+}
+
+// SetClock overrides the job's time source so partition boundary and cooldown
+// behavior can be tested deterministically. Call before Start(); production
+// callers should leave the default SystemClock in place.
+func (j *PartitionRolloverJob) SetClock(c timeutil.Clock) {
+	j.clock = c
+}
+
+// Start begins the rollover loop. It is safe to call Start only once.
+func (j *PartitionRolloverJob) Start() {
+	j.ctx, j.cancel = context.WithCancel(context.Background())
+	j.running.Store(1)
+
+	j.wg.Add(1)
+	go j.rolloverLoop()
+}
+
+// Stop signals the rollover loop to exit and waits up to ShutdownTimeout for
+// in-flight work to drain.
+func (j *PartitionRolloverJob) Stop() error {
+	if j.cancel == nil {
+		return nil
+	}
+	j.cancel()
+
+	done := make(chan struct{})
+	go func() {
+		j.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		j.running.Store(0)
+		return nil
+	case <-time.After(j.config.ShutdownTimeout):
+		j.running.Store(0)
+		return fmt.Errorf("partition rollover job shutdown timed out after %v", j.config.ShutdownTimeout)
+	}
+}
+
+// Health returns nil if the job is running and not stuck in a failure loop.
+func (j *PartitionRolloverJob) Health() error {
+	if j.running.Load() != 1 {
+		return errors.New("partition rollover job is not running")
+	}
+
+	j.mu.RLock()
+	consec := j.consecutiveErrs
+	j.mu.RUnlock()
+
+	if consec > 5 {
+		return fmt.Errorf("partition rollover job has %d consecutive errors", consec)
+	}
+	return nil
+}
+
+// PartitionRolloverStats reports rollover job statistics.
+type PartitionRolloverStats struct {
+	RolloverCount   int64
+	PartitionsAdded int64
+	PartitionsGone  int64
+	LastRunTime     time.Time
+	LastRunError    string
+	ConsecutiveErr  int
+}
+
+// GetStats returns a snapshot of the job's statistics.
+func (j *PartitionRolloverJob) GetStats() PartitionRolloverStats {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+
+	errMsg := ""
+	if j.lastRunError != nil {
+		errMsg = j.lastRunError.Error()
+	}
+	return PartitionRolloverStats{
+		RolloverCount:   j.rolloverCount,
+		PartitionsAdded: j.partitionsAdded,
+		PartitionsGone:  j.partitionsGone,
+		LastRunTime:     j.lastRunTime,
+		LastRunError:    errMsg,
+		ConsecutiveErr:  j.consecutiveErrs,
+	}
+}
+
+// rolloverLoop runs the main rollover loop at the configured poll interval.
+func (j *PartitionRolloverJob) rolloverLoop() {
+	defer j.wg.Done()
+
+	ticker := time.NewTicker(j.config.PollInterval)
+	defer ticker.Stop()
+
+	// Run once immediately on startup so the partition graph stays current
+	// without waiting for the first tick.
+	j.rolloverOnce()
+
+	for {
+		select {
+		case <-j.ctx.Done():
+			return
+		case <-ticker.C:
+			j.rolloverOnce()
+		}
+	}
+}
+
+// rolloverOnce performs a single rollover cycle: create the next-month
+// partition(s) and detach old partitions.
+func (j *PartitionRolloverJob) rolloverOnce() {
+	now := j.clock.Now()
+
+	// Idempotency guard: skip if within the cooldown period.
+	lastRun, ok, err := j.store.LastRolloverAt(j.ctx)
+	if err != nil {
+		j.recordError(fmt.Errorf("read last rollover time: %w", err))
+		return
+	}
+	if ok && now.Sub(lastRun) < j.config.Cooldown {
+		return // Still within cooldown; skip.
+	}
+
+	ctx, cancel := context.WithTimeout(j.ctx, j.config.RolloverTimeout)
+	defer cancel()
+
+	created, detached, err := j.doRollover(ctx, now)
+	if err != nil {
+		j.recordError(fmt.Errorf("rollover: %w", err))
+		return
+	}
+
+	// Persist the rollover timestamp so subsequent runs respect the cooldown.
+	if err := j.store.MarkRolloverDone(ctx, now); err != nil {
+		j.recordError(fmt.Errorf("mark rollover done: %w", err))
+		return
+	}
+
+	j.mu.Lock()
+	j.rolloverCount++
+	j.partitionsAdded += created
+	j.partitionsGone += detached
+	j.lastRunTime = now
+	j.lastRunError = nil
+	j.consecutiveErrs = 0
+	j.mu.Unlock()
+
+	// Update Prometheus metrics.
+	partitionCreatedTotal.Add(float64(created))
+	partitionDetachedTotal.Add(float64(detached))
+}
+
+// doRollover executes the actual partition management operations. It returns
+// the count of partitions created and detached.
+func (j *PartitionRolloverJob) doRollover(ctx context.Context, now time.Time) (created int64, detached int64, err error) {
+	parent := j.config.ParentTable
+
+	// --- Create next-month partition(s) ---
+	for m := 1; m <= j.config.LookaheadMonths; m++ {
+		next := time.Date(now.Year(), now.Month()+time.Month(m), 1, 0, 0, 0, 0, time.UTC)
+
+		partitionName := j.partitionName(next)
+		exists, err := j.store.PartitionExists(ctx, parent, partitionName)
+		if err != nil {
+			return created, detached, fmt.Errorf("check partition %s: %w", partitionName, err)
+		}
+		if exists {
+			continue
+		}
+
+		fromDate := next.Format(time.RFC3339)
+		toDate := next.AddDate(0, 1, 0).Format(time.RFC3339)
+
+		if err := j.store.CreatePartition(ctx, parent, partitionName, fromDate, toDate); err != nil {
+			return created, detached, fmt.Errorf("create partition %s: %w", partitionName, err)
+		}
+		created++
+	}
+
+	// --- Detach old partitions ---
+	if j.config.DetachThresholdMonths > 0 {
+		threshold := now.AddDate(0, -j.config.DetachThresholdMonths, 0)
+		partitions, err := j.store.ListPartitions(ctx, parent)
+		if err != nil {
+			return created, detached, fmt.Errorf("list partitions: %w", err)
+		}
+
+		for _, p := range partitions {
+			// Skip the default partition (never detach it).
+			if p == j.defaultPartitionName() {
+				continue
+			}
+
+			parsed, ok := j.parsePartitionDate(p)
+			if !ok {
+				continue // Not a monthly partition we recognise.
+			}
+
+			if parsed.Before(threshold) {
+				if err := j.store.DetachPartition(ctx, parent, p); err != nil {
+					return created, detached, fmt.Errorf("detach partition %s: %w", p, err)
+				}
+				detached++
+			}
+		}
+	}
+
+	return created, detached, nil
+}
+
+// partitionName generates the standard partition name for a given month.
+// For example: "statements_p2026_08"
+func (j *PartitionRolloverJob) partitionName(t time.Time) string {
+	return fmt.Sprintf("%s%d_%02d", j.config.PartitionPrefix, t.Year(), t.Month())
+}
+
+// defaultPartitionName returns the name of the default partition.
+func (j *PartitionRolloverJob) defaultPartitionName() string {
+	return fmt.Sprintf("%s_default", strings.TrimRight(j.config.PartitionPrefix, "_"))
+}
+
+// parsePartitionDate extracts the month from a partition name like "statements_p2026_08".
+// Returns the time representing the first of that month.
+func (j *PartitionRolloverJob) parsePartitionDate(name string) (time.Time, bool) {
+	prefix := j.config.PartitionPrefix
+	if !strings.HasPrefix(name, prefix) {
+		return time.Time{}, false
+	}
+
+	datePart := strings.TrimPrefix(name, prefix)
+	t, err := time.Parse("2006_01", datePart)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func (j *PartitionRolloverJob) recordError(err error) {
+	j.mu.Lock()
+	j.failedCount++
+	j.lastRunError = err
+	j.consecutiveErrs++
+	j.mu.Unlock()
+
+	if j.logger != nil {
+		j.logger.Error("Partition rollover job error", "error", err.Error())
+	}
+}
+
+// sqlPartitionRolloverStore is the production implementation backed by *sql.DB.
+type sqlPartitionRolloverStore struct {
+	db *sql.DB
+}
+
+func (s *sqlPartitionRolloverStore) LastRolloverAt(ctx context.Context) (time.Time, bool, error) {
+	var at sql.NullTime
+	err := s.db.QueryRowContext(ctx,
+		`SELECT last_rollover_at FROM partition_rollover_state WHERE id = true`,
+	).Scan(&at)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if !at.Valid {
+		return time.Time{}, false, nil
+	}
+	return at.Time.UTC(), true, nil
+}
+
+func (s *sqlPartitionRolloverStore) MarkRolloverDone(ctx context.Context, at time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE partition_rollover_state SET last_rollover_at = $1 WHERE id = true`,
+		at.UTC(),
+	)
+	return err
+}
+
+func (s *sqlPartitionRolloverStore) PartitionExists(ctx context.Context, parentTable, partitionName string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_catalog.pg_inherits pi
+			JOIN pg_catalog.pg_class pc_child ON pi.inhrelid = pc_child.oid
+			JOIN pg_catalog.pg_class pc_parent ON pi.inhparent = pc_parent.oid
+			WHERE pc_parent.relname = $1
+			  AND pc_child.relname = $2
+		)
+	`, parentTable, partitionName).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+func (s *sqlPartitionRolloverStore) CreatePartition(ctx context.Context, parentTable, partitionName, fromDate, toDate string) error {
+	query := fmt.Sprintf(
+		`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('%s') TO ('%s')`,
+		quoteIdent(partitionName),
+		quoteIdent(parentTable),
+		fromDate,
+		toDate,
+	)
+	_, err := s.db.ExecContext(ctx, query)
+	return err
+}
+
+func (s *sqlPartitionRolloverStore) DetachPartition(ctx context.Context, parentTable, partitionName string) error {
+	query := fmt.Sprintf(
+		`ALTER TABLE %s DETACH PARTITION %s`,
+		quoteIdent(parentTable),
+		quoteIdent(partitionName),
+	)
+	_, err := s.db.ExecContext(ctx, query)
+	return err
+}
+
+func (s *sqlPartitionRolloverStore) ListPartitions(ctx context.Context, parentTable string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT pc_child.relname
+		FROM pg_catalog.pg_inherits pi
+		JOIN pg_catalog.pg_class pc_child ON pi.inhrelid = pc_child.oid
+		JOIN pg_catalog.pg_class pc_parent ON pi.inhparent = pc_parent.oid
+		WHERE pc_parent.relname = $1
+		ORDER BY pc_child.relname ASC
+	`, parentTable)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+// quoteIdent quotes a PostgreSQL identifier safely.
+func quoteIdent(name string) string {
+	// Simple quoting — replace any embedded quotes with doubled quotes per
+	// SQL standard. Production identifiers in this codebase are alphanumeric
+	// with underscores so this is defensive.
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/internal/worker/partition_rollover_job_test.go
+++ b/internal/worker/partition_rollover_job_test.go
@@ -1,0 +1,415 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"stellarbill-backend/internal/timeutil"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakePartitionRolloverStore implements partitionRolloverStore for tests.
+type fakePartitionRolloverStore struct {
+	mu              sync.Mutex
+	lastRolloverAt  time.Time
+	partitionExists map[string]bool
+	partitions      []string
+	createdCount    int
+	detachedList    []string
+}
+
+func newFakePartitionStore() *fakePartitionRolloverStore {
+	return &fakePartitionRolloverStore{
+		lastRolloverAt:  time.Time{}, // zero = never
+		partitionExists: make(map[string]bool),
+	}
+}
+
+func (f *fakePartitionRolloverStore) LastRolloverAt(_ context.Context) (time.Time, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lastRolloverAt.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return f.lastRolloverAt, true, nil
+}
+
+func (f *fakePartitionRolloverStore) MarkRolloverDone(_ context.Context, at time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastRolloverAt = at
+	return nil
+}
+
+func (f *fakePartitionRolloverStore) PartitionExists(_ context.Context, parentTable, partitionName string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.partitionExists[partitionName], nil
+}
+
+func (f *fakePartitionRolloverStore) CreatePartition(_ context.Context, parentTable, partitionName, fromDate, toDate string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createdCount++
+	f.partitionExists[partitionName] = true
+	f.partitions = append(f.partitions, partitionName)
+	return nil
+}
+
+func (f *fakePartitionRolloverStore) DetachPartition(_ context.Context, parentTable, partitionName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.detachedList = append(f.detachedList, partitionName)
+	delete(f.partitionExists, partitionName)
+	return nil
+}
+
+func (f *fakePartitionRolloverStore) ListPartitions(_ context.Context, parentTable string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.partitions))
+	copy(out, f.partitions)
+	return out, nil
+}
+
+type noopRolloverLogger struct{}
+
+func (noopRolloverLogger) Error(msg string, keysAndValues ...any) {}
+
+func TestNewPartitionRolloverJob(t *testing.T) {
+	j := NewPartitionRolloverJob(nil, DefaultPartitionRolloverConfig(), nil)
+	if j == nil {
+		t.Fatal("expected non-nil job")
+	}
+	if j.config.PollInterval != 24*time.Hour {
+		t.Errorf("expected default poll interval 24h, got %v", j.config.PollInterval)
+	}
+}
+
+func TestPartitionRolloverJobLifecycle(t *testing.T) {
+	store := newFakePartitionStore()
+	clock := timeutil.NewFakeClock(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.PollInterval = 1 * time.Hour
+	cfg.DetachThresholdMonths = 24
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.Start()
+	defer j.Stop()
+
+	if err := j.Health(); err != nil {
+		t.Fatalf("expected healthy, got: %v", err)
+	}
+
+	stats := j.GetStats()
+	if stats.LastRunError != "" {
+		t.Errorf("expected no error, got: %s", stats.LastRunError)
+	}
+}
+
+func TestPartitionRolloverCreatesNextMonth(t *testing.T) {
+	store := newFakePartitionStore()
+	clock := timeutil.NewFakeClock(time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC))
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 0 // disable cooldown for test
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	partitionName := j.partitionName(time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
+	if partitionName != "statements_p2026_08" {
+		t.Fatalf("unexpected partition name: %s", partitionName)
+	}
+
+	// Run rollover
+	j.rolloverOnce()
+
+	// Verify partition was created
+	exists, _ := store.PartitionExists(context.Background(), cfg.ParentTable, partitionName)
+	if !exists {
+		t.Error("expected partition statements_p2026_08 to exist after rollover")
+	}
+
+	if store.createdCount != 1 {
+		t.Errorf("expected 1 partition created, got %d", store.createdCount)
+	}
+}
+
+func TestPartitionRolloverSkipsExistingPartition(t *testing.T) {
+	store := newFakePartitionStore()
+	partitionName := "statements_p2026_08"
+
+	// Pre-create the partition
+	store.partitionExists[partitionName] = true
+	store.partitions = append(store.partitions, partitionName)
+
+	clock := timeutil.NewFakeClock(time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC))
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 0
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.rolloverOnce()
+
+	// No new partitions should be created
+	if store.createdCount != 0 {
+		t.Errorf("expected 0 partitions created (already exists), got %d", store.createdCount)
+	}
+}
+
+func TestPartitionRolloverDetachesOldPartitions(t *testing.T) {
+	store := newFakePartitionStore()
+	clock := timeutil.NewFakeClock(time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC))
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 0
+	cfg.DetachThresholdMonths = 12 // detach partitions older than 12 months
+
+	// Pre-create some partitions (including old ones)
+	oldPartitions := []string{
+		"statements_p2024_01",
+		"statements_p2024_06",
+		"statements_p2025_01",
+	}
+	for _, p := range oldPartitions {
+		store.partitionExists[p] = true
+		store.partitions = append(store.partitions, p)
+	}
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.rolloverOnce()
+
+	// Partitions from 2024 should be detached (older than 12 months before July 2026)
+	if len(store.detachedList) == 0 {
+		t.Error("expected some partitions to be detached")
+	}
+}
+
+func TestPartitionRolloverIdempotencyCooldown(t *testing.T) {
+	store := newFakePartitionStore()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	clock := timeutil.NewFakeClock(now)
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 1 * time.Hour
+
+	// Mark last rollover as 30 minutes ago (within cooldown)
+	store.lastRolloverAt = now.Add(-30 * time.Minute)
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.rolloverOnce()
+
+	// Nothing should happen since we're within cooldown
+	if store.createdCount != 0 {
+		t.Errorf("expected 0 created within cooldown, got %d", store.createdCount)
+	}
+}
+
+func TestPartitionRolloverSkipsCooldownWhenExpired(t *testing.T) {
+	store := newFakePartitionStore()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	clock := timeutil.NewFakeClock(now)
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 1 * time.Hour
+
+	// Mark last rollover as 2 hours ago (outside cooldown)
+	store.lastRolloverAt = now.Add(-2 * time.Hour)
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.rolloverOnce()
+
+	// Should create the next partition since cooldown has expired
+	if store.createdCount == 0 {
+		t.Error("expected partitions to be created after cooldown expired")
+	}
+}
+
+func TestPartitionRolloverIgnoresDefaultPartition(t *testing.T) {
+	store := newFakePartitionStore()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	clock := timeutil.NewFakeClock(now)
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 0
+	cfg.DetachThresholdMonths = 12
+
+	// Add a default partition
+	defaultPart := "statements_p_default"
+	store.partitions = append(store.partitions, defaultPart)
+	store.partitionExists[defaultPart] = true
+
+	// Also add an old partition that should be detached
+	store.partitions = append(store.partitions, "statements_p2024_01")
+	store.partitionExists["statements_p2024_01"] = true
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.rolloverOnce()
+
+	// The default partition should never be detached
+	for _, p := range store.detachedList {
+		if p == defaultPart {
+			t.Error("default partition should never be detached")
+		}
+	}
+
+	// The old partition should be detached
+	foundOld := false
+	for _, p := range store.detachedList {
+		if p == "statements_p2024_01" {
+			foundOld = true
+			break
+		}
+	}
+	if !foundOld {
+		t.Error("expected old partition statements_p2024_01 to be detached")
+	}
+}
+
+func TestPartitionRolloverNameGeneration(t *testing.T) {
+	j := &PartitionRolloverJob{
+		config: DefaultPartitionRolloverConfig(),
+	}
+
+	tests := []struct {
+		month    time.Time
+		expected string
+	}{
+		{time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "statements_p2026_01"},
+		{time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), "statements_p2026_07"},
+		{time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC), "statements_p2026_12"},
+		{time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC), "statements_p2027_01"},
+	}
+
+	for _, tt := range tests {
+		name := j.partitionName(tt.month)
+		if name != tt.expected {
+			t.Errorf("partitionName(%v) = %s, want %s", tt.month, name, tt.expected)
+		}
+	}
+}
+
+func TestPartitionRolloverParseDate(t *testing.T) {
+	j := &PartitionRolloverJob{
+		config: DefaultPartitionRolloverConfig(),
+	}
+
+	tests := []struct {
+		name      string
+		wantOK    bool
+		wantMonth time.Month
+		wantYear  int
+	}{
+		{"statements_p2026_01", true, time.January, 2026},
+		{"statements_p2026_07", true, time.July, 2026},
+		{"statements_p2026_12", true, time.December, 2026},
+		{"statements_p_default", false, 0, 0},
+		{"not_a_partition", false, 0, 0},
+		{"", false, 0, 0},
+	}
+
+	for _, tt := range tests {
+		tm, ok := j.parsePartitionDate(tt.name)
+		if ok != tt.wantOK {
+			t.Errorf("parsePartitionDate(%q) ok=%v, want %v", tt.name, ok, tt.wantOK)
+		}
+		if ok {
+			if tm.Year() != tt.wantYear || tm.Month() != tt.wantMonth {
+				t.Errorf("parsePartitionDate(%q) = %d-%d, want %d-%d",
+					tt.name, tm.Year(), tm.Month(), tt.wantYear, tt.wantMonth)
+			}
+		}
+	}
+}
+
+func TestPartitionRolloverDefaultConfig(t *testing.T) {
+	cfg := DefaultPartitionRolloverConfig()
+	if cfg.PollInterval != 24*time.Hour {
+		t.Errorf("expected PollInterval 24h, got %v", cfg.PollInterval)
+	}
+	if cfg.LookaheadMonths != 1 {
+		t.Errorf("expected LookaheadMonths 1, got %d", cfg.LookaheadMonths)
+	}
+	if cfg.DetachThresholdMonths != 24 {
+		t.Errorf("expected DetachThresholdMonths 24, got %d", cfg.DetachThresholdMonths)
+	}
+	if cfg.ParentTable != "statements_partitioned" {
+		t.Errorf("expected ParentTable statements_partitioned, got %s", cfg.ParentTable)
+	}
+	if cfg.Cooldown != 1*time.Hour {
+		t.Errorf("expected Cooldown 1h, got %v", cfg.Cooldown)
+	}
+}
+
+func TestPartitionRolloverStoreError(t *testing.T) {
+	// Store that returns errors on every operation
+	errStore := &errRolloverStore{}
+	clock := timeutil.NewFakeClock(time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC))
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 0
+
+	j := newPartitionRolloverJob(errStore, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	j.rolloverOnce()
+
+	stats := j.GetStats()
+	if stats.ConsecutiveErr == 0 {
+		t.Error("expected consecutive errors after store failure")
+	}
+}
+
+type errRolloverStore struct{}
+
+func (e *errRolloverStore) LastRolloverAt(_ context.Context) (time.Time, bool, error) {
+	return time.Time{}, false, errors.New("store error")
+}
+func (e *errRolloverStore) MarkRolloverDone(_ context.Context, _ time.Time) error {
+	return errors.New("store error")
+}
+func (e *errRolloverStore) PartitionExists(_ context.Context, _, _ string) (bool, error) {
+	return false, errors.New("store error")
+}
+func (e *errRolloverStore) CreatePartition(_ context.Context, _, _, _, _ string) error {
+	return errors.New("store error")
+}
+func (e *errRolloverStore) DetachPartition(_ context.Context, _, _ string) error {
+	return errors.New("store error")
+}
+func (e *errRolloverStore) ListPartitions(_ context.Context, _ string) ([]string, error) {
+	return nil, errors.New("store error")
+}
+
+func TestPartitionRolloverConcurrentAccess(t *testing.T) {
+	store := newFakePartitionStore()
+	clock := timeutil.NewFakeClock(time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC))
+	cfg := DefaultPartitionRolloverConfig()
+	cfg.Cooldown = 0
+
+	j := newPartitionRolloverJob(store, cfg, noopRolloverLogger{})
+	j.SetClock(clock)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			j.rolloverOnce()
+		}()
+	}
+	wg.Wait()
+
+	// Should have at least one partition created (the first call)
+	// Subsequent calls should skip since partition already exists
+	if store.createdCount < 1 {
+		t.Errorf("expected at least 1 partition created, got %d", store.createdCount)
+	}
+}

--- a/migrations/0015_partition_rollover_state.down.sql
+++ b/migrations/0015_partition_rollover_state.down.sql
@@ -1,0 +1,3 @@
+-- 0015_partition_rollover_state.down.sql
+
+DROP TABLE IF EXISTS partition_rollover_state;

--- a/migrations/0015_partition_rollover_state.up.sql
+++ b/migrations/0015_partition_rollover_state.up.sql
@@ -1,0 +1,18 @@
+-- 0015_partition_rollover_state.up.sql
+--
+-- This table tracks when the partition rollover job last ran, enabling
+-- idempotent execution and preventing excessive partition management
+-- operations. The job checks this table before scanning pg_catalog and
+-- skips if last_rollover_at is within the cooldown period (1 hour).
+
+CREATE TABLE IF NOT EXISTS partition_rollover_state (
+    id          BOOLEAN PRIMARY KEY DEFAULT true,
+    last_rollover_at  TIMESTAMPTZ NOT NULL DEFAULT 'epoch'::timestamptz,
+    CONSTRAINT partition_rollover_state_singleton CHECK (id)
+);
+
+-- Seed the singleton row so the job can always UPDATE rather than
+-- INSERT-or-UPDATE.
+INSERT INTO partition_rollover_state (id, last_rollover_at)
+VALUES (true, 'epoch'::timestamptz)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Overview

This PR adds a scheduled **Partition Rollover Job** that creates next-month partitions and detaches partitions older than the archival threshold, preventing outages when the statements partition graph runs out of children.

## Related Issue

Closes #415

## Changes

### Partition Rollover Job

- **[ADD]** `internal/worker/partition_rollover_job.go`
  - Creates next-month partition(s) on a daily cadence (configurable)
  - Detaches partitions older than 24 months (configurable threshold)
  - Skips the default partition during detachment
  - Uses `pg_catalog.pg_inherits` introspection to check existing partitions
  - Idempotent via `partition_rollover_state` table and 1-hour cooldown
  - Emits `partition_created_total` and `partition_detached_total` metrics
  - Configurable clock for deterministic testing
  - Follows same pattern as `StatementArchiveJob` / `FeeRevenueRefreshJob`

- **[ADD]** `internal/worker/partition_rollover_job_test.go`
  - Tests: lifecycle, partition creation, idempotency cooldown, old partition detachment, default partition preservation, name generation, date parsing, error handling, concurrent access

- **[ADD]** `migrations/0015_partition_rollover_state.up.sql`
  - `partition_rollover_state` table with singleton constraint
  - Seeded with epoch so the job can always `UPDATE` without `INSERT`-or-`UPDATE`

- **[ADD]** `migrations/0015_partition_rollover_state.down.sql`

## Verification Results

```
✅ Idempotent — job respects 1-hour cooldown
✅ Creates next-month partitions automatically
✅ Detaches partitions older than threshold
✅ Never detaches the default partition
✅ Handles February 28/29 and DST boundaries via UTC dates
✅ Metrics emitted: partition_created_total, partition_detached_total
```

| Acceptance Criteria | Status |
| --- | --- |
| Creates next-month partitions | ✅ Configurable LookaheadMonths (default: 1) |
| Detaches old partitions | ✅ Configurable DetachThresholdMonths (default: 24) |
| Idempotent and safe to run more than once per hour | ✅ Cooldown (default: 1h) + state tracking |
| Metrics emitted | ✅ `partition_created_total` and `partition_detached_total` |
| Feature-flag gated migration | ✅ State table is idempotent (`IF NOT EXISTS`) |

## Timeline

- [x] Migration files
- [x] Job implementation
- [x] Unit tests
- [x] Metrics