### PR TITLE
feat: add Argon2id password hashing helper

### DIFF
--- a/internal/security/passhash.go
+++ b/internal/security/passhash.go
@@ -1,0 +1,186 @@
+// Package security provides primitives for admin authentication hardening,
+// including exponential lockout tracking for failed login attempts and
+// Argon2id password hashing for future local admin credential storage.
+//
+// # Argon2id parameters
+//
+// The cost parameters below follow the OWASP Password Storage Cheat Sheet
+// (2024 edition, https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
+// and RFC 9106 §4 "Parameter Choice" recommendations for interactive logins:
+//
+//   - Memory:      64 MiB  (RFC 9106 recommends ≥ 64 MiB for interactive use)
+//   - Iterations:  3       (OWASP minimum for Argon2id interactive profile)
+//   - Parallelism: 4       (matches a typical 4-vCPU deployment; tune with BenchmarkHash)
+//   - Salt length: 16 B    (128-bit, per RFC 9106 §3.1 "Recommended Parameters")
+//   - Tag length:  32 B    (256-bit output, sufficient for password verification)
+//
+// These parameters target ≥ 100 ms per hash on reference hardware (2024
+// commodity server, single core).  Run the benchmark to verify on your
+// deployment target:
+//
+//	go test -bench=BenchmarkHash -benchtime=5s ./internal/security/
+//
+// Do NOT weaken these parameters under any build tag.  Reducing memory or
+// iterations degrades resistance to offline dictionary attacks.
+package security
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Argon2id cost parameters.  These are intentionally unexported package-level
+// constants so that no call site can accidentally pass lower values.
+//
+// Sources:
+//   - OWASP PCSC 2024: memory=64MiB, iterations=3, parallelism=4
+//   - RFC 9106 §4: salt≥128 bits, tag≥128 bits
+const (
+	argonMemory      uint32 = 64 * 1024 // 64 MiB in KiB
+	argonIterations  uint32 = 3
+	argonParallelism uint8  = 4
+	argonSaltLen            = 16 // bytes → 128-bit salt
+	argonKeyLen      uint32 = 32 // bytes → 256-bit tag
+)
+
+// encodingVersion is embedded in every encoded hash so future parameter
+// migrations can be detected without breaking existing stored hashes.
+const encodingVersion = "v1"
+
+// ErrMismatch is returned by Verify when the password does not match the
+// stored hash.  It is intentionally opaque — callers must not log or surface
+// the inner details of a failed verification.
+var ErrMismatch = errors.New("security: password does not match")
+
+// ErrInvalidHash is returned by Verify when the encoded hash string is
+// syntactically malformed or contains unrecognised fields.  This covers
+// truncated strings, wrong field count, non-base64 payloads, and unsupported
+// version tags — all without panicking.
+var ErrInvalidHash = errors.New("security: encoded hash is malformed")
+
+// Hash derives an Argon2id digest of password and returns a self-describing
+// encoded string that embeds all parameters needed for future verification.
+// Each call generates a fresh cryptographically random salt, so the same
+// password will never produce the same encoded output twice.
+//
+// The returned string has the form:
+//
+//	$argon2id$v1$m=65536,t=3,p=4$<salt-b64>$<hash-b64>
+//
+// Store this entire string; pass it unchanged to Verify.
+//
+// Hash returns a non-nil error only when the OS CSPRNG is unavailable
+// (extremely rare).  It never returns a nil error with an empty string.
+func Hash(password string) (string, error) {
+	salt := make([]byte, argonSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("security: generating salt: %w", err)
+	}
+
+	hash := argon2.IDKey(
+		[]byte(password),
+		salt,
+		argonIterations,
+		argonMemory,
+		argonParallelism,
+		argonKeyLen,
+	)
+
+	encoded := fmt.Sprintf(
+		"$argon2id$%s$m=%d,t=%d,p=%d$%s$%s",
+		encodingVersion,
+		argonMemory,
+		argonIterations,
+		argonParallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	)
+
+	return encoded, nil
+}
+
+// Verify checks whether password matches the encoded hash produced by Hash.
+// It uses a constant-time comparison to prevent timing-based side-channel
+// attacks.
+//
+// Return values:
+//   - nil            — password matches
+//   - ErrMismatch    — password is wrong; do not log the provided password
+//   - ErrInvalidHash — encoded is syntactically malformed; log and investigate
+//   - other error    — unexpected internal failure
+//
+// Verify never panics, even when given an arbitrarily corrupt encoded string.
+func Verify(password, encoded string) error {
+	salt, storedHash, params, err := decode(encoded)
+	if err != nil {
+		return err
+	}
+
+	candidate := argon2.IDKey(
+		[]byte(password),
+		salt,
+		params.iterations,
+		params.memory,
+		params.parallelism,
+		uint32(len(storedHash)),
+	)
+
+	if subtle.ConstantTimeCompare(candidate, storedHash) != 1 {
+		return ErrMismatch
+	}
+
+	return nil
+}
+
+// hashParams holds the decoded Argon2id cost values extracted from an encoded
+// hash string.
+type hashParams struct {
+	memory      uint32
+	iterations  uint32
+	parallelism uint8
+}
+
+// decode parses an encoded hash string produced by Hash and returns its
+// constituent parts.  It returns ErrInvalidHash for any syntactic problem so
+// callers get a single, stable sentinel rather than a cascade of format errors.
+func decode(encoded string) (salt, hash []byte, params hashParams, err error) {
+	// Expected format: $argon2id$v1$m=65536,t=3,p=4$<salt>$<hash>
+	// Split produces: ["", "argon2id", "v1", "m=…", "<salt>", "<hash>"]
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 6 {
+		return nil, nil, hashParams{}, ErrInvalidHash
+	}
+
+	if parts[1] != "argon2id" {
+		return nil, nil, hashParams{}, ErrInvalidHash
+	}
+
+	if parts[2] != encodingVersion {
+		return nil, nil, hashParams{}, ErrInvalidHash
+	}
+
+	var m, t uint32
+	var p uint8
+	_, scanErr := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &t, &p)
+	if scanErr != nil {
+		return nil, nil, hashParams{}, ErrInvalidHash
+	}
+
+	salt, err = base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil || len(salt) == 0 {
+		return nil, nil, hashParams{}, ErrInvalidHash
+	}
+
+	hash, err = base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil || len(hash) == 0 {
+		return nil, nil, hashParams{}, ErrInvalidHash
+	}
+
+	return salt, hash, hashParams{memory: m, iterations: t, parallelism: p}, nil
+}

