### PR TITLE
devops: adopt Argo Rollouts canary strategy

### DIFF
--- a/deploy/helm/stellabill/templates/analysis-template.yaml
+++ b/deploy/helm/stellabill/templates/analysis-template.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.rollout.enabled }}
+# deploy/helm/stellabill/templates/analysis-template.yaml
+#
+# AnalysisTemplate: stellabill-canary-analysis
+#
+# Metrics evaluated during every canary step:
+#   1. p99-latency  — p99 request latency must be < rollout.analysis.p99LatencyThresholdMs ms
+#   2. error-rate   — HTTP 5xx rate must be < rollout.analysis.errorRateThreshold (0–1)
+#
+# Safety: if the query returns zero samples (no traffic yet), the analysis is
+# marked Inconclusive, not Failed, so early canary steps with very low traffic
+# do not trigger a false abort. An Inconclusive result will not promote the
+# rollout automatically — it will wait for the next interval.
+#
+# The analysis runs every rollout.analysis.intervalSeconds seconds for
+# rollout.analysis.count total measurements. Failure on any measurement
+# causes an immediate abort and rollback.
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ .Values.rollout.analysis.templateName | default "stellabill-canary-analysis" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stellabill.labels" . | nindent 4 }}
+    app.kubernetes.io/component: canary-analysis
+spec:
+  args:
+    # Passed from the Rollout spec.strategy.canary.analysis.args.
+    - name: service-name
+    - name: namespace
+
+  metrics:
+    # ─────────────────────────────────────────────────────────────────────────
+    # Metric 1: p99 request latency (milliseconds)
+    # Fails if p99 latency exceeds the configured threshold.
+    # Inconclusive if no samples exist (zero-traffic guard).
+    # ─────────────────────────────────────────────────────────────────────────
+    - name: p99-latency
+      interval: {{ .Values.rollout.analysis.intervalSeconds | default 60 }}s
+      count: {{ .Values.rollout.analysis.count | default 5 }}
+      failureLimit: {{ .Values.rollout.analysis.failureLimit | default 1 }}
+      inconclusiveLimit: {{ .Values.rollout.analysis.inconclusiveLimit | default 3 }}
+      successCondition: >-
+        result != nil && len(result) > 0 &&
+        asFloat(result[0]) < {{ .Values.rollout.analysis.p99LatencyThresholdMs | default 500 }}
+      failureCondition: >-
+        result != nil && len(result) > 0 &&
+        asFloat(result[0]) >= {{ .Values.rollout.analysis.p99LatencyThresholdMs | default 500 }}
+      provider:
+        prometheus:
+          address: {{ .Values.rollout.analysis.prometheusAddress | default "http://prometheus-operated.monitoring.svc.cluster.local:9090" }}
+          query: |
+            histogram_quantile(
+              0.99,
+              sum(
+                rate(
+                  http_request_duration_milliseconds_bucket{
+                    service="{{ `{{args.service-name}}` }}",
+                    namespace="{{ `{{args.namespace}}` }}"
+                  }[2m]
+                )
+              ) by (le)
+            )
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Metric 2: HTTP 5xx error rate (fraction of total requests)
+    # Fails if more than rollout.analysis.errorRateThreshold of requests are 5xx.
+    # Inconclusive if no requests have been observed yet.
+    # ─────────────────────────────────────────────────────────────────────────
+    - name: error-rate
+      interval: {{ .Values.rollout.analysis.intervalSeconds | default 60 }}s
+      count: {{ .Values.rollout.analysis.count | default 5 }}
+      failureLimit: {{ .Values.rollout.analysis.failureLimit | default 1 }}
+      inconclusiveLimit: {{ .Values.rollout.analysis.inconclusiveLimit | default 3 }}
+      successCondition: >-
+        result != nil && len(result) > 0 &&
+        asFloat(result[0]) < {{ .Values.rollout.analysis.errorRateThreshold | default 0.01 }}
+      failureCondition: >-
+        result != nil && len(result) > 0 &&
+        asFloat(result[0]) >= {{ .Values.rollout.analysis.errorRateThreshold | default 0.01 }}
+      provider:
+        prometheus:
+          address: {{ .Values.rollout.analysis.prometheusAddress | default "http://prometheus-operated.monitoring.svc.cluster.local:9090" }}
+          query: |
+            sum(
+              rate(
+                http_requests_total{
+                  service="{{ `{{args.service-name}}` }}",
+                  namespace="{{ `{{args.namespace}}` }}",
+                  status=~"5.."
+                }[2m]
+              )
+            )
+            /
+            sum(
+              rate(
+                http_requests_total{
+                  service="{{ `{{args.service-name}}` }}",
+                  namespace="{{ `{{args.namespace}}` }}"
+                }[2m]
+              )
+            )
+{{- end }}

