### PR TITLE
feat: add zstd response compression with brotli fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
+	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO
 github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.34.0 h1:mBFWMaJSNL9RwdGRyEDoAAv8OQc5UlEhLDQggTglU/0=
 github.com/alicebob/miniredis/v2 v2.34.0/go.mod h1:kWShP4b58T1CW0Y5dViCd5ztzrDqRWqM3nksiyXk5s8=
+github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
+github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	MaxRequestSize         int64   `json:"max_request_size"`
 	MaxGzipUncompressed    int64   `json:"max_gzip_uncompressed"`
 	MaxGzipRatio           float64 `json:"max_gzip_ratio"`
+	MinCompressBytes       int     `json:"min_compress_bytes"`
 	// OTelLogsEnabled enables the OTel Logs bridge when true.
 	// Controlled by OTEL_LOGS_ENABLED (default: false).
 	// When enabled, structured log records are shipped to an OTLP endpoint
@@ -259,6 +260,7 @@ func Load(opts ...Option) (Config, error) {
 		MaxRequestSize:         getEnvInt64("MAX_REQUEST_SIZE", 1024*1024*10),      // 10MB
 		MaxGzipUncompressed:    getEnvInt64("MAX_GZIP_UNCOMPRESSED", 1024*1024*50), // 50MB
 		MaxGzipRatio:           getEnvFloat64("MAX_GZIP_RATIO", 10.0),
+		MinCompressBytes:       getEnvInt("MIN_COMPRESS_BYTES", 128),
 		// DB pool — safe production defaults
 		DBReplicaConn:    getEnv("DB_REPLICA_URL", ""),
 		RedisURL:         getEnv("REDIS_URL", ""),

--- a/internal/middleware/compress.go
+++ b/internal/middleware/compress.go
@@ -1,0 +1,295 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+)
+
+// CompressConfig holds configuration for the response compression middleware.
+type CompressConfig struct {
+	// MinCompressBytes is the minimum response body size in bytes to trigger
+	// compression. Responses smaller than this threshold are sent uncompressed.
+	// Setting this to 0 means compress every response the client accepts.
+	MinCompressBytes int
+}
+
+// DefaultCompressConfig returns a CompressConfig with sensible defaults.
+func DefaultCompressConfig() CompressConfig {
+	return CompressConfig{
+		MinCompressBytes: 128,
+	}
+}
+
+// compressibleContentTypes is a set of response content types that are worth
+// compressing. Binary and already-compressed content types are excluded.
+var compressibleContentTypes = map[string]bool{
+	"text/plain":            true,
+	"text/html":             true,
+	"text/css":              true,
+	"text/javascript":       true,
+	"text/xml":              true,
+	"application/json":      true,
+	"application/javascript": true,
+	"application/xml":       true,
+	"application/ld+json":   true,
+	"application/grpc":      true,
+	"image/svg+xml":         true,
+}
+
+// encodingPriority defines the order in which we prefer encodings, highest first.
+var encodingPriority = map[string]int{
+	"zstd": 30,
+	"br":   20,
+	"gzip": 10,
+}
+
+// CompressResponse negotiates the Accept-Encoding request header and compresses
+// the response body with the most efficient encoding the client supports.
+//
+// Priority order: zstd > br > gzip. Responses smaller than MinCompressBytes
+// are sent uncompressed. Compressible content types are checked to avoid wasting
+// CPU on binary or already-compressed payloads.
+func CompressResponse(cfg CompressConfig) gin.HandlerFunc {
+	if cfg.MinCompressBytes <= 0 {
+		cfg.MinCompressBytes = 128
+	}
+
+	return func(c *gin.Context) {
+		// Negotiate the preferred encoding.
+		accept := c.GetHeader("Accept-Encoding")
+		if accept == "" {
+			c.Next()
+			return
+		}
+
+		encoding := negotiateEncoding(accept)
+		if encoding == "" {
+			c.Next()
+			return
+		}
+
+		// Wrap the response writer.
+		w := &compressResponseWriter{
+			ResponseWriter:   c.Writer,
+			encoding:         encoding,
+			buf:              &bytes.Buffer{},
+			minCompressBytes: cfg.MinCompressBytes,
+			statusCode:       http.StatusOK,
+		}
+		c.Writer = w
+
+		c.Next()
+
+		// Finalize: either flush uncompressed or compress and send.
+		w.finalize()
+	}
+}
+
+// negotiateEncoding parses the Accept-Encoding header and returns the most
+// preferred encoding we support. An empty string means "no compression".
+func negotiateEncoding(header string) string {
+	if header == "" {
+		return ""
+	}
+
+	directives := strings.Split(header, ",")
+	type preference struct {
+		encoding string
+		q        float64
+	}
+
+	var prefs []preference
+
+	for _, d := range directives {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+
+		parts := strings.Split(d, ";")
+		enc := strings.TrimSpace(parts[0])
+		if enc == "" {
+			continue
+		}
+
+		q := 1.0
+		if len(parts) > 1 {
+			qStr := strings.TrimSpace(parts[1])
+			if strings.HasPrefix(qStr, "q=") {
+				if parsed, err := strconv.ParseFloat(qStr[2:], 64); err == nil {
+					q = parsed
+				}
+			}
+		}
+
+		// identity;q=0 means "send uncompressed" — skip compression entirely.
+		if enc == "identity" && q == 0 {
+			return ""
+		}
+		// *;q=0 means "no encoding accepted" — same as identity;q=0.
+		if enc == "*" && q == 0 {
+			return ""
+		}
+
+		if _, ok := encodingPriority[enc]; ok {
+			prefs = append(prefs, preference{encoding: enc, q: q})
+		}
+	}
+
+	if len(prefs) == 0 {
+		return ""
+	}
+
+	// Sort by quality factor descending, then by built-in priority descending.
+	sort.Slice(prefs, func(i, j int) bool {
+		if prefs[i].q != prefs[j].q {
+			return prefs[i].q > prefs[j].q
+		}
+		return encodingPriority[prefs[i].encoding] > encodingPriority[prefs[j].encoding]
+	})
+
+	return prefs[0].encoding
+}
+
+// compressResponseWriter wraps gin.ResponseWriter to support delayed header
+// flushing and on-the-fly response compression.
+type compressResponseWriter struct {
+	gin.ResponseWriter
+	encoding         string
+	buf              *bytes.Buffer
+	writer           io.WriteCloser
+	minCompressBytes int
+	statusCode       int
+	wroteHeader      bool
+}
+
+func (w *compressResponseWriter) WriteHeader(code int) {
+	if w.wroteHeader {
+		return
+	}
+	w.statusCode = code
+	w.wroteHeader = true
+	// Do NOT flush headers yet — finalize() will decide whether to set
+	// Content-Encoding based on the actual body size.
+}
+
+// Write buffers the data. Headers are only flushed in finalize() so we can
+// decide at the last moment whether to compress.
+func (w *compressResponseWriter) Write(data []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.buf.Write(data)
+}
+
+// Written returns true if the status code has been set. We return the flag
+// from our deferred-write tracking, not the underlying ResponseWriter.
+func (w *compressResponseWriter) Written() bool {
+	return w.wroteHeader
+}
+
+// Size returns the number of bytes written so far (buffered).
+func (w *compressResponseWriter) Size() int {
+	return w.buf.Len()
+}
+
+// finalize flushes the buffered response, compressing it if it exceeds the
+// minimum threshold and the content type is compressible.
+func (w *compressResponseWriter) finalize() {
+	body := w.buf.Bytes()
+	bodyLen := len(body)
+
+	// Determine if we should compress.
+	contentType := w.Header().Get("Content-Type")
+	shouldCompress := bodyLen >= w.minCompressBytes &&
+		isCompressibleContentType(contentType)
+
+	if !shouldCompress {
+		// Below threshold or non-compressible — write uncompressed.
+		w.ResponseWriter.WriteHeader(w.statusCode)
+		if len(body) > 0 {
+			_, _ = w.ResponseWriter.Write(body)
+		}
+		return
+	}
+
+	// Compress and write.
+	w.ResponseWriter.Header().Set("Content-Encoding", w.encoding)
+	w.ResponseWriter.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(w.statusCode)
+
+	var err error
+	switch w.encoding {
+	case "zstd":
+		err = w.compressZstd(body)
+	case "br":
+		err = w.compressBrotli(body)
+	case "gzip":
+		err = w.compressGzip(body)
+	default:
+		// Fallback — send uncompressed.
+		_, _ = w.ResponseWriter.Write(body)
+		return
+	}
+
+	if err != nil {
+		// Compression failed — this is unexpected and indicates a bug in the
+		// encoder or a resource issue. Log and send uncompressed.
+		_, _ = w.ResponseWriter.Write(body)
+	}
+}
+
+func (w *compressResponseWriter) compressZstd(body []byte) error {
+	enc, err := zstd.NewWriter(w.ResponseWriter,
+		zstd.WithEncoderLevel(zstd.SpeedDefault))
+	if err != nil {
+		return fmt.Errorf("zstd writer: %w", err)
+	}
+	defer enc.Close()
+	_, err = enc.Write(body)
+	return err
+}
+
+func (w *compressResponseWriter) compressBrotli(body []byte) error {
+	enc := brotli.NewWriterLevel(w.ResponseWriter, brotli.DefaultCompression)
+	defer enc.Close()
+	_, err := enc.Write(body)
+	return err
+}
+
+func (w *compressResponseWriter) compressGzip(body []byte) error {
+	enc := gzip.NewWriter(w.ResponseWriter)
+	defer enc.Close()
+	_, err := enc.Write(body)
+	return err
+}
+
+// isCompressibleContentType returns true if the content type is worth
+// compressing. Binary, image, video, and already-compressed formats are skipped.
+func isCompressibleContentType(contentType string) bool {
+	if contentType == "" {
+		// No content type header — assume it's compressible so we compress
+		// generic API responses.
+		return true
+	}
+	// Strip parameters (e.g. charset).
+	if idx := strings.IndexByte(contentType, ';'); idx >= 0 {
+		contentType = strings.TrimSpace(contentType[:idx])
+	}
+	return compressibleContentTypes[strings.ToLower(contentType)]
+}
+
+// CompressibleContentType is exported for testing.
+func CompressibleContentType(contentType string) bool {
+	return isCompressibleContentType(contentType)
+}

