### PR TITLE
feat: add per-endpoint concurrency ceiling with shed policy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,13 @@ type Config struct {
 	// in-flight requests to complete before forcing shutdown. Env:
 	// GRACEFUL_SHUTDOWN_TIMEOUT (default: DefaultGracefulShutdownTimeout).
 	GracefulShutdownTimeout int // seconds
+	// ConcurrencyCapsPath is the path to the per-endpoint concurrency caps YAML
+	// configuration file. When empty, concurrency shedding is disabled.
+	// Env: CONCURRENCY_CAPS_PATH (default: "" — disabled; set to deploy/concurrency-caps.yaml to enable)
+	ConcurrencyCapsPath string
+
+	// OTelLogsEnabled toggles OpenTelemetry log export (env: OTEL_LOGS_ENABLED).
+	OTelLogsEnabled bool
 }
 
 // ValidationResult holds the result of configuration validation
@@ -282,6 +289,7 @@ func Load(opts ...Option) (Config, error) {
 		DBStatementCacheMode:     DefaultDBStatementCacheMode,
 		PgBouncerIdleInTxTimeout: DefaultPgBouncerIdleInTxTimeout,
 		GracefulShutdownTimeout:  DefaultGracefulShutdownTimeout,
+		ConcurrencyCapsPath:      getEnv("CONCURRENCY_CAPS_PATH", ""),
 	}
 
 	// Resolve secrets through the provider

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -44,6 +44,16 @@ func Register(r *gin.Engine) {
 	r.Use(middleware.TailSamplingSignals())
 	r.Use(middleware.TraceIDMiddleware())
 
+	// Per-endpoint concurrency shedding — shed excess load before rate limiting
+	if cfg.ConcurrencyCapsPath != "" {
+		concCfg, err := middleware.LoadConcurrencyConfig(cfg.ConcurrencyCapsPath)
+		if err != nil {
+			fmt.Printf("WARNING: failed to load concurrency caps config from %s: %v\n", cfg.ConcurrencyCapsPath, err)
+		} else {
+			r.Use(middleware.InflightMiddleware(concCfg))
+		}
+	}
+
 	// Rate limiting
 	rateLimitConfig := middleware.RateLimiterConfig{
 		Enabled:        cfg.RateLimitEnabled,


### PR DESCRIPTION
## Summary

Wires the existing InflightMiddleware into the route registration chain to cap in-flight requests per route with a semaphore and shed excess load with 503 Service Unavailable + Retry-After.

Closes #682

## Changes

- internal/config/config.go: Added ConcurrencyCapsPath field (env: CONCURRENCY_CAPS_PATH) and fixed missing OTelLogsEnabled field
- internal/routes/routes.go: Wired InflightMiddleware into the middleware chain before rate limiting

## How it works

1. Set CONCURRENCY_CAPS_PATH=deploy/concurrency-caps.yaml to enable
2. The YAML defines per-route concurrency limits with a default fallback
3. When exceeded, returns 503 with Retry-After header
4. Emits inflight_current{route} Prometheus gauge
5. Semaphore tokens released via defer, guaranteeing cleanup even on panics

## Testing

- Existing inflight_test.go covers all edge cases
- Config tests pass