### PR TITLE
feat: cap JWKS negative cache and coalesce refetches

### DIFF
--- a/internal/auth/jwks_cache.go
+++ b/internal/auth/jwks_cache.go
@@ -4,10 +4,26 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// maxNegativeCacheTTL caps how long an absent/unknown kid is cached as a
+	// miss, regardless of the cache's configured (positive) ttl. This bounds
+	// how long a key that legitimately rotates in (e.g. during an issuer key
+	// rollover) can be masked by a stale negative-cache entry.
+	maxNegativeCacheTTL = 5 * time.Second
+
+	// negativeCacheJitter randomizes the negative TTL within
+	// (maxNegativeCacheTTL-negativeCacheJitter, maxNegativeCacheTTL], so many
+	// callers that cache a miss for the same kid at the same instant don't
+	// all expire and refetch in the same instant.
+	negativeCacheJitter = 1 * time.Second
 )
 
 // JWKSCache implements a JWKS key cache with TTL, negative caching, and rate limiting.
@@ -20,6 +36,7 @@ type JWKSCache struct {
 	expiry        time.Time
 	lastRefresh   time.Time
 	refreshLimit  time.Duration
+	sf            singleflight.Group
 }
 
 // NewJWKSCache initializes a new JWKSCache.
@@ -31,6 +48,12 @@ func NewJWKSCache(url string, ttl time.Duration) *JWKSCache {
 		negativeCache: make(map[string]time.Time),
 		refreshLimit:  60 * time.Second,
 	}
+}
+
+// negativeTTL returns a jittered TTL capped at maxNegativeCacheTTL.
+func negativeTTL() time.Duration {
+	jitter := time.Duration(rand.Int63n(int64(negativeCacheJitter)))
+	return maxNegativeCacheTTL - jitter
 }
 
 // GetKey retrieves a public key by kid.