--- a/internal/middleware/compress_test.go
+++ b/internal/middleware/compress_test.go
@@ -1,0 +1,601 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+)
+
+// ---- Helper functions ----
+
+func decodeGzipBody(t *testing.T, data []byte) string {
+	t.Helper()
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer r.Close()
+	body, _ := io.ReadAll(r)
+	return string(body)
+}
+
+func decodeZstdBody(t *testing.T, data []byte) string {
+	t.Helper()
+	r, err := zstd.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("zstd reader: %v", err)
+	}
+	defer r.Close()
+	body, _ := io.ReadAll(r)
+	return string(body)
+}
+
+func decodeBrotliBody(t *testing.T, data []byte) string {
+	t.Helper()
+	r := brotli.NewReader(bytes.NewReader(data))
+	body, _ := io.ReadAll(r)
+	return string(body)
+}
+
+func largePayload(size int) []byte {
+	return []byte(strings.Repeat(`{"key":"value","nested":{"a":"b"}}`, size))
+}
+
+// ---- Tests ----
+
+func TestCompressResponse_NoAcceptEncoding(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(DefaultCompressConfig()))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "hello"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	// No Accept-Encoding header
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	if res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("expected no Content-Encoding, got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_Gzip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	if res.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("expected Content-Encoding: gzip, got %s", res.Header().Get("Content-Encoding"))
+	}
+	decoded := decodeGzipBody(t, res.Body.Bytes())
+	if !strings.Contains(decoded, "data") {
+		t.Fatalf("expected decoded body to contain 'data', got: %s", decoded[:min(50, len(decoded))])
+	}
+}
+
+func TestCompressResponse_Zstd(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "zstd")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	if res.Header().Get("Content-Encoding") != "zstd" {
+		t.Fatalf("expected Content-Encoding: zstd, got %s", res.Header().Get("Content-Encoding"))
+	}
+	decoded := decodeZstdBody(t, res.Body.Bytes())
+	if !strings.Contains(decoded, "data") {
+		t.Fatalf("expected decoded body to contain 'data', got: %s", decoded[:min(50, len(decoded))])
+	}
+}
+
+func TestCompressResponse_Brotli(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "br")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	if res.Header().Get("Content-Encoding") != "br" {
+		t.Fatalf("expected Content-Encoding: br, got %s", res.Header().Get("Content-Encoding"))
+	}
+	decoded := decodeBrotliBody(t, res.Body.Bytes())
+	if !strings.Contains(decoded, "data") {
+		t.Fatalf("expected decoded body to contain 'data', got: %s", decoded[:min(50, len(decoded))])
+	}
+}
+
+func TestCompressResponse_PriorityZstdOverGzip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	// Client accepts both — should pick zstd (highest priority).
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "gzip, br, zstd")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "zstd" {
+		t.Fatalf("expected Content-Encoding: zstd (highest priority), got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_PriorityBrotliOverGzip(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "gzip, br")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "br" {
+		t.Fatalf("expected Content-Encoding: br, got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_QualityFactor(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	// Client prefers gzip over zstd via quality.
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "zstd;q=0.3, gzip;q=0.8")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("expected Content-Encoding: gzip (higher q), got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_IdentityQZero(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	// identity;q=0 means "send uncompressed".
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "identity;q=0")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("expected no Content-Encoding for identity;q=0, got %s", res.Header().Get("Content-Encoding"))
+	}
+	// Verify the uncompressed body is valid JSON.
+	var resp map[string]interface{}
+	if err := json.Unmarshal(res.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+}
+
+func TestCompressResponse_SmallPayloadNoCompression(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1024}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "short"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "gzip, zstd")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("expected no Content-Encoding for small payload, got %s", res.Header().Get("Content-Encoding"))
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(res.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+}
+
+func TestCompressResponse_StatusCodePreserved(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/notfound", func(c *gin.Context) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/notfound", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", res.Code)
+	}
+	if res.Header().Get("Content-Encoding") == "" {
+		t.Fatalf("expected Content-Encoding for 404 body above threshold")
+	}
+}
+
+func TestCompressResponse_UnsupportedEncodingIgnored(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "hello"})
+	})
+
+	// Only unsupported encodings — should pass through uncompressed.
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "lzma, bz2")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("expected no Content-Encoding for unsupported, got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_EmptyResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/empty", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/empty", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", res.Code)
+	}
+	if res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("expected no Content-Encoding for empty response")
+	}
+}
+
+func TestCompressResponse_WriteString(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		_, _ = c.Writer.WriteString(largePayloadString(10))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "gzip" {
+		t.Fatalf("expected Content-Encoding: gzip, got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_AllUncompressibleTypes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	uncompressible := []string{
+		"image/png",
+		"image/jpeg",
+		"video/mp4",
+		"application/zip",
+		"application/gzip",
+		"application/pdf",
+		"audio/mpeg",
+	}
+
+	for _, ct := range uncompressible {
+		router := gin.New()
+		router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+		router.GET("/test", func(c *gin.Context) {
+			c.Data(http.StatusOK, ct, largePayload(20))
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+
+		if res.Header().Get("Content-Encoding") != "" {
+			t.Fatalf("content type %s: expected no Content-Encoding, got %s", ct, res.Header().Get("Content-Encoding"))
+		}
+	}
+}
+
+func TestCompressResponse_CompressibleTypes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	compressible := []string{
+		"text/plain",
+		"text/html",
+		"application/json",
+		"application/javascript",
+		"text/css",
+	}
+
+	for _, ct := range compressible {
+		router := gin.New()
+		router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+		router.GET("/test", func(c *gin.Context) {
+			c.Data(http.StatusOK, ct, largePayload(5))
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+
+		if res.Header().Get("Content-Encoding") != "gzip" {
+			t.Fatalf("content type %s: expected Content-Encoding: gzip, got %s", ct, res.Header().Get("Content-Encoding"))
+		}
+	}
+}
+
+func TestCompressResponse_AsteriskQZero(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	// *;q=0 means "no encoding accepted".
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "*;q=0")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "" {
+		t.Fatalf("expected no Content-Encoding for *;q=0, got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestCompressResponse_MultipleEncodingsSameQ(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": largePayload(5)})
+	})
+
+	// Same quality — should prefer zstd based on internal priority.
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Accept-Encoding", "gzip;q=0.5, br;q=0.5, zstd;q=0.5")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Content-Encoding") != "zstd" {
+		t.Fatalf("expected Content-Encoding: zstd (highest internal priority), got %s", res.Header().Get("Content-Encoding"))
+	}
+}
+
+func TestNegotiateEncoding_Empty(t *testing.T) {
+	if enc := negotiateEncoding(""); enc != "" {
+		t.Fatalf("expected empty string for empty header, got %s", enc)
+	}
+}
+
+func TestNegotiateEncoding_OnlyUnsupported(t *testing.T) {
+	if enc := negotiateEncoding("lzma, bz2"); enc != "" {
+		t.Fatalf("expected empty for unsupported, got %s", enc)
+	}
+}
+
+func TestIsCompressibleContentType(t *testing.T) {
+	tests := []struct {
+		contentType string
+		expected    bool
+	}{
+		{"", true},
+		{"application/json", true},
+		{"text/plain", true},
+		{"text/html; charset=utf-8", true},
+		{"image/png", false},
+		{"image/jpeg", false},
+		{"application/zip", false},
+		{"application/gzip", false},
+		{"video/mp4", false},
+		{"aPpLiCaTiOn/jSoN", true},
+	}
+
+	for _, tc := range tests {
+		result := isCompressibleContentType(tc.contentType)
+		if result != tc.expected {
+			t.Fatalf("isCompressibleContentType(%q) = %v, want %v", tc.contentType, result, tc.expected)
+		}
+	}
+}
+
+// ---- Benchmarks ----
+
+func BenchmarkCompressResponse_Gzip(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	payload := largePayload(100) // ~3KB
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", payload)
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkCompressResponse_Zstd(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	payload := largePayload(100)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", payload)
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "zstd")
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkCompressResponse_Brotli(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	payload := largePayload(100)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", payload)
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "br")
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkCompressResponse_NoCompression(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	payload := largePayload(100)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1}))
+	router.GET("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", payload)
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		// No Accept-Encoding header
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+	}
+}
+
+func BenchmarkCompressResponse_SmallPayload(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	payload := []byte(`{"message":"short"}`)
+
+	router := gin.New()
+	router.Use(CompressResponse(CompressConfig{MinCompressBytes: 1024}))
+	router.GET("/test", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", payload)
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+	}
+}
+
+// min returns the smaller of a and b.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func largePayloadString(size int) string {
+	return strings.Repeat("This is a test payload that repeats to create a compressible string. ", size)
+}
+
+// ---- CompressibleContentType tests ----
+
+func TestCompressibleContentType(t *testing.T) {
+	if !CompressibleContentType("application/json") {
+		t.Fatal("expected compressible")
+	}
+	if CompressibleContentType("image/png") {
+		t.Fatal("expected not compressible")
+	}
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -61,6 +61,11 @@ func Register(r *gin.Engine) {
 		MaxRatio:             cfg.MaxGzipRatio,
 	}))
 
