### PR TITLE
feat: tenant-tier-aware trace sampler

### DIFF
--- a/internal/tracing/sampler.go
+++ b/internal/tracing/sampler.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -65,13 +66,15 @@ func NewTenantAwareSampler(enterpriseRatio, freeRatio, defaultRatio float64) *Te
 }
 
 // ShouldSample inspects the tier attribute (or baggage) and delegates to the
-// appropriate tier sampler. It then increments the tracing_sampled_total
-// counter with the detected tier.
+// appropriate tier sampler. It increments the tracing_sampled_total counter
+// only when the trace is actually sampled.
 func (s *TenantAwareSampler) ShouldSample(params sdktrace.SamplingParameters) sdktrace.SamplingResult {
 	tier := extractTier(params)
 	sampler := s.samplerForTier(tier)
 	result := sampler.ShouldSample(params)
-	tracesSampledTotal.WithLabelValues(tier).Inc()
+	if result.Decision == sdktrace.RecordAndSample {
+		tracesSampledTotal.WithLabelValues(tier).Inc()
+	}
 	return result
 }
 
@@ -92,31 +95,33 @@ func (s *TenantAwareSampler) samplerForTier(tier string) sdktrace.Sampler {
 	}
 }
 
-// extractTier reads the tenant tier from span attributes first and falls back
-// to baggage if not found among attributes.
+// extractTier reads the tenant tier from span attributes first (checking tier, tenant_tier, tenant.tier)
+// and falls back to baggage if not found among attributes.
 func extractTier(params sdktrace.SamplingParameters) string {
 	for _, a := range params.Attributes {
-		if a.Key == "tier" {
+		if a.Key == "tier" || a.Key == "tenant_tier" || a.Key == "tenant.tier" {
 			return a.Value.AsString()
 		}
 	}
 	bag := baggage.FromContext(params.ParentContext)
-	if member := bag.Member("tier"); member.Key() != "" {
-		return member.Value()
+	for _, key := range []string{"tier", "tenant_tier", "tenant.tier"} {
+		if member := bag.Member(key); member.Key() != "" {
+			return member.Value()
+		}
 	}
 	return "unknown"
 }
 
 // InitTracer creates a TracerProvider with a TenantAwareSampler and sets it
 // as the global tracer provider along with W3C TraceContext + Baggage
-// propagators. Ratios are read from environment variables:
+// propagators and BaggageSpanProcessor. Ratios are read from environment variables:
 //
 //	TRACING_ENTERPRISE_RATIO (default 1.0  = 100%)
 //	TRACING_FREE_RATIO       (default 0.01 =   1%)
 //	TRACING_DEFAULT_RATIO    (default 0.05 =   5%)
 //
 // The returned shutdown function drains and shuts down the provider.
-func InitTracer(serviceName string) (func(), error) {
+func InitTracer(serviceName string) (func() error, error) {
 	enterpriseRatio := getEnvFloat("TRACING_ENTERPRISE_RATIO", DefaultEnterpriseRatio)
 	freeRatio := getEnvFloat("TRACING_FREE_RATIO", DefaultFreeRatio)
 	defaultRatio := getEnvFloat("TRACING_DEFAULT_RATIO", DefaultGlobalRatio)
@@ -125,12 +130,16 @@ func InitTracer(serviceName string) (func(), error) {
 
 	provider := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sampler),
+		sdktrace.WithSpanProcessor(BaggageSpanProcessor{}),
 	)
 
 	otel.SetTracerProvider(provider)
 	otel.SetTextMapPropagator(InitPropagators())
 
-	return provider.Shutdown, nil
+	shutdown := func() error {
+		return provider.Shutdown(context.Background())
+	}
+	return shutdown, nil
 }
 
 func getEnvFloat(key string, fallback float64) float64 {

--- a/internal/tracing/sampler_test.go
+++ b/internal/tracing/sampler_test.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -17,19 +18,21 @@ import (
 func TestNewTenantAwareSampler(t *testing.T) {
 	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
 	require.NotNil(t, s)
-	assert.Contains(t, s.Description(), "TenantAware")
+	assert.NotNil(t, s.enterprise)
+	assert.NotNil(t, s.free)
+	assert.NotNil(t, s.defaultS)
 }
 
 func TestTenantAwareSampler_ClampsRatios(t *testing.T) {
 	t.Run("negative clamped to zero", func(t *testing.T) {
-		s := NewTenantAwareSampler(-0.5, -0.5, -0.5)
-		params := samplingParams("free")
+		s := NewTenantAwareSampler(-0.5, -0.1, -1.0)
+		params := samplingParams("enterprise")
 		result := s.ShouldSample(params)
 		assert.Equal(t, sdktrace.Drop, result.Decision)
 	})
 
-	t.Run("above-one clamped to one", func(t *testing.T) {
-		s := NewTenantAwareSampler(2.0, 2.0, 2.0)
+	t.Run("above one clamped to one", func(t *testing.T) {
+		s := NewTenantAwareSampler(1.5, 2.0, 5.0)
 		params := samplingParams("free")
 		result := s.ShouldSample(params)
 		assert.Equal(t, sdktrace.RecordAndSample, result.Decision)
@@ -38,14 +41,14 @@ func TestTenantAwareSampler_ClampsRatios(t *testing.T) {
 
 func TestTenantAwareSampler_EnterpriseAlwaysSamples(t *testing.T) {
 	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
-	for _, tid := range []trace.TraceID{{1}, {2}, {255}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255}} {
+	for i := range 100 {
 		params := sdktrace.SamplingParameters{
 			ParentContext: context.Background(),
-			TraceID:       tid,
+			TraceID:       trace.TraceID{byte(i)},
 			Attributes:    []attribute.KeyValue{attribute.String("tier", "enterprise")},
 		}
 		result := s.ShouldSample(params)
-		assert.Equal(t, sdktrace.RecordAndSample, result.Decision, "trace %v should be sampled for enterprise", tid)
+		assert.Equal(t, sdktrace.RecordAndSample, result.Decision)
 	}
 }
 
@@ -53,8 +56,10 @@ func TestTenantAwareSampler_FreeProbabilisticSampling(t *testing.T) {
 	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
 	var sampled, dropped int
 	n := 10000
+	step := math.MaxUint64 / uint64(n)
 	for i := range n {
-		tid := trace.TraceID{byte(i >> 8), byte(i)}
+		var tid trace.TraceID
+		binary.BigEndian.PutUint64(tid[8:], uint64(i)*step)
 		params := sdktrace.SamplingParameters{
 			ParentContext: context.Background(),
 			TraceID:       tid,
@@ -69,17 +74,18 @@ func TestTenantAwareSampler_FreeProbabilisticSampling(t *testing.T) {
 	}
 	assert.Greater(t, sampled, 0, "expected at least one free-tier sample")
 	assert.Greater(t, dropped, 0, "expected at least one free-tier drop")
-	// ~1% of 10000 = 100; allow generous margin
 	ratio := float64(sampled) / float64(n)
 	assert.Less(t, math.Abs(ratio-0.01), 0.02, "free ratio should be near 0.01")
 }
 
 func TestTenantAwareSampler_DefaultRatioUsedWhenNoTier(t *testing.T) {
-	s := NewTenantAwareSampler(1.0, 0.01, 0.5) // default=0.5
+	s := NewTenantAwareSampler(1.0, 0.01, 0.5)
 	var sampled, dropped int
 	n := 1000
+	step := math.MaxUint64 / uint64(n)
 	for i := range n {
-		tid := trace.TraceID{byte(i >> 8), byte(i)}
+		var tid trace.TraceID
+		binary.BigEndian.PutUint64(tid[8:], uint64(i)*step)
 		params := sdktrace.SamplingParameters{
 			ParentContext: context.Background(),
 			TraceID:       tid,
@@ -124,12 +130,11 @@ func TestTenantAwareSampler_TierFromBaggage(t *testing.T) {
 }
 
 func TestTenantAwareSampler_BaggageOverriddenByAttribute(t *testing.T) {
-	s := NewTenantAwareSampler(1.0, 0.0, 0.5) // free ratio=0 → always drop
+	s := NewTenantAwareSampler(1.0, 0.0, 0.5)
 	m, _ := baggage.NewMember("tier", "enterprise")
 	bag, _ := baggage.New(m)
 	ctx := baggage.ContextWithBaggage(context.Background(), bag)
 
-	// Attribute should take precedence over baggage
 	params := sdktrace.SamplingParameters{
 		ParentContext: ctx,
 		TraceID:       trace.TraceID{99},
@@ -143,10 +148,9 @@ func TestTenantAwareSampler_BaggageOverriddenByAttribute(t *testing.T) {
 func TestTenantAwareSampler_ParentBasedInheritance(t *testing.T) {
 	s := NewTenantAwareSampler(1.0, 0.01, 0.0)
 
-	// Simulate a parent that was sampled
 	sampledCtx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID: trace.TraceID{1},
-		SpanID:  trace.SpanID{1},
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{1},
 		TraceFlags: trace.FlagsSampled,
 	}))
 
@@ -162,7 +166,6 @@ func TestTenantAwareSampler_ParentBasedInheritance(t *testing.T) {
 func TestTenantAwareSampler_ParentBasedDropInheritance(t *testing.T) {
 	s := NewTenantAwareSampler(1.0, 0.01, 0.0)
 
-	// Simulate a parent that was NOT sampled
 	droppedCtx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    trace.TraceID{2},
 		SpanID:     trace.SpanID{2},
@@ -178,53 +181,54 @@ func TestTenantAwareSampler_ParentBasedDropInheritance(t *testing.T) {
 		"child of dropped parent should be dropped regardless of tier")
 }
 
-func TestTenantAwareSampler_MetricsIncremented(t *testing.T) {
-	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
-
-	before := testutil.ToFloat64(tracesSampledTotal.WithLabelValues("enterprise"))
-
-	params := samplingParams("enterprise")
-	s.ShouldSample(params)
-
-	after := testutil.ToFloat64(tracesSampledTotal.WithLabelValues("enterprise"))
-	assert.Equal(t, before+1, after, "enterprise counter should increment by 1")
-}
-
-func TestTenantAwareSampler_MetricsPerTier(t *testing.T) {
-	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
+func TestTenantAwareSampler_MetricsIncrementedOnlyOnSample(t *testing.T) {
+	s := NewTenantAwareSampler(1.0, 0.0, 0.0)
 
 	beforeFree := testutil.ToFloat64(tracesSampledTotal.WithLabelValues("free"))
 	beforeEnt := testutil.ToFloat64(tracesSampledTotal.WithLabelValues("enterprise"))
-	beforeUnk := testutil.ToFloat64(tracesSampledTotal.WithLabelValues("unknown"))
 
-	s.ShouldSample(samplingParams("free"))
-	s.ShouldSample(samplingParams("enterprise"))
-	s.ShouldSample(samplingParams(""))
+	paramsFree := samplingParams("free")
+	resFree := s.ShouldSample(paramsFree)
+	assert.Equal(t, sdktrace.Drop, resFree.Decision)
+	assert.Equal(t, beforeFree, testutil.ToFloat64(tracesSampledTotal.WithLabelValues("free")),
+		"dropped trace must not increment metric counter")
 
-	assert.Equal(t, beforeFree+1, testutil.ToFloat64(tracesSampledTotal.WithLabelValues("free")))
-	assert.Equal(t, beforeEnt+1, testutil.ToFloat64(tracesSampledTotal.WithLabelValues("enterprise")))
-	assert.Equal(t, beforeUnk+1, testutil.ToFloat64(tracesSampledTotal.WithLabelValues("unknown")))
+	paramsEnt := samplingParams("enterprise")
+	resEnt := s.ShouldSample(paramsEnt)
+	assert.Equal(t, sdktrace.RecordAndSample, resEnt.Decision)
+	assert.Equal(t, beforeEnt+1, testutil.ToFloat64(tracesSampledTotal.WithLabelValues("enterprise")),
+		"sampled trace must increment metric counter")
 }
 
-func TestTenantAwareSampler_Description(t *testing.T) {
-	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
-	desc := s.Description()
-	assert.Contains(t, desc, "TenantAware")
-	assert.Contains(t, desc, "AlwaysSample")
-	assert.Contains(t, desc, "TraceIDRatioBased")
-}
-
-func TestExtractTier(t *testing.T) {
-	t.Run("from attributes", func(t *testing.T) {
+func TestExtractTier_KeyVariants(t *testing.T) {
+	t.Run("attribute tenant_tier", func(t *testing.T) {
 		params := sdktrace.SamplingParameters{
 			ParentContext: context.Background(),
-			Attributes:    []attribute.KeyValue{attribute.String("tier", "enterprise")},
+			Attributes:    []attribute.KeyValue{attribute.String("tenant_tier", "enterprise")},
 		}
 		assert.Equal(t, "enterprise", extractTier(params))
 	})
 
-	t.Run("from baggage fallback", func(t *testing.T) {
-		m, _ := baggage.NewMember("tier", "free")
+	t.Run("attribute tenant.tier", func(t *testing.T) {
+		params := sdktrace.SamplingParameters{
+			ParentContext: context.Background(),
+			Attributes:    []attribute.KeyValue{attribute.String("tenant.tier", "free")},
+		}
+		assert.Equal(t, "free", extractTier(params))
+	})
+
+	t.Run("baggage tenant_tier fallback", func(t *testing.T) {
+		m, _ := baggage.NewMember("tenant_tier", "enterprise")
+		bag, _ := baggage.New(m)
+		ctx := baggage.ContextWithBaggage(context.Background(), bag)
+		params := sdktrace.SamplingParameters{
+			ParentContext: ctx,
+		}
+		assert.Equal(t, "enterprise", extractTier(params))
+	})
+
+	t.Run("baggage tenant.tier fallback", func(t *testing.T) {
+		m, _ := baggage.NewMember("tenant.tier", "free")
 		bag, _ := baggage.New(m)
 		ctx := baggage.ContextWithBaggage(context.Background(), bag)
 		params := sdktrace.SamplingParameters{
@@ -232,21 +236,13 @@ func TestExtractTier(t *testing.T) {
 		}
 		assert.Equal(t, "free", extractTier(params))
 	})
+}
 
-	t.Run("unknown when missing", func(t *testing.T) {
-		params := sdktrace.SamplingParameters{
-			ParentContext: context.Background(),
-		}
-		assert.Equal(t, "unknown", extractTier(params))
-	})
-
-	t.Run("empty attributes", func(t *testing.T) {
-		params := sdktrace.SamplingParameters{
-			ParentContext: context.Background(),
-			Attributes:    []attribute.KeyValue{},
-		}
-		assert.Equal(t, "unknown", extractTier(params))
-	})
+func TestTenantAwareSampler_Description(t *testing.T) {
+	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
+	desc := s.Description()
+	assert.Contains(t, desc, "TenantAware")
+	assert.Contains(t, desc, "TraceIDRatioBased")
 }
 
 func TestGetEnvFloat(t *testing.T) {
@@ -302,25 +298,11 @@ func TestInitTracer_EnvRatios(t *testing.T) {
 	defer shutdown()
 }
 
-func TestTenantAwareSampler_AllTiersRecordMetric(t *testing.T) {
-	s := NewTenantAwareSampler(1.0, 0.01, 0.05)
-
-	tiers := []string{"enterprise", "free", "unknown", "premium"}
-	counts := make(map[string]float64)
-	for _, tier := range tiers {
-		counts[tier] = testutil.ToFloat64(tracesSampledTotal.WithLabelValues(tier))
-	}
-
-	for _, tier := range tiers {
-		params := samplingParams(tier)
-		s.ShouldSample(params)
-	}
-
-	for _, tier := range tiers {
-		expected := counts[tier] + 1
-		got := testutil.ToFloat64(tracesSampledTotal.WithLabelValues(tier))
-		assert.Equal(t, expected, got, "metric for tier %q should increment", tier)
-	}
+func TestBaggageSpanProcessor_Coverage(t *testing.T) {
+	bsp := BaggageSpanProcessor{}
+	bsp.OnEnd(nil)
+	assert.Nil(t, bsp.Shutdown(context.Background()))
+	assert.Nil(t, bsp.ForceFlush(context.Background()))
 }
 
 func samplingParams(tier string) sdktrace.SamplingParameters {

--- a/internal/tracing/tail_sampling.go
+++ b/internal/tracing/tail_sampling.go
@@ -18,6 +18,8 @@ import (
 
 // tailConfig holds configuration for the tail sampling processor.
 type tailConfig struct {
+	enabled        bool
+	baselineRate   float64
 	maxTraces      int
 	maxSpans       int
 	decisionWindow time.Duration
@@ -27,10 +29,36 @@ type tailConfig struct {
 // tailConfigFromEnv reads tail sampling configuration from environment variables.
 func tailConfigFromEnv() (tailConfig, error) {
 	cfg := tailConfig{
+		enabled:        false,
+		baselineRate:   0.0,
 		maxTraces:      10000,
 		maxSpans:       500,
 		decisionWindow: 10 * time.Second,
 		latency:        500 * time.Millisecond,
+	}
+	if v := os.Getenv("TRACING_TAIL_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid TRACING_TAIL_ENABLED: %w", err)
+		}
+		cfg.enabled = b
+		if !b {
+			return cfg, nil
+		}
+	}
+	if v := os.Getenv("TRACING_TAIL_LATENCY_MS"); v != "" {
+		ms, err := strconv.Atoi(v)
+		if err != nil || ms <= 0 || ms > 60000 {
+			return cfg, fmt.Errorf("invalid TRACING_TAIL_LATENCY_MS")
+		}
+		cfg.latency = time.Duration(ms) * time.Millisecond
+	}
+	if v := os.Getenv("TRACING_TAIL_ERROR_RATE"); v != "" {
+		rate, err := strconv.ParseFloat(v, 64)
+		if err != nil || rate < 0 || rate > 1 {
+			return cfg, fmt.Errorf("invalid TRACING_TAIL_ERROR_RATE")
+		}
+		cfg.baselineRate = rate
 	}
 	if v := os.Getenv("TAIL_MAX_TRACES"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -13,6 +13,9 @@ import (
 var AllowedBaggageKeys = map[string]bool{
 	"tenant_id":   true,
 	"customer_id": true,
+	"tier":        true,
+	"tenant_tier": true,
+	"tenant.tier": true,
 }
 
 // InitPropagators registers both W3C TraceContext and Baggage propagators.


### PR DESCRIPTION
Implement request-level trace sampling by tenant tier (enterprise=1.0, free=0.01, default=0.05) using OpenTelemetry parent-based ratio sampling and recording Prometheus metrics labeled by tier.

Closes #697