@@ -63,13 +86,14 @@ func (c *JWKSCache) GetKey(ctx context.Context, kid string) (jwk.Key, error) {
 
 func (c *JWKSCache) refreshAndGetKey(ctx context.Context, kid string) (jwk.Key, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	// Double check after acquiring lock
 	if key, found := c.keys[kid]; found && time.Now().Before(c.expiry) {
+		c.mu.Unlock()
 		return key, nil
 	}
 	if negExpiry, inNegCache := c.negativeCache[kid]; inNegCache && time.Now().Before(negExpiry) {
+		c.mu.Unlock()
 		return nil, fmt.Errorf("key id %s not found (negative cached)", kid)
 	}
 
@@ -77,31 +101,59 @@ func (c *JWKSCache) refreshAndGetKey(ctx context.Context, kid string) (jwk.Key, 
 	if time.Since(c.lastRefresh) < c.refreshLimit {
 		// If we can't refresh yet, and we don't have the key, return error or stale key
 		if key, found := c.keys[kid]; found {
+			c.mu.Unlock()
 			return key, nil // Return stale key as fallback
 		}
-		return nil, fmt.Errorf("rate limited: last refresh was %v ago", time.Since(c.lastRefresh))
+		sinceRefresh := time.Since(c.lastRefresh)
+		c.mu.Unlock()
+		return nil, fmt.Errorf("rate limited: last refresh was %v ago", sinceRefresh)
 	}
 
 	if c.url == "" {
+		c.mu.Unlock()
 		return nil, errors.New("JWKS_URL is not configured")
 	}
 
-	// Fetch new JWKS
-	set, err := jwk.Fetch(ctx, c.url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch JWKS: %w", err)
-	}
+	// Release the lock before doing network I/O. Holding it here would block
+	// GetKey for every other (already-cached, healthy) kid for the entire
+	// round trip to the issuer — exactly the "one broken issuer degrades the
+	// whole cluster" failure mode this change is meant to prevent.
+	c.mu.Unlock()
 
-	// Update cache
-	newKeys := make(map[string]jwk.Key)
-	iter := set.Keys(ctx)
-	for iter.Next(ctx) {
-		k := iter.Pair().Value.(jwk.Key)
-		if k.KeyID() != "" {
-			newKeys[k.KeyID()] = k
+	// Coalesce concurrent refetches for this URL into a single in-flight
+	// fetch, so a burst of simultaneous cache misses never sends more than
+	// one request to the issuer at a time.
+	result, err, _ := c.sf.Do(c.url, func() (interface{}, error) {
+		set, fetchErr := jwk.Fetch(ctx, c.url)
+		if fetchErr != nil {
+			jwksRefreshErrorsTotal.Inc()
+			return nil, fmt.Errorf("failed to fetch JWKS: %w", fetchErr)
 		}
+
+		newKeys := make(map[string]jwk.Key)
+		iter := set.Keys(ctx)
+		for iter.Next(ctx) {
+			k := iter.Pair().Value.(jwk.Key)
+			if k.KeyID() != "" {
+				newKeys[k.KeyID()] = k
+			}
+		}
+		return newKeys, nil
+	})
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err != nil {
+		// Always record the attempt, even on failure, so a persistently
+		// broken issuer is still rate-limited rather than hit on every
+		// single request. Previously lastRefresh was only updated on
+		// success, so an issuer that always errors was never rate-limited.
+		c.lastRefresh = time.Now()
+		return nil, err
 	}
 
+	newKeys := result.(map[string]jwk.Key)
 	c.keys = newKeys
 	c.expiry = time.Now().Add(c.ttl)
 	c.lastRefresh = time.Now()
@@ -114,7 +166,8 @@ func (c *JWKSCache) refreshAndGetKey(ctx context.Context, kid string) (jwk.Key, 
 		return key, nil
 	}
 
-	// If still not found, add to negative cache
-	c.negativeCache[kid] = time.Now().Add(c.ttl) // Or a different negative TTL? Let's use ttl.
+	// If still not found, add to negative cache, capped at maxNegativeCacheTTL
+	// regardless of the configured (positive) ttl.
+	c.negativeCache[kid] = time.Now().Add(negativeTTL())
 	return nil, fmt.Errorf("key id %s not found in JWKS", kid)
 }

--- a/internal/auth/jwks_cache_test.go
+++ b/internal/auth/jwks_cache_test.go
@@ -1,5 +1,4 @@
 package auth
-
 import (
 	"context"
 	"crypto/rand"
@@ -7,11 +6,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,4 +118,109 @@ func TestJWKSCache_MalformedPayload(t *testing.T) {
 func TestJWKSCache_MixedTokens(t *testing.T) {
 	// This is more of a middleware test, but we can verify the cache logic here
 	// by ensuring it doesn't fail when requested with different kids.
+}
+
+func TestJWKSCache_NegativeCacheCappedRegardlessOfTTL(t *testing.T) {
+	rawKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	key, _ := jwk.FromRaw(rawKey)
+	_ = key.Set(jwk.KeyIDKey, "known-kid")
+	set := jwk.NewSet()
+	_ = set.AddKey(key)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(set)
+	}))
+	defer server.Close()
+
+	// Deliberately large positive TTL: if the negative cache reused this,
+	// an unknown kid would be masked for an hour instead of ~5 seconds.
+	cache := NewJWKSCache(server.URL, time.Hour)
+	cache.refreshLimit = 0
+
+	before := time.Now()
+	_, err := cache.GetKey(context.Background(), "unknown-kid")
+	require.Error(t, err)
+
+	cache.mu.RLock()
+	negExpiry, inNegCache := cache.negativeCache["unknown-kid"]
+	cache.mu.RUnlock()
+
+	require.True(t, inNegCache)
+	assert.LessOrEqual(t, negExpiry.Sub(before), maxNegativeCacheTTL)
+	assert.Greater(t, negExpiry.Sub(before), maxNegativeCacheTTL-negativeCacheJitter-100*time.Millisecond)
+}
+
+func TestJWKSCache_ConcurrentRefreshesCoalesce(t *testing.T) {
+	rawKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	key, _ := jwk.FromRaw(rawKey)
+	_ = key.Set(jwk.KeyIDKey, "test-kid")
+	set := jwk.NewSet()
+	_ = set.AddKey(key)
+
+	var callCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		// Simulate a slow issuer so concurrent callers genuinely overlap.
+		time.Sleep(50 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(set)
+	}))
+	defer server.Close()
+
+	cache := NewJWKSCache(server.URL, time.Hour)
+	cache.refreshLimit = 0
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = cache.GetKey(context.Background(), "test-kid")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount), "expected concurrent refetches to coalesce into a single request")
+}
+
+func TestJWKSCache_DoesNotThrashOnRepeatedIssuerErrors(t *testing.T) {
+	var callCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cache := NewJWKSCache(server.URL, time.Hour)
+	cache.refreshLimit = time.Minute
+
+	_, err := cache.GetKey(context.Background(), "any-kid")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+
+	// A second call shortly after a failed fetch must be rate-limited, not
+	// re-hit the broken issuer. Previously lastRefresh was only updated on
+	// success, so a failing issuer was hit on every single call.
+	_, err = cache.GetKey(context.Background(), "any-kid")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+}
+
+func TestJWKSCache_MetricIncrementsOnFetchFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	before := testutil.ToFloat64(jwksRefreshErrorsTotal)
+
+	cache := NewJWKSCache(server.URL, time.Hour)
+	_, err := cache.GetKey(context.Background(), "any-kid")
+	require.Error(t, err)
+
+	after := testutil.ToFloat64(jwksRefreshErrorsTotal)
+	assert.Greater(t, after, before)
 }