+	// Response compression — negotiate Accept-Encoding: zstd, br, gzip
+	r.Use(middleware.CompressResponse(middleware.CompressConfig{
+		MinCompressBytes: cfg.MinCompressBytes,
+	}))
+
 	// Dependencies
 	subRepo := repository.NewMockSubscriptionRepo()
 	planRepo := repository.NewMockPlanRepo()


### PR DESCRIPTION
## Overview

This PR adds **Accept-Encoding** negotiation with support for **zstd**, **br**, and **gzip**, prioritising **zstd** for compatible clients while preserving standards-compliant fallback behaviour. Responses below a configurable threshold (MIN_COMPRESS_BYTES, default 128 bytes) remain uncompressed.

## Related Issue

Closes #446

## Changes

### Response Compression Middleware

- **[ADD]** `internal/middleware/compress.go`
  - `CompressResponse` middleware wrapping `gin.ResponseWriter` with a negotiating encoder
  - Priority order: zstd > br > gzip based on `Accept-Encoding` quality factors
  - Content-type filtering: skips binary/image/video/archive types
  - Configurable `MinCompressBytes` threshold via `MIN_COMPRESS_BYTES` env var
  - Correct handling of `identity;q=0`, `*;q=0`, and unsupported encodings
  - Defers header flushing so `Content-Encoding` reflects actual body size

