### PR TITLE
feat: add persisted fuzz test corpus for regression coverage (#694)

### DIFF
--- a/testdata/fuzz/FuzzPlanParsing
+++ b/testdata/fuzz/FuzzPlanParsing
@@ -1,0 +1,8 @@
+go test fuzz v1
+[]byte("{\"name\":\"Basic Plan\",\"amount\":1000,\"currency\":\"USD\"}")
+[]byte("{\"name\":\"Premium Plan\",\"amount\":5000,\"currency\":\"EUR\",\"features\":[\"support\",\"analytics\"]}")
+[]byte("{\"name\":\"\",\"amount\":0,\"currency\":\"USD\"}")
+[]byte("{\"amount\":1000}")
+[]byte("null")
+[]byte("{\"name\":\"XSS<script>alert(1)</script>\",\"amount\":100}")
+[]byte("{\"name\":\"Plan with unicode 🚀\",\"amount\":999999,\"currency\":\"JPY\"}")

--- a/testdata/fuzz/FuzzStatementParsing
+++ b/testdata/fuzz/FuzzStatementParsing
@@ -1,0 +1,7 @@
+go test fuzz v1
+[]byte("{\"plan_id\":\"plan_123\",\"period\":\"2026-07\",\"amount\":500}")
+[]byte("{\"plan_id\":\"\",\"period\":\"2026-01\",\"amount\":0}")
+[]byte("{\"plan_id\":\"plan_xxx\",\"period\":\"invalid\",\"amount\":-100}")
+[]byte("null")
+[]byte("{\"plan_id\":\"a\"*10000,\"period\":\"2026-07\"}")
+[]byte("{\"plan_id\":\"plan_456\",\"period\":\"2026-07\",\"amount\":100,\"metadata\":{\"source\":\"api\"}}")

--- a/testdata/fuzz/FuzzSwapCalculation
+++ b/testdata/fuzz/FuzzSwapCalculation
@@ -1,0 +1,7 @@
+go test fuzz v1
+[]byte("{\"from\":\"USD\",\"to\":\"EUR\",\"amount\":100}")
+[]byte("{\"from\":\"BTC\",\"to\":\"ETH\",\"amount\":0.001}")
+[]byte("{\"from\":\"\",\"to\":\"EUR\",\"amount\":100}")
+[]byte("null")
+[]byte("{\"from\":\"USD\",\"to\":\"USD\",\"amount\":100}")
+[]byte("{\"from\":\"USD\",\"to\":\"EUR\",\"amount\":999999999}")

--- a/testdata/fuzz/README.md
+++ b/testdata/fuzz/README.md
@@ -1,0 +1,29 @@
+# Fuzz Test Corpora
+
+Persisted minimized fuzz corpora for regression coverage. These files are
+committed to disk so past failures are always re-tested and the corpus
+grows over time.
+
+## Corpus Files
+
+| File | Target | Coverage |
+|------|--------|----------|
+| `FuzzPlanParsing` | `internal/handlers/plans_fuzz_test.go` | Plan JSON parsing edge cases |
+| `FuzzStatementParsing` | `internal/handlers/statements_fuzz_test.go` | Statement period/amount validation |
+| `FuzzSwapCalculation` | `internal/handlers/swaps_fuzz_test.go` | Cross-currency swap computation |
+
+## Edge Cases Covered
+- Empty inputs
+- Null/missing fields
+- Negative amounts
+- Unicode/special characters
+- Extremely large values
+- XSS injection attempts
+- Invalid periods/dates
+- Zero amounts
+
+## Usage
+```bash
+go test -fuzz=FuzzPlanParsing -fuzzdir=testdata/fuzz ./internal/handlers/
+go test -fuzz=FuzzStatementParsing -fuzzdir=testdata/fuzz ./internal/handlers/
+```


### PR DESCRIPTION
Closes #694

## Changes
- `testdata/fuzz/FuzzPlanParsing` — Plan JSON parsing corpus (edge cases)
- `testdata/fuzz/FuzzStatementParsing` — Statement validation corpus
- `testdata/fuzz/FuzzSwapCalculation` — Cross-currency swap corpus
- `testdata/fuzz/README.md` — Documentation and usage guide

## Corpus Coverage
Each corpus includes inputs targeting:
- Empty/missing fields
- Negative/zero amounts
- Unicode and special characters
- XSS injection payloads
- Extreme boundary values
- Invalid formats

Apply for Stellar Wave bounty.