--- a/deploy/helm/stellabill/templates/rollout.yaml
+++ b/deploy/helm/stellabill/templates/rollout.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.rollout.enabled }}
+# deploy/helm/stellabill/templates/rollout.yaml
+#
+# Argo Rollouts Rollout resource for the stellabill-api component.
+# Replaces the Deployment for the api component when rollout.enabled=true.
+#
+# Traffic is shifted in four canary steps: 10% → 25% → 50% → 100%.
+# Each step pauses for automated analysis on p99 latency and 5xx error rate.
+# If analysis fails, the rollout is automatically aborted and traffic returns
+# to the stable revision.
+#
+# Prerequisites:
+#   - Argo Rollouts controller installed in the cluster
+#     (https://argoproj.github.io/argo-rollouts/)
+#   - Prometheus available at the URL configured in rollout.analysis.prometheusAddress
+#   - The stellabill Service must exist (created separately or via service.yaml)
+#
+# Manual operations:
+#   kubectl argo rollouts get rollout stellabill-api -n <namespace> --watch
+#   kubectl argo rollouts promote stellabill-api -n <namespace>       # manual promote
+#   kubectl argo rollouts abort stellabill-api -n <namespace>         # manual abort
+#   kubectl argo rollouts undo stellabill-api -n <namespace>          # rollback
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ .Values.api.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stellabill.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  annotations:
+    # Record the chart version for audit purposes.
+    helm.sh/chart-version: {{ .Chart.Version | quote }}
+spec:
+  replicas: {{ .Values.api.replicas }}
+  revisionHistoryLimit: {{ .Values.rollout.revisionHistoryLimit | default 3 }}
+
+  selector:
+    matchLabels:
+      {{- include "stellabill.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "component" "api") | nindent 6 }}
+
+  template:
+    metadata:
+      labels:
+        {{- include "stellabill.componentLabels" (dict "Chart" .Chart "Release" .Release "component" "api") | nindent 8 }}
+        tier: {{ .Values.api.labels.tier }}
+        component: {{ .Values.api.labels.component }}
+    spec:
+      {{- with .Values.api.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.api.topologySpread.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.api.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.api.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.api.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "stellabill.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "component" "api") | nindent 14 }}
+      {{- end }}
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.api.container.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.container.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: {{ .Values.api.container.portName }}
+              containerPort: {{ .Values.api.container.port }}
+              protocol: TCP
+          {{- with .Values.api.container.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.container.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          {{- with .Values.api.container.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.api.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.api.container.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.api.serviceAccountName | default (printf "%s-%s" .Release.Name "api") }}
+
+  strategy:
+    canary:
+      # Reference the AnalysisTemplate that checks p99 latency and 5xx rate.
+      analysis:
+        templates:
+          - templateName: {{ .Values.rollout.analysis.templateName | default "stellabill-canary-analysis" }}
+        # Start analysis after the first canary step is stable.
+        startingStep: 1
+        args:
+          - name: service-name
+            value: {{ .Values.api.name }}
+          - name: namespace
+            value: {{ .Release.Namespace }}
+
+      steps:
+        # Step 1: send 10% of traffic to canary; run analysis.
+        - setWeight: 10
+        - pause:
+            duration: {{ .Values.rollout.canary.step1PauseDuration | default "2m" }}
+
+        # Step 2: promote to 25% if analysis passes.
+        - setWeight: 25
+        - pause:
+            duration: {{ .Values.rollout.canary.step2PauseDuration | default "2m" }}
+
+        # Step 3: promote to 50%.
+        - setWeight: 50
+        - pause:
+            duration: {{ .Values.rollout.canary.step3PauseDuration | default "5m" }}
+
+        # Step 4: full traffic — analysis continues until rollout completes.
+        - setWeight: 100
+
+      # Abort and roll back automatically if analysis fails.
+      abortScaleDownDelaySeconds: {{ .Values.rollout.canary.abortScaleDownDelaySeconds | default 30 }}
+
+      # Keep the canary alive for the duration of all analysis steps.
+      scaleDownDelaySeconds: {{ .Values.rollout.canary.scaleDownDelaySeconds | default 30 }}
+{{- end }}

--- a/deploy/helm/stellabill/values.yaml
+++ b/deploy/helm/stellabill/values.yaml
@@ -1,6 +1,66 @@
 # Default values for stellabill
 # This is a YAML-formatted file.
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Argo Rollouts — Canary Strategy
+#
+# Set rollout.enabled=true to replace the api Deployment with an Argo Rollouts
+# Rollout resource. Requires the Argo Rollouts controller to be installed.
+#
+# Traffic steps: 10% → 25% → 50% → 100%
+# Each step runs automated analysis on p99 latency and 5xx error rate.
+# Failed analysis triggers an automatic abort and rollback to the stable revision.
+#
+# Install Argo Rollouts:
+#   kubectl create namespace argo-rollouts
+#   kubectl apply -n argo-rollouts \
+#     -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+rollout:
+  # enabled: set to true to use Argo Rollouts instead of plain Deployment for api.
+  enabled: false
+
+  revisionHistoryLimit: 3
+
+  canary:
+    # Pause durations between traffic weight steps.
+    step1PauseDuration: "2m"   # 10% → wait → 25%
+    step2PauseDuration: "2m"   # 25% → wait → 50%
+    step3PauseDuration: "5m"   # 50% → wait → 100%
+
+    # Seconds to wait before scaling down the canary after abort.
+    abortScaleDownDelaySeconds: 30
+    # Seconds to wait before scaling down after a successful promotion.
+    scaleDownDelaySeconds: 30
+
+  analysis:
+    # Name of the AnalysisTemplate created by this chart.
+    templateName: "stellabill-canary-analysis"
+
+    # Prometheus endpoint reachable from the Argo Rollouts controller.
+    prometheusAddress: "http://prometheus-operated.monitoring.svc.cluster.local:9090"
+
+    # How often to query Prometheus during analysis (seconds).
+    intervalSeconds: 60
+
+    # Total number of measurements per metric per analysis run.
+    count: 5
+
+    # How many consecutive failures before the analysis is marked Failed.
+    failureLimit: 1
+
+    # How many Inconclusive results (zero samples) are tolerated before abort.
+    inconclusiveLimit: 3
+
+    # p99 latency threshold in milliseconds. Exceeding this fails the analysis.
+    p99LatencyThresholdMs: 500
+
+    # 5xx error rate threshold (0–1 fraction). Exceeding this fails the analysis.
+    # 0.01 = 1% error rate.
+    errorRateThreshold: 0.01
+
+
+
 # Global image configuration
 image:
   repository: stellabill/backend

--- a/docs/ops/argo-rollouts.md
+++ b/docs/ops/argo-rollouts.md
@@ -1,0 +1,213 @@
+# Argo Rollouts — Canary Strategy
+
+This document describes the canary deployment strategy for the `stellabill-api`
+component using [Argo Rollouts](https://argoproj.github.io/argo-rollouts/).
+
+---
+
+## Overview
+
+Instead of a rolling Deployment, the API uses an Argo Rollouts `Rollout` resource
+that shifts traffic progressively: **10% → 25% → 50% → 100%**.
+
+Between each step, automated analysis queries Prometheus for:
+
+| Metric | Threshold | Failure action |
+|---|---|---|
+| p99 request latency | < 500 ms (configurable) | Abort + rollback |
+| HTTP 5xx error rate | < 1% of requests (configurable) | Abort + rollback |
+
+If analysis fails at any step, Argo Rollouts automatically aborts and returns
+all traffic to the previous stable revision.
+
+---
+
+## Prerequisites
+
+**Argo Rollouts controller** must be installed in the cluster:
+
+```bash
+kubectl create namespace argo-rollouts
+kubectl apply -n argo-rollouts \
+  -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
+
+# Install the kubectl plugin (optional but recommended)
+curl -LO https://github.com/argoproj/argo-rollouts/releases/latest/download/kubectl-argo-rollouts-linux-amd64
+chmod +x kubectl-argo-rollouts-linux-amd64
+mv kubectl-argo-rollouts-linux-amd64 /usr/local/bin/kubectl-argo-rollouts
+```
+
+**Prometheus** must be reachable at `rollout.analysis.prometheusAddress`
+(default: `http://prometheus-operated.monitoring.svc.cluster.local:9090`).
+
+---
+
+## Enabling the canary strategy
+
+Set `rollout.enabled=true` when installing or upgrading the chart:
+
+```bash
+helm upgrade stellabill deploy/helm/stellabill \
+  --set rollout.enabled=true \
+  --set image.tag=v1.2.3 \
+  --namespace stellabill
+```
+
+When `rollout.enabled=false` (default), the chart deploys a standard `Deployment`.
+
+---
+
+## Helm values reference
+
+```yaml
+rollout:
+  enabled: false                        # flip to true to activate
+  revisionHistoryLimit: 3
+
+  canary:
+    step1PauseDuration: "2m"            # 10% → pause → 25%
+    step2PauseDuration: "2m"            # 25% → pause → 50%
+    step3PauseDuration: "5m"            # 50% → pause → 100%
+    abortScaleDownDelaySeconds: 30
+    scaleDownDelaySeconds: 30
+
+  analysis:
+    templateName: stellabill-canary-analysis
+    prometheusAddress: http://prometheus-operated.monitoring.svc.cluster.local:9090
+    intervalSeconds: 60                 # query Prometheus every 60s
+    count: 5                            # 5 measurements per metric
+    failureLimit: 1                     # 1 failure triggers abort
+    inconclusiveLimit: 3                # 3 zero-sample results tolerated
+    p99LatencyThresholdMs: 500          # p99 must stay below 500ms
+    errorRateThreshold: 0.01            # 5xx rate must stay below 1%
+```
+
+---
+
+## Monitoring a rollout
+
+```bash
+# Watch rollout progress in real time
+kubectl argo rollouts get rollout stellabill-api -n stellabill --watch
+
+# Short status
+kubectl argo rollouts status stellabill-api -n stellabill
+```
+
+Example output during canary:
+
+```
+Name:            stellabill-api
+Namespace:       stellabill
+Status:          ॥ Paused
+Message:         CanaryPauseStep
+Strategy:        Canary
+  Step:          2/8
+  SetWeight:     10
+  ActualWeight:  10
+Images:          stellabill/backend:v1.2.2 (stable)
+                 stellabill/backend:v1.2.3 (canary)
+```
+
+---
+
+## Manual operations
+
+### Promote (skip remaining pause and advance to next step)
+
+```bash
+kubectl argo rollouts promote stellabill-api -n stellabill
+```
+
+### Full promote (skip all remaining steps and go straight to 100%)
+
+```bash
+kubectl argo rollouts promote stellabill-api -n stellabill --full
+```
+
+### Abort (stop the canary and roll back to stable)
+
+```bash
+kubectl argo rollouts abort stellabill-api -n stellabill
+```
+
+### Undo (roll back to the previous revision)
+
+```bash
+kubectl argo rollouts undo stellabill-api -n stellabill
+```
+
+### Retry after abort
+
+```bash
+kubectl argo rollouts retry rollout stellabill-api -n stellabill
+```
+
+---
+
+## Analysis edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| Zero samples (no traffic yet) | `Inconclusive` — rollout pauses, retries up to `inconclusiveLimit` times |
+| p99 latency spike above threshold | `Failed` → automatic abort + rollback |
+| 5xx error rate above threshold | `Failed` → automatic abort + rollback |
+| Prometheus unreachable | `Error` → treated as failure after `failureLimit` |
+| Analysis succeeds all steps | Rollout completes, canary becomes new stable |
+
+---
+
+## Rollback runbook
+
+If a rollout is aborted automatically:
+
+1. **Check analysis results:**
+   ```bash
+   kubectl argo rollouts get rollout stellabill-api -n stellabill
+   # Look for AnalysisRun resources listed under the rollout
+   kubectl get analysisrun -n stellabill
+   kubectl describe analysisrun <name> -n stellabill
+   ```
+
+2. **Check Prometheus metrics** to understand the failure signal.
+
+3. **Fix the issue** in the new image or configuration.
+
+4. **Build and push** a corrected image tag.
+
+5. **Update the rollout:**
+   ```bash
+   helm upgrade stellabill deploy/helm/stellabill \
+     --set rollout.enabled=true \
+     --set image.tag=v1.2.4 \
+     --namespace stellabill
+   ```
+
+---
+
+## Disabling canary (revert to Deployment)
+
+```bash
+helm upgrade stellabill deploy/helm/stellabill \
+  --set rollout.enabled=false \
+  --namespace stellabill
+```
+
+This re-creates the standard `Deployment` resource. The `Rollout` resource
+is not automatically deleted — remove it manually if needed:
+
+```bash
+kubectl delete rollout stellabill-api -n stellabill
+kubectl delete analysistemplate stellabill-canary-analysis -n stellabill
+```
+
+---
+
+## Security notes
+
+- The `AnalysisTemplate` queries Prometheus read-only; no credentials are
+  stored in the template — configure Prometheus RBAC separately if required.
+- The `Rollout` serviceAccountName follows the same convention as the
+  `Deployment` (`<release>-api`) — no additional RBAC is needed.
+- Analysis queries are scoped by `service` and `namespace` labels to prevent
+  cross-tenant metric pollution.


### PR DESCRIPTION
## Summary

Replaces the direct Deployment for stellabill-api with an Argo Rollouts Rollout resource that shifts traffic at 10% -> 25% -> 50% -> 100% with automated analysis on p99 latency and 5xx error rate. Rollback is automatic on analysis failure.

## Changes

- deploy/helm/stellabill/templates/rollout.yaml — Rollout resource, disabled by default (rollout.enabled=false). Mirrors all pod spec fields from the existing Deployment.
- deploy/helm/stellabill/templates/analysis-template.yaml — AnalysisTemplate with two Prometheus metrics: p99-latency (< 500ms) and error-rate (< 1% 5xx). Zero-sample guard returns Inconclusive instead of Failed.
- deploy/helm/stellabill/values.yaml — New rollout.* values block with all thresholds, pause durations, and Prometheus address.
- docs/ops/argo-rollouts.md — Installation, enabling, values reference, monitoring commands, manual pause/promote/abort/undo/retry, edge cases, rollback runbook, security notes.

## Testing

```bash
helm template stellabill deploy/helm/stellabill --set rollout.enabled=true --set image.tag=v1.2.3
kubectl argo rollouts get rollout stellabill-api -n stellabill
```

## Edge cases

| Scenario | Behaviour |
|---|---|
| Zero traffic samples | Inconclusive — no false abort |
| p99 latency spike | Automatic abort + rollback |
| 5xx error rate spike | Automatic abort + rollback |
| Prometheus unreachable | Error -> abort after failureLimit |
| rollout.enabled=false | Standard Deployment used |

Closes #464