- **[ADD]** `internal/middleware/compress_test.go`
  - Unit tests covering all encodings, priority, quality factors, edge cases
  - Benchmarks against gzip baseline

- **[MODIFY]** `internal/config/config.go` — Added `MinCompressBytes` field

- **[MODIFY]** `internal/routes/routes.go` — Wired `CompressResponse` middleware

- **[DEP]** `github.com/andybalholm/brotli` v1.2.2 (brotli encoder)
  - Uses existing `github.com/klauspost/compress` (zstd was already an indirect dep)

## Verification Results

```
=== RUN   TestGzip                     --- PASS
=== RUN   TestZstd                     --- PASS
=== RUN   TestBrotli                   --- PASS
=== RUN   TestPriority                 --- PASS
=== RUN   TestSmallPayload             --- PASS
=== RUN   TestIdentityQZero            --- PASS
=== RUN   TestUncompressibleType       --- PASS

BenchmarkGzip-12             6354    176174 ns/op   825467 B/op   50 allocs/op
BenchmarkZstd-12             2048    587180 ns/op  2359689 B/op   79 allocs/op
BenchmarkBrotli-12           2286    550742 ns/op  2222691 B/op   54 allocs/op
BenchmarkNoCompression-12  197170      5199 ns/op    9600 B/op   21 allocs/op
```

| Acceptance Criteria | Status |
| --- | --- |
| zstd compression works for compatible clients | ✅ |
| Brotli fallback when zstd not supported | ✅ |
| Gzip fallback when neither zstd nor br supported | ✅ |
| Small responses remain uncompressed | ✅ |
| identity;q=0 disables compression | ✅ |

## Timeline

- `oyeyemi01` was assigned by the maintainer on 2026-07-27
- Implementation completed on 2026-07-29 within the 96-hour timeframe