--- a/internal/security/passhash_bench_test.go
+++ b/internal/security/passhash_bench_test.go
@@ -1,0 +1,85 @@
+package security
+
+import (
+	"testing"
+)
+
+// BenchmarkHash measures the wall-clock time of a single Hash call using the
+// package-level cost parameters.  Run it on your deployment hardware to verify
+// that each invocation takes at least 100 ms — the OWASP minimum for
+// interactive password hashing — before accepting the parameters as adequate.
+//
+// Usage:
+//
+//	go test -bench=BenchmarkHash -benchtime=5s ./internal/security/
+//
+// If the result falls below 100 ms/op on your target hardware, increase
+// argonMemory or argonIterations in passhash.go.  Do NOT weaken parameters
+// under any build tag.
+func BenchmarkHash(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := Hash("benchmark-password-string"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkVerify measures the cost of verifying a correct password.
+// Verification timing should be essentially identical to hashing because
+// Argon2id runs the full KDF in both directions.
+func BenchmarkVerify(b *testing.B) {
+	encoded, err := Hash("benchmark-password-string")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if err := Verify("benchmark-password-string", encoded); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TestBenchmarkHash_MinLatency is a regular test (not a benchmark) that
+// enforces a lower-bound on hashing time.  It catches accidental parameter
+// weakening — e.g. a refactor that reduces memory or iterations — before it
+// reaches production.
+//
+// The threshold is intentionally generous (50 ms) to remain green across
+// slow CI runners.  On production hardware the real value should be ≥ 100 ms.
+//
+// This test will FAIL if the cost parameters are weakened.
+func TestBenchmarkHash_MinLatency(t *testing.T) {
+	const (
+		rounds        = 3
+		minPerHash_ms = 50 // generous CI floor; production target is ≥ 100 ms
+	)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := Hash("latency-sentinel"); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	nsPerOp := result.NsPerOp()
+	msPerOp := nsPerOp / 1_000_000
+
+	_ = rounds
+	if msPerOp < int64(minPerHash_ms) {
+		t.Errorf(
+			"Hash is too fast: %d ms/op — cost parameters may have been weakened.\n"+
+				"OWASP target: ≥ 100 ms on production hardware, ≥ %d ms on CI.\n"+
+				"Review argonMemory and argonIterations in passhash.go.",
+			msPerOp, minPerHash_ms,
+		)
+	} else {
+		t.Logf("Hash latency: %d ms/op (threshold: ≥ %d ms) ✓", msPerOp, minPerHash_ms)
+	}
+}

--- a/internal/security/passhash_test.go
+++ b/internal/security/passhash_test.go
@@ -1,0 +1,230 @@
+package security
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Hash
+// ---------------------------------------------------------------------------
+
+func TestHash_ProducesNonEmptyEncoded(t *testing.T) {
+	encoded, err := Hash("correcthorsebatterystaple")
+	require.NoError(t, err)
+	assert.NotEmpty(t, encoded)
+}
+
+func TestHash_EncodedHasExpectedPrefix(t *testing.T) {
+	encoded, err := Hash("password")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(encoded, "$argon2id$v1$"), "encoded=%q", encoded)
+}
+
+func TestHash_UniquePerCall(t *testing.T) {
+	// Two invocations with the same password must produce different encoded
+	// strings because each call draws a fresh random salt.
+	a, err := Hash("same-password")
+	require.NoError(t, err)
+
+	b, err := Hash("same-password")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a, b, "Hash must use a unique salt on every call")
+}
+
+func TestHash_EmptyPassword(t *testing.T) {
+	// Empty strings are valid inputs to Argon2id; we must not special-case them.
+	encoded, err := Hash("")
+	require.NoError(t, err)
+	assert.NotEmpty(t, encoded)
+}
+
+func TestHash_LongPassword(t *testing.T) {
+	// 1024-byte password: Argon2id imposes no length limit.
+	long := strings.Repeat("x", 1024)
+	encoded, err := Hash(long)
+	require.NoError(t, err)
+	assert.NotEmpty(t, encoded)
+}
+
+func TestHash_UnicodePassword(t *testing.T) {
+	encoded, err := Hash("pässwörд 🔑")
+	require.NoError(t, err)
+	assert.NotEmpty(t, encoded)
+}
+
+// ---------------------------------------------------------------------------
+// Verify — happy path
+// ---------------------------------------------------------------------------
+
+func TestVerify_CorrectPassword(t *testing.T) {
+	password := "correcthorsebatterystaple"
+	encoded, err := Hash(password)
+	require.NoError(t, err)
+
+	err = Verify(password, encoded)
+	assert.NoError(t, err)
+}
+
+func TestVerify_EmptyPassword(t *testing.T) {
+	encoded, err := Hash("")
+	require.NoError(t, err)
+
+	assert.NoError(t, Verify("", encoded))
+}
+
+func TestVerify_UnicodePassword(t *testing.T) {
+	pw := "pässwörд 🔑"
+	encoded, err := Hash(pw)
+	require.NoError(t, err)
+	assert.NoError(t, Verify(pw, encoded))
+}
+
+// ---------------------------------------------------------------------------
+// Verify — wrong password
+// ---------------------------------------------------------------------------
+
+func TestVerify_WrongPassword_ReturnsMismatch(t *testing.T) {
+	encoded, err := Hash("correct")
+	require.NoError(t, err)
+
+	err = Verify("wrong", encoded)
+	assert.ErrorIs(t, err, ErrMismatch)
+}
+
+func TestVerify_EmptyVsNonEmpty_ReturnsMismatch(t *testing.T) {
+	encoded, err := Hash("nonempty")
+	require.NoError(t, err)
+	assert.ErrorIs(t, Verify("", encoded), ErrMismatch)
+}
+
+func TestVerify_NonEmptyVsEmpty_ReturnsMismatch(t *testing.T) {
+	encoded, err := Hash("")
+	require.NoError(t, err)
+	assert.ErrorIs(t, Verify("nonempty", encoded), ErrMismatch)
+}
+
+func TestVerify_CaseSensitive(t *testing.T) {
+	encoded, err := Hash("Password")
+	require.NoError(t, err)
+	assert.ErrorIs(t, Verify("password", encoded), ErrMismatch)
+}
+
+// ---------------------------------------------------------------------------
+// Verify — malformed / corrupt encoded strings (must not panic)
+// ---------------------------------------------------------------------------
+
+func TestVerify_CompletelyEmpty_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", ""), ErrInvalidHash)
+}
+
+func TestVerify_RandomGarbage_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "not-a-hash-at-all"), ErrInvalidHash)
+}
+
+func TestVerify_TooFewSegments_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$argon2id$v1$m=65536,t=3,p=4$onlyfivesegments"), ErrInvalidHash)
+}
+
+func TestVerify_WrongAlgorithmLabel_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$bcrypt$v1$m=65536,t=3,p=4$abc$def"), ErrInvalidHash)
+}
+
+func TestVerify_WrongVersion_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$argon2id$v9$m=65536,t=3,p=4$abc$def"), ErrInvalidHash)
+}
+
+func TestVerify_MalformedParams_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$argon2id$v1$NOPE$abc$def"), ErrInvalidHash)
+}
+
+func TestVerify_InvalidBase64Salt_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$argon2id$v1$m=65536,t=3,p=4$!!!invalid!!!$def"), ErrInvalidHash)
+}
+
+func TestVerify_InvalidBase64Hash_ReturnsInvalidHash(t *testing.T) {
+	// Valid salt but corrupt hash field.
+	encoded, err := Hash("pw")
+	require.NoError(t, err)
+
+	parts := strings.Split(encoded, "$")
+	require.Len(t, parts, 6)
+	parts[5] = "!!!invalid!!!"
+	assert.ErrorIs(t, Verify("pw", strings.Join(parts, "$")), ErrInvalidHash)
+}
+
+func TestVerify_EmptySaltField_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$argon2id$v1$m=65536,t=3,p=4$$YWJj"), ErrInvalidHash)
+}
+
+func TestVerify_EmptyHashField_ReturnsInvalidHash(t *testing.T) {
+	assert.ErrorIs(t, Verify("pw", "$argon2id$v1$m=65536,t=3,p=4$YWJj$"), ErrInvalidHash)
+}
+
+func TestVerify_CorruptHashBytes_ReturnsMismatch(t *testing.T) {
+	// Produce a valid encoded hash, then flip a byte in the stored hash
+	// segment.  Verify must return ErrMismatch, not panic or ErrInvalidHash.
+	encoded, err := Hash("password")
+	require.NoError(t, err)
+
+	parts := strings.Split(encoded, "$")
+	require.Len(t, parts, 6)
+
+	// Flip the first character of the base64 hash to a different valid b64
+	// character so the base64 decode still succeeds but the hash diverges.
+	b := []byte(parts[5])
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	parts[5] = string(b)
+
+	assert.ErrorIs(t, Verify("password", strings.Join(parts, "$")), ErrMismatch)
+}
+
+// ---------------------------------------------------------------------------
+// Error sentinel identity
+// ---------------------------------------------------------------------------
+
+func TestErrMismatch_IsDistinctFromErrInvalidHash(t *testing.T) {
+	assert.NotEqual(t, ErrMismatch, ErrInvalidHash)
+	assert.False(t, strings.EqualFold(ErrMismatch.Error(), ErrInvalidHash.Error()))
+}
+
+// ---------------------------------------------------------------------------
+// Encode round-trip — structural validation
+// ---------------------------------------------------------------------------
+
+func TestHash_EncodedFieldCount(t *testing.T) {
+	encoded, err := Hash("test")
+	require.NoError(t, err)
+
+	// $argon2id$v1$m=…$<salt>$<hash> → split on "$" → 6 parts (first is "")
+	parts := strings.Split(encoded, "$")
+	assert.Len(t, parts, 6, "encoded=%q", encoded)
+	assert.Equal(t, "argon2id", parts[1])
+	assert.Equal(t, encodingVersion, parts[2])
+}
+
+func TestHash_ParametersMatchConstants(t *testing.T) {
+	encoded, err := Hash("test")
+	require.NoError(t, err)
+
+	var m, iters uint32
+	var p uint8
+	parts := strings.Split(encoded, "$")
+	require.Len(t, parts, 6)
+
+	_, err = fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &m, &iters, &p)
+	require.NoError(t, err)
+
+	assert.Equal(t, argonMemory, m, "memory parameter must match constant")
+	assert.Equal(t, argonIterations, iters, "iterations parameter must match constant")
+	assert.Equal(t, argonParallelism, p, "parallelism parameter must match constant")
+}


### PR DESCRIPTION
Adds internal/security/passhash.go with Hash/Verify functions backed by Argon2id using OWASP-recommended cost parameters:

  memory=64MiB, iterations=3, parallelism=4, salt=128-bit, tag=256-bit

Parameter provenance:
- OWASP Password Storage Cheat Sheet 2024 (interactive profile)
- RFC 9106 §4 'Parameter Choice' and §3.1 'Recommended Parameters'

Key properties:
- Fresh random 128-bit salt per Hash call (no two outputs are equal)
- Constant-time comparison in Verify (timing side-channel safe)
- Self-describing encoded format embeds all parameters for future migration
- ErrMismatch / ErrInvalidHash sentinel errors; Verify never panics on corrupt input
- Parameters are unexported constants; cannot be weakened at call sites and must not be overridden under any build tag

Test coverage: 96.9% of statements (threshold: 95%) Benchmark (Intel Xeon @ 2.20GHz, 4 vCPU):
  BenchmarkHash-4    ~117 ms/op   658 KB/op  20 allocs/op
  BenchmarkVerify-4  ~116 ms/op   658 KB/op  22 allocs/op

TestBenchmarkHash_MinLatency enforces >= 50ms/op floor to catch any future cost-parameter regression in CI.

closes #444