### PR TITLE
feat: drain DB pool gracefully on SIGTERM before pod exit

### DIFF
--- a/PR_DESCRIPTION_685.md
+++ b/PR_DESCRIPTION_685.md
@@ -1,0 +1,232 @@
+# PR: Enable Graceful Pool Draining on SIGTERM Before Pod Exit
+
+**Closes:** #685  
+**Branch:** `feat/graceful-pool-drain`  
+**Author:** Buffy (Freebuff AI)  
+**Type:** Feature / Reliability
+
+---
+
+## Summary
+
+On SIGTERM, the server now **stops accepting new HTTP requests**, waits for in-flight requests to complete (bounded by a configurable grace period), **drains and closes the `pgxpool.Pool` cleanly**, and records a `shutdown_duration_seconds` histogram — all before the process exits. This eliminates half-open database connections that previously survived pod restarts and could block the next replica from starting.
+
+---
+
+## Problem
+
+Before this PR, the application handled `SIGTERM` by performing a graceful HTTP server shutdown (`srv.Shutdown()`), but the `*pgxpool.Pool` was never explicitly drained or closed. This meant:
+
+1. **Half-open connections** — Acquired connections with in-flight queries were left dangling when the process exited without waiting for them to finish or rollback.
+2. **Startup blocking** — The next replica (in a rolling deployment) could be blocked from acquiring connections if the previous pod's connections were still visible to the database as "idle in transaction" or "active".
+3. **No observability** — No metric captured how long shutdown took, making it hard to tune `terminationGracePeriodSeconds` in Kubernetes.
+4. **Silent cleanup failures** — If cleanup failed, there was no log output to alert operators.
+
+---
+
+## Solution
+
+### High-Level Flow
+
+```
+SIGTERM received
+    │
+    ▼
+┌─────────────────────────────────┐
+│  HTTP server stops accepting     │  srv.Shutdown(shutdownCtx)
+│  new connections                 │  bounded by GracefulShutdownTimeout
+│  Drains in-flight HTTP requests  │  (default 30s, env: GRACEFUL_SHUTDOWN_TIMEOUT)
+└──────────────┬──────────────────┘
+               │
+               ▼
+┌─────────────────────────────────┐
+│  DB pool drain                   │  DrainPool(ctx, pool)
+│  - Calls pool.Close() in         │  bounded by fresh GracefulShutdownTimeout
+│    goroutine with timeout ctx    │  (always runs even if HTTP shutdown timed out)
+│  - Logs errors to stderr         │
+│  - Records ShutdownDuration      │
+│    histogram                     │
+└──────────────┬──────────────────┘
+               │
+               ▼
+           Process exits
+```
+
+### Key Design Decisions
+
+1. **Sequential draining** — HTTP shutdown completes first, then the DB pool. This ensures no new queries are submitted while connections are being drained.
+2. **Cleanup always runs** — A `defer` in `runHTTPServer` guarantees the pool drain fires even when `srv.Shutdown()` times out or a second signal forces an immediate close. If we didn't do this, a stuck HTTP handler would prevent the pool from ever closing.
+3. **Fresh timeout context for drain** — The pool drain gets its own `context.WithTimeout` (matching `GracefulShutdownTimeout`) rather than reusing the potentially-expired HTTP shutdown context.
+4. **Errors are logged, not swallowed** — Drain failures are written to stderr via `log.Printf` so operators can detect when connections were forcefully terminated rather than drained cleanly.
+5. **Nil-safe** — `DrainPool` is a no-op when the pool is `nil` (e.g., local dev without `DATABASE_URL`), so the server still shuts down gracefully in all environments.
+
+---
+
+## Files Changed (10 files, +321 / −25 lines)
+
+### Core Implementation
+
+| File | Change |
+|---|---|
+| `internal/db/pool.go` | Added `DrainPool(ctx, pool)` — runs `pool.Close()` in a goroutine with a bounded context deadline. Returns `context.DeadlineExceeded` on timeout. Nil-safe. |
+| `cmd/server/providers.go` | Added `ProvideDBPool(cfg)` — creates `*pgxpool.Pool` from validated config with a connect-timeout context. Returns `(nil, nil)` when `cfg.DBConn` is empty. |
+| `cmd/server/wire.go` | Added `ProvideDBPool` to `AppProviders`. Changed `InitializeServer()` return type from `(*http.Server, error)` → `(*pgxpool.Pool, *http.Server, error)`. |
+| `cmd/server/wire_gen.go` | Updated generated DI code to match `wire.go`. `InitializeServer` now calls `ProvideDBPool` and returns the pool alongside the server. |
+| `cmd/server/main.go` | **`main()`**: receives pool from `InitializeServer`, creates cleanup closure that calls `DrainPool` and records `ShutdownDuration` histogram. Reads `GRACEFUL_SHUTDOWN_TIMEOUT` via `shutdownTimeoutSecs()` helper (default 30s, validated 1–600s). **`runHTTPServer()`**: cleanup is now deferred and always runs (even on HTTP shutdown timeout). Errors are logged rather than silently discarded. |
+
+### Tests
+
+| File | Change |
+|---|---|
+| `internal/db/pool_test.go` | **5 new tests**: `TestDrainPool_NilPool` (nil safety), `TestDrainPool_AlreadyClosedPool`, `TestDrainPool_ContextCancelled` (pre-cancelled context), `TestDrainPool_ClosesPoolCleanly` (happy path), `TestDrainPool_TimeoutWithAcquiredConnection` (edge case: long-running query via `pg_sleep(2)` with 200ms drain timeout → verifies `DeadlineExceeded`). Test helper `newTestPool(t)` skips gracefully when `DATABASE_URL` is not set or in short mode. |
+| `cmd/server/main_test.go` | **Updated** `TestRunHTTPServer_SecondSignalForcesClose` — fixed assertion (was checking for non-existent `"forced shutdown after second signal"` string), now verifies cleanup is called after forced close. **New** `TestRunHTTPServer_CleanupCalledOnTimeout` — verifies cleanup runs even when HTTP shutdown times out (the key invariant). |
+
+### Kubernetes Manifests
+
+| File | Change |
+|---|---|
+| `deploy/kustomize/base/deployment.yaml` | Added `terminationGracePeriodSeconds: 65` with inline documentation explaining the formula: `2 × GRACEFUL_SHUTDOWN_TIMEOUT + 5s buffer`. |
+| `deploy/helm/stellabill/templates/deployment.yaml` | Added conditional `terminationGracePeriodSeconds` block that reads from `values.yaml`. |
+| `deploy/helm/stellabill/values.yaml` | Added `terminationGracePeriodSeconds: 65` to both `api` and `worker` sections with documentation. |
+
+---
+
+## Timing & Kubernetes Coordination
+
+```
+Application startup
+    │
+    ├─ config.Load()  ── reads GRACEFUL_SHUTDOWN_TIMEOUT (default 30s)
+    ├─ ProvideDBPool() ── creates pgxpool.Pool (bounded by DBPoolConnectTimeout)
+    └─ ListenAndServe()
+            │
+    SIGTERM from kubelet
+            │
+    ┌───────┴─────────────────────────────────────────────┐
+    │  Phase 1: HTTP Shutdown  (≤ 30s)                     │
+    │  srv.Shutdown(shutdownCtx) blocks until all handlers  │
+    │  return or deadline fires                             │
+    └───────┬─────────────────────────────────────────────┘
+            │
+    ┌───────┴─────────────────────────────────────────────┐
+    │  Phase 2: DB Pool Drain  (≤ 30s)                     │
+    │  DrainPool(cleanupCtx, pool)                          │
+    │    → pool.Close() in goroutine                        │
+    │    → waits for acquired connections                    │
+    │    → returns on completion or DeadlineExceeded         │
+    │  ShutdownDuration.Observe(elapsed)                     │
+    └───────┬─────────────────────────────────────────────┘
+            │
+        exit(0)
+
+Total worst-case application drain: ≤ 60s (2 × 30s)
+Kubernetes terminationGracePeriodSeconds: 65s (60s + 5s buffer)
+```
+
+**Important:** If you change `GRACEFUL_SHUTDOWN_TIMEOUT` from the default, update `terminationGracePeriodSeconds` accordingly. The formula is:
+
+```
+terminationGracePeriodSeconds ≥ 2 × GRACEFUL_SHUTDOWN_TIMEOUT + 5
+```
+
+---
+
+## Edge Cases Covered
+
+| Edge Case | Behavior | Test Coverage |
+|---|---|---|
+| **No database configured** (`DATABASE_URL` empty) | `ProvideDBPool` returns `(nil, nil)`. `DrainPool` is a no-op on nil pool. Server shuts down normally. | `TestNewPool_EmptyDBConnReturnsNilNil` + `TestDrainPool_NilPool` |
+| **HTTP shutdown times out** (stuck handler) | Cleanup defer fires with fresh context, pool drain still runs. Error logged. | `TestRunHTTPServer_CleanupCalledOnTimeout` |
+| **Second SIGTERM forces immediate close** | `srv.Close()` called. Cleanup defer still runs (pool drain). Error logged. | `TestRunHTTPServer_SecondSignalForcesClose` |
+| **Long-running query holds connection** | `pool.Close()` blocks. Drain deadline fires → returns `DeadlineExceeded`. PG sends cancel/terminate → rollback. | `TestDrainPool_TimeoutWithAcquiredConnection` (uses `pg_sleep(2)`) |
+| **Pool already closed** (e.g., prior drain attempt) | `pool.Close()` is idempotent. Drain returns nil. | `TestDrainPool_AlreadyClosedPool` |
+| **Context cancelled before drain** | Drain observes `ctx.Done()` and returns `context.Canceled`. | `TestDrainPool_ContextCancelled` |
+| **Pool closes cleanly** (no in-flight queries) | Drain returns nil. Subsequent `Ping` fails (pool is closed). | `TestDrainPool_ClosesPoolCleanly` |
+
+---
+
+## Metrics
+
+### `shutdown_duration_seconds` (histogram)
+
+Already existed in `internal/metrics/metrics.go`. Now actually **recorded** during graceful shutdown.
+
+- **Buckets:** `[0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 30]`
+- **Labels:** none (global metric)
+- **Observed:** In the cleanup closure, timing the full `DrainPool` call
+
+**Alert ideas:**
+- `shutdown_duration_seconds` approaching `GRACEFUL_SHUTDOWN_TIMEOUT` → pool drain is slow, investigate query performance or increase timeout
+- `shutdown_duration_seconds` exceeding `GRACEFUL_SHUTDOWN_TIMEOUT` → drain timed out, connections may have been force-terminated
+
+---
+
+## Configuration
+
+| Env Var | Default | Valid Range | Description |
+|---|---|---|---|
+| `GRACEFUL_SHUTDOWN_TIMEOUT` | `30` | `1`–`600` seconds | Maximum time for HTTP shutdown AND pool drain (each gets its own timeout). Already existed in `config.go`, now also consumed by `main.go`. |
+| `DB_POOL_CONNECT_TIMEOUT` | `5` | `1`–`300` seconds | Per-dial timeout when creating the pool at startup. No change. |
+
+---
+
+## Migration / Rollback
+
+- **No database schema changes.**
+- **No configuration changes required.** Existing `GRACEFUL_SHUTDOWN_TIMEOUT` continues to work.
+- **Backward compatible.** If the pool is `nil` (e.g., old deployment without `DATABASE_URL`), shutdown proceeds normally.
+- **If reverting:** Simply revert this commit. The `terminationGracePeriodSeconds: 65` in Kubernetes is safe to leave (it's a maximum, not a minimum).
+
+---
+
+## Verification
+
+### Before merging
+
+```bash
+# Run unit tests (short mode, no DB required)
+go test -short -count=1 ./cmd/server/... ./internal/db/...
+
+# Run integration tests (requires DATABASE_URL)
+DATABASE_URL="postgres://user:pass@localhost:5432/test?sslmode=disable" \
+  go test -count=1 -run 'TestDrainPool' ./internal/db/...
+
+# Lint
+golangci-lint run ./cmd/server/... ./internal/db/...
+
+# Regenerate wire (if providers change)
+go generate ./cmd/server/...
+```
+
+### In staging
+
+1. Deploy with `GRACEFUL_SHUTDOWN_TIMEOUT=30`
+2. Trigger a rolling restart: `kubectl rollout restart deployment/stellabill-api`
+3. Watch logs for `cleanup error during shutdown` (should not appear in normal operation):
+   ```
+   kubectl logs -l app=stellabill --tail=50 | grep "cleanup error"
+   ```
+4. Check Prometheus for `shutdown_duration_seconds`:
+   ```
+   shutdown_duration_seconds_bucket{le="30"} - shutdown_duration_seconds_bucket{le="5"}
+   ```
+5. Verify no `pg_stat_activity` entries remain from terminated pods:
+   ```sql
+   SELECT pid, state, query_start, query
+   FROM pg_stat_activity
+   WHERE backend_type = 'client backend' AND state != 'idle';
+   ```
+
+### Post-deploy
+
+1. Monitor `shutdown_duration_seconds` for 24h
+2. If p99 approaches 25s during peak traffic, increase `GRACEFUL_SHUTDOWN_TIMEOUT` and adjust `terminationGracePeriodSeconds`
+
+---
+
+## Future Work
+
+- [ ] Wire the real `*pgxpool.Pool` into `routes.Register()` so handlers use the drained pool (currently uses mock repos)
+- [ ] Add a `shutdown_connections_leaked` gauge that reports `pg_stat_activity` count after drain
+- [ ] Consider draining read-replica pools in `internal/db/router.go` when a read/write split is active
+- [ ] Benchmark drain latency under load (100+ concurrent long-running queries) to validate timeout choices

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,8 +8,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
+
+	"stellarbill-backend/internal/db"
+	"stellarbill-backend/internal/metrics"
 )
 
 // listenAndServe is a package-level variable so tests can inject a fake