--- a/internal/auth/metrics.go
+++ b/internal/auth/metrics.go
@@ -1,0 +1,17 @@
+package auth
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// jwksRefreshErrorsTotal counts failed JWKS refresh attempts against the
+// configured issuer. A rising rate indicates the issuer is unreachable or
+// misbehaving; combined with the negative-cache cap and refresh rate limit,
+// this is what an on-call engineer should alert on.
+var jwksRefreshErrorsTotal prometheus.Counter
+
+func init() {
+	jwksRefreshErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "jwks_refresh_errors_total",
+		Help: "Total number of failed JWKS refresh attempts against the configured issuer",
+	})
+	_ = prometheus.Register(jwksRefreshErrorsTotal)
+}


### PR DESCRIPTION
Closes #692

## Summary

Hardens `JWKSCache` against a broken/misbehaving issuer degrading the
whole cluster:

- Negative-cache TTL is now capped at 5 seconds (jittered) regardless of
  the cache's configured positive TTL.
- Concurrent refetches for the same URL are coalesced via
  `golang.org/x/sync/singleflight`, and the exclusive lock is released
  during the actual network call.
- Failed refresh attempts now correctly update `lastRefresh`, so rate
  limiting actually applies when the issuer is down.
- New `jwks_refresh_errors_total` counter.

## Two real bugs found and fixed, not just additive changes

1. **Lock held during network I/O.** The previous implementation held
   `c.mu` for the entire `jwk.Fetch` round trip, including on failure.
   Since `GetKey`'s fast path takes `c.mu.RLock()`, a slow or hanging
   issuer would stall *every* `GetKey` call — including for kids that
   were already cached and perfectly valid — for the full duration of
   the fetch. This is the literal "broken issuer degrades the entire
   cluster" scenario. The lock is now released before the network call;
   `singleflight` still ensures only one fetch is in flight per URL.
2. **No rate limiting on failure.** `lastRefresh` was previously only
   updated after a *successful* fetch, so an issuer that always errors
   was retried on every single request with zero backoff — the "thrash
   retries" edge case in the issue. `lastRefresh` is now updated on both
   success and failure.

## Negative cache cap

`maxNegativeCacheTTL = 5s`, jittered by up to 1s (`negativeCacheJitter`)
so concurrent misses for the same kid don't all expire and refetch in
the same instant. This is now independent of the cache's `ttl` field —
previously a negative entry inherited the full positive TTL, which could
mask a legitimately-rotated-in key for as long as the positive TTL
(e.g. an hour in some configurations).

## Test plan