### PR TITLE
docs: document Vault dynamic database secrets

### DIFF
--- a/docs/ops/vault-dynamic-db-secrets.md
+++ b/docs/ops/vault-dynamic-db-secrets.md
@@ -1,0 +1,24 @@
+# Vault dynamic database credentials
+
+Configure Vault's database secrets engine to issue a dedicated, short-lived
+Postgres role for this service. Do not store generated passwords in deployment
+manifests or application configuration.
+
+```hcl
+path "database/creds/stellarbill" {
+  capabilities = ["read"]
+}
+path "sys/leases/renew" {
+  capabilities = ["update"]
+}
+```
+
+The `stellarbill` database role must have a bounded default and maximum TTL.
+Set the maximum TTL longer than the application's connection-drain window, and
+renew before the lease reaches 80% of its lifetime. If renewal fails, keep the
+current lease only until expiry, then stop accepting database work and surface a
+readiness failure rather than reusing expired credentials.
+
+The application should request `database/creds/stellarbill`, build a Postgres
+DSN from the returned username and password, and rotate its pool only after a
+new lease has been acquired successfully. Revoke leases during decommissioning.


### PR DESCRIPTION
## Description
Documents the Vault database secrets-engine role, scoped policy, lease-renewal timing, expiry behavior, and safe pool rotation approach for #442.

## Validation
Not run: the environment does not include the Go toolchain. This documentation-only draft intentionally does not claim to implement the runtime renewer or pool wiring.

## Follow-up
Runtime implementation and tests for the credential renewer remain required to close #442.