@@ -19,7 +23,7 @@ var listenAndServe = func(srv *http.Server) error {
 }
 
 func main() {
-	srv, err := InitializeServer()
+	pool, srv, err := InitializeServer()
 	if err != nil {
 		printConfigError(err)
 		os.Exit(1)
@@ -28,14 +32,29 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	shutdownTimeout := time.Duration(shutdownTimeoutSecs()) * time.Second
+
+	// cleanup drains the database pool after the HTTP server has stopped
+	// accepting new connections. It always runs (even if HTTP shutdown timed
+	// out) so half-open connections are closed before the process exits.
+	cleanup := func(cleanupCtx context.Context) error {
+		start := time.Now()
+		defer func() {
+			metrics.ShutdownDuration.Observe(time.Since(start).Seconds())
+		}()
+		return db.DrainPool(cleanupCtx, pool)
+	}
+
 	log.Printf("server listening on %s", srv.Addr)
-	if err := runHTTPServer(ctx, make(chan os.Signal, 1), srv, 30*time.Second, nil); err != nil {
+	if err := runHTTPServer(ctx, make(chan os.Signal, 1), srv, shutdownTimeout, cleanup); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
 }
 
 // runHTTPServer starts srv and performs a graceful shutdown when ctx is
-// cancelled.  The optional cleanup function is called during shutdown.
+// cancelled.  The optional cleanup function is always called during shutdown
+// (even if HTTP shutdown times out) so that resources such as the database
+// pool are drained before the process exits.
 // A second signal on secondSignal forces an immediate close.
 func runHTTPServer(
 	ctx context.Context,
@@ -62,6 +81,20 @@ func runHTTPServer(
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
+	// Always call cleanup on exit so resources (DB pool) are drained even
+	// when the HTTP server shutdown times out.  cleanup gets a fresh context
+	// to avoid racing with an expired shutdownCtx. Errors are logged rather
+	// than returned so the HTTP shutdown error takes precedence.
+	defer func() {
+		if cleanup != nil {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer cleanupCancel()
+			if err := cleanup(cleanupCtx); err != nil {
+				log.Printf("cleanup error during shutdown: %v", err)
+			}
+		}
+	}()
+
 	// A second signal forces an immediate close.
 	go func() {
 		select {
@@ -77,12 +110,6 @@ func runHTTPServer(
 
 	if shutdownCtx.Err() == context.DeadlineExceeded {
 		return fmt.Errorf("http server shutdown: timed out")
-	}
-
-	if cleanup != nil {
-		if err := cleanup(shutdownCtx); err != nil {
-			return fmt.Errorf("cleanup: %w", err)
-		}
 	}
 
 	if err := <-serverErr; err != nil {
@@ -101,4 +128,17 @@ type stdLogger struct{}
 
 func (stdLogger) Error(msg string, keysAndValues ...any) {
 	log.Println(append([]any{"ERROR: " + msg}, keysAndValues...)...)
+}
+
+// shutdownTimeoutSecs reads the GRACEFUL_SHUTDOWN_TIMEOUT env var, falling
+// back to 30 seconds. This is kept outside config.Load() so main() can
+// consume the graceful shutdown timeout without threading the full Config
+// through InitializeServer.
+func shutdownTimeoutSecs() int {
+	if v := os.Getenv("GRACEFUL_SHUTDOWN_TIMEOUT"); v != "" {
+		if s, err := strconv.Atoi(v); err == nil && s >= 1 && s <= 600 {
+			return s
+		}
+	}
+	return 30
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -138,6 +138,7 @@ func TestRunHTTPServer_SecondSignalForcesClose(t *testing.T) {
 	ln, restore := listenOnLocalhost(t)
 	defer restore()
 
+	var cleanupCalled atomic.Bool
 	started := make(chan struct{})
 	srv := &http.Server{
 		Addr: ln.Addr().String(),
@@ -151,7 +152,10 @@ func TestRunHTTPServer_SecondSignalForcesClose(t *testing.T) {
 	secondSignal := make(chan os.Signal, 1)
 	done := make(chan error, 1)
 	go func() {
-		done <- runHTTPServer(ctx, secondSignal, srv, time.Second, nil)
+		done <- runHTTPServer(ctx, secondSignal, srv, time.Second, func(context.Context) error {
+			cleanupCalled.Store(true)
+			return nil
+		})
 	}()
 
 	client := &http.Client{Timeout: time.Second}
@@ -167,10 +171,59 @@ func TestRunHTTPServer_SecondSignalForcesClose(t *testing.T) {
 
 	err := <-done
 	if err == nil {
-		t.Fatal("expected forced shutdown error")
+		t.Fatal("expected error after second signal forced close")
 	}
-	if !strings.Contains(err.Error(), "forced shutdown after second signal") {
-		t.Fatalf("expected forced shutdown error, got %v", err)
+	if !strings.Contains(err.Error(), "http server shutdown") {
+		t.Fatalf("expected shutdown error to mention http server shutdown, got %v", err)
+	}
+	if !cleanupCalled.Load() {
+		t.Fatal("expected cleanup to be called even after second signal forced close")
+	}
+	<-clientDone
+}
+
+// TestRunHTTPServer_CleanupCalledOnTimeout verifies that the cleanup function
+// is called even when the HTTP server shutdown times out. This ensures the
+// database pool is always drained before exit.
+func TestRunHTTPServer_CleanupCalledOnTimeout(t *testing.T) {
+	ln, restore := listenOnLocalhost(t)
+	defer restore()
+
+	started := make(chan struct{})
+	var cleanupCalled atomic.Bool
+	srv := &http.Server{
+		Addr: ln.Addr().String(),
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			close(started)
+			select {} // hang forever to cause shutdown timeout
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runHTTPServer(ctx, make(chan os.Signal), srv, 25*time.Millisecond, func(context.Context) error {
+			cleanupCalled.Store(true)
+			return nil
+		})
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	clientDone := make(chan struct{})
+	go func() {
+		_, _ = client.Get("http://" + ln.Addr().String())
+		close(clientDone)
+	}()
+
+	<-started
+	cancel()
+
+	err := <-done
+	if err == nil {
+		t.Fatal("expected shutdown timeout error")
+	}
+	if !cleanupCalled.Load() {
+		t.Fatal("expected cleanup to be called even on shutdown timeout")
 	}
 	<-clientDone
 }

--- a/cmd/server/providers.go
+++ b/cmd/server/providers.go
@@ -14,14 +14,17 @@ package main
 //     defaulted to zero, preventing accidental unbounded connections.
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
 
 	"stellarbill-backend/internal/config"
+	"stellarbill-backend/internal/db"
 	"stellarbill-backend/internal/routes"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // ProvideConfig loads and validates the application configuration from the
@@ -45,6 +48,21 @@ func ProvideRouter(cfg config.Config) *gin.Engine {
 	router.Use(gin.Recovery())
 	routes.Register(router)
 	return router
+}
+
+// ProvideDBPool creates a *pgxpool.Pool from the validated config. When
+// cfg.DBConn is empty (e.g. local dev without DATABASE_URL), it returns
+// (nil, nil) so callers can degrade gracefully.
+//
+// The pool is created with a context bound by DBPoolConnectTimeout so startup
+// fails fast when the database is unreachable.
+func ProvideDBPool(cfg config.Config) (*pgxpool.Pool, error) {
+	ctx, cancel := context.WithTimeout(
+		context.Background(),
+		time.Duration(cfg.DBPoolConnectTimeout)*time.Second,
+	)
+	defer cancel()
+	return db.NewPool(ctx, cfg)
 }
 
 // ProvideHTTPServer assembles an *http.Server from the validated config and

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/google/wire"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // AppProviders is the complete set of constructor functions that wire uses to
@@ -28,6 +29,7 @@ import (
 var AppProviders = wire.NewSet(
 	ProvideConfig,
 	ProvideRouter,
+	ProvideDBPool,
 	ProvideHTTPServer,
 )
 
@@ -36,9 +38,9 @@ var AppProviders = wire.NewSet(
 //
 // The function signature is the public contract:
 //   - no inputs – all values come from the provider chain.
-//   - returns (*http.Server, error) so callers can detect config failures
-//     without a panic.
-func InitializeServer() (*http.Server, error) {
+//   - returns (*pgxpool.Pool, *http.Server, error) — the pool is needed so
+//     main() can drain it during graceful shutdown.
+func InitializeServer() (*pgxpool.Pool, *http.Server, error) {
 	wire.Build(AppProviders)
-	return nil, nil
+	return nil, nil, nil
 }

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/google/wire"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"net/http"
 )
 
@@ -18,16 +19,20 @@ import (
 //
 // The function signature is the public contract:
 //   - no inputs – all values come from the provider chain.
-//   - returns (*http.Server, error) so callers can detect config failures
-//     without a panic.
-func InitializeServer() (*http.Server, error) {
+//   - returns (*pgxpool.Pool, *http.Server, error) — the pool is needed so
+//     main() can drain it during graceful shutdown.
+func InitializeServer() (*pgxpool.Pool, *http.Server, error) {
 	config, err := ProvideConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	engine := ProvideRouter(config)
+	pool, err := ProvideDBPool(config)
+	if err != nil {
+		return nil, nil, err
+	}
 	server := ProvideHTTPServer(config, engine)
-	return server, nil
+	return pool, server, nil
 }
 
 // wire.go:
@@ -40,5 +45,6 @@ func InitializeServer() (*http.Server, error) {
 var AppProviders = wire.NewSet(
 	ProvideConfig,
 	ProvideRouter,
+	ProvideDBPool,
 	ProvideHTTPServer,
 )

--- a/deploy/helm/stellabill/templates/deployment.yaml
+++ b/deploy/helm/stellabill/templates/deployment.yaml
@@ -11,9 +11,12 @@ metadata:
     {{- include "stellabill.labels" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $component }}
     tier: {{ $values.labels.tier }}
-spec:
-  replicas: {{ $values.replicas }}
-  selector:
+spec:  replicas: {{ $values.replicas }}
+      {{- if $values.terminationGracePeriodSeconds }}
+      # Coordinate with GRACEFUL_SHUTDOWN_TIMEOUT — see deploy/kustomize/base/deployment.yaml
+      terminationGracePeriodSeconds: {{ $values.terminationGracePeriodSeconds }}
+      {{- end }}
+      selector:
     matchLabels:
       {{- include "stellabill.componentSelectorLabels" (dict "Chart" $.Chart "Release" $.Release "component" $component) | nindent 6 }}
       tier: {{ $values.labels.tier }}

--- a/deploy/helm/stellabill/values.yaml
+++ b/deploy/helm/stellabill/values.yaml
@@ -120,6 +120,10 @@ api:
     # For single-node dev clusters, override with maxUnavailable: 1
     minAvailable: 1
     maxUnavailable: null
+  # Coordinate with GRACEFUL_SHUTDOWN_TIMEOUT (default 30s). The application
+  # drains HTTP server → DB pool sequentially, each bounded by 30s. Set
+  # terminationGracePeriodSeconds >= 65 (2*30 + 5 buffer).
+  terminationGracePeriodSeconds: 65
   topologySpread:
     enabled: true
     maxSkew: 1
@@ -169,6 +173,8 @@ worker:
     enabled: true
     minAvailable: 1
     maxUnavailable: null
+  # Coordinate with GRACEFUL_SHUTDOWN_TIMEOUT — see api section above.
+  terminationGracePeriodSeconds: 65
   topologySpread:
     enabled: true
     maxSkew: 1

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -8,6 +8,14 @@ metadata:
     component: backend
 spec:
   replicas: 2
+  # Coordinate with GRACEFUL_SHUTDOWN_TIMEOUT (default 30s). The
+  # application drains the HTTP server first (up to
+  # GRACEFUL_SHUTDOWN_TIMEOUT), then drains the DB pool (up to another
+  # GRACEFUL_SHUTDOWN_TIMEOUT). Add a 5s buffer so Kubernetes doesn't
+  # SIGKILL the pod while the pool is still draining.
+  # Formula: >= 2 * GRACEFUL_SHUTDOWN_TIMEOUT + 5
+  # Default: >= 65 seconds (30 + 30 + 5).
+  terminationGracePeriodSeconds: 65
   selector:
     matchLabels:
       app: stellabill

--- a/internal/db/pool.go
+++ b/internal/db/pool.go
@@ -104,6 +104,32 @@ func (t *timingTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, _ pgx.Tra
 	}
 }
 
+// DrainPool stops accepting new connections and waits for in-flight queries to
+// complete, bounded by ctx. It closes the pool afterward and should be called
+// during graceful shutdown after the HTTP server has stopped accepting new
+// requests. A nil pool is a no-op.
+//
+// Because pgxpool.Pool.Close() blocks until all acquired connections are
+// released, DrainPool runs Close in a separate goroutine and respects ctx.
+func DrainPool(ctx context.Context, pool *pgxpool.Pool) error {
+	if pool == nil {
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		pool.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("drain database pool: %w", ctx.Err())
+	}
+}
+
 // NewPool constructs a pgx connection pool from cfg, applying the DBPool*
 // tuning fields and PgBouncer settings, and verifies connectivity before
 // returning.

--- a/internal/db/pool_test.go
+++ b/internal/db/pool_test.go
@@ -2,10 +2,12 @@ package db
 
 import (
 	"context"
+	"os"
 	"stellarbill-backend/internal/config"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -111,4 +113,136 @@ func TestPoolPinger_SatisfiesDBPinger(t *testing.T) {
 		PingContext(ctx context.Context) error
 	}
 	var _ dbPinger = (*PoolPinger)(nil)
+}
+
+// ─── DrainPool tests ────────────────────────────────────────────────────────
+
+func TestDrainPool_NilPool(t *testing.T) {
+	err := DrainPool(context.Background(), nil)
+	assert.NoError(t, err, "nil pool must be a no-op, not an error")
+}
+
+func TestDrainPool_AlreadyClosedPool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database test in short mode")
+	}
+
+	pool := newTestPool(t)
+	pool.Close() // close immediately
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := DrainPool(ctx, pool)
+	assert.NoError(t, err, "draining an already-closed pool must succeed")
+}
+
+func TestDrainPool_ContextCancelled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database test in short mode")
+	}
+
+	pool := newTestPool(t)
+	defer pool.Close()
+
+	// Cancel context immediately so DrainPool times out before pool.Close()
+	// completes (pool has no acquired connections so it should close fast,
+	// but we verify the timeout path is exercised).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := DrainPool(ctx, pool)
+	// The pool may close before the cancelled context is observed, so either
+	// nil or context.Canceled is acceptable.
+	if err != nil && err.Error() != context.Canceled.Error() {
+		t.Errorf("expected nil or context.Canceled, got: %v", err)
+	}
+}
+
+func TestDrainPool_ClosesPoolCleanly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database test in short mode")
+	}
+
+	pool := newTestPool(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := DrainPool(ctx, pool)
+	require.NoError(t, err, "draining an open pool must succeed")
+
+	// After draining, the pool should be closed. Verify by trying to ping.
+	pingErr := pool.Ping(context.Background())
+	assert.Error(t, pingErr, "ping after drain must fail (pool is closed)")
+}
+
+// TestDrainPool_TimeoutWithAcquiredConnection verifies that DrainPool returns
+// context.DeadlineExceeded when a connection is held open and the deadline
+// fires. This simulates a long-running query that prevents pool.Close() from
+// completing within the grace period.
+func TestDrainPool_TimeoutWithAcquiredConnection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database test in short mode")
+	}
+
+	pool := newTestPool(t)
+
+	// Acquire a connection and start a long-running query so pool.Close()
+	// cannot complete before the drain deadline fires.
+	conn, err := pool.Acquire(context.Background())
+	require.NoError(t, err)
+	defer conn.Release()
+
+	// pg_sleep holds the connection for 2s — longer than our 200ms drain
+	// timeout, guaranteeing the deadline fires first.
+	queryDone := make(chan error, 1)
+	go func() {
+		_, qErr := conn.Exec(context.Background(), "SELECT pg_sleep(2)")
+		queryDone <- qErr
+	}()
+
+	// Drain with a short deadline that fires before pg_sleep completes.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	drainErr := DrainPool(ctx, pool)
+	elapsed := time.Since(start)
+
+	require.Error(t, drainErr, "drain must fail when connection is held open")
+	assert.ErrorIs(t, drainErr, context.DeadlineExceeded,
+		"drain timeout must surface as DeadlineExceeded")
+	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
+		"must wait at least the deadline before returning")
+
+	// Wait for pg_sleep to finish so the connection can be released cleanly.
+	if err := <-queryDone; err != nil {
+		// Connection may have been terminated by pool.Close() during drain.
+		t.Logf("pg_sleep completed with: %v", err)
+	}
+}
+
+// newTestPool creates a pool pointing at the DATABASE_URL env var for
+// integration-style tests. Skips if no URL is set or SHORT mode is active.
+func newTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	pool, err := pgxpool.New(context.Background(), dsn)
+	require.NoError(t, err, "failed to create test pool")
+
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Skipf("database not reachable: %v", err)
+	}
+
+	t.Cleanup(func() {
+		pool.Close()
+	})
+	return pool
 }


### PR DESCRIPTION
On SIGTERM, the server stops accepting new HTTP requests, waits for in-flight requests to complete up to a bounded grace period, then drains and closes the pgxpool.Pool cleanly before exit. This eliminates half-open connections that could block the next replica from starting during rolling deployments.

Core changes:
- Add DrainPool(ctx, pool) to internal/db/pool.go — runs pool.Close() in a goroutine with a bounded context deadline, nil-safe, returns DeadlineExceeded on timeout
- Add ProvideDBPool provider to wire DI graph
- Modify InitializeServer() to return *pgxpool.Pool alongside *http.Server
- Wire pool drain into runHTTPServer via cleanup callback; cleanup always runs via defer (even on HTTP shutdown timeout)
- Record shutdown_duration_seconds histogram in cleanup path
- Read GRACEFUL_SHUTDOWN_TIMEOUT env var (default 30s) with validation bounds 1–600s
- Add terminationGracePeriodSeconds: 65 to K8s manifests (2 x 30s + 5s buffer), with documentation on the formula

Edge cases covered:
- Nil pool (no DATABASE_URL) — no-op shutdown
- HTTP shutdown timeout — cleanup still fires via defer
- Second SIGTERM forced close — cleanup still fires
- Long-running query holding connection — drain deadline fires, pg_sleep test exercises this path
- Already-closed pool — idempotent Close()
- Pre-cancelled context — returns context.Canceled

Files changed: 10 files, +321/-25
- cmd/server/main.go, main_test.go, providers.go, wire.go, wire_gen.go
- internal/db/pool.go, pool_test.go
- deploy/kustomize/base/deployment.yaml
- deploy/helm/stellabill/templates/deployment.yaml, values.yaml

Closes #685