### PR TITLE
docs: enforce OpenAPI operation examples #693

### DIFF
--- a/docs/OPENAPI_GUIDE.md
+++ b/docs/OPENAPI_GUIDE.md
@@ -16,6 +16,7 @@ When adding or modifying API endpoints, follow this checklist:
 - [ ] Add security requirements if authentication is needed
 - [ ] Update the `operationId` to be unique
 - [ ] Add appropriate tags
+- [ ] Add at least one request-body example (when a body is declared) and one success (2xx) response example; examples must validate against their schemas
 
 ### 2. Implement the Endpoint
 - [ ] Implement the handler in `internal/handlers/`
@@ -24,9 +25,10 @@ When adding or modifying API endpoints, follow this checklist:
 - [ ] Add authentication/authorization as specified in the OpenAPI security scheme
 
 ### 3. Validate Contract
+- [ ] Run `go run ./tools/openapi-lint` to enforce request/response examples
 - [ ] Run `go test ./internal/contract/...` to verify the endpoint matches the spec
 - [ ] Run `go run ./cmd/openapi-validate` to check for discrepancies
-- [ ] Ensure CI passes (contract tests are run automatically)
+- [ ] Ensure CI passes (contract tests and openapi-lint run automatically)
 
 ### 4. Documentation
 - [ ] Update README.md if the endpoint changes public API surface
@@ -58,6 +60,9 @@ When adding or modifying API endpoints, follow this checklist:
 ## Running Validation Locally
 
 ```bash
+# Enforce request/response examples on every operation
+go run ./tools/openapi-lint
+
 # Validate OpenAPI spec can be loaded
 go run ./cmd/openapi-validate
 
@@ -71,11 +76,13 @@ go test ./... -cover
 ## CI Enforcement
 
 The CI pipeline automatically:
+- Runs `go run ./tools/openapi-lint` (fails if any operation lacks a valid example)
 - Runs contract tests (`go test ./...`)
 - Validates OpenAPI spec (`go run ./cmd/openapi-validate`)
 - Fails if any endpoint is not documented or if the implementation doesn't match the spec.
 
 If CI fails due to OpenAPI contract issues, check:
 1. Is the new endpoint added to `openapi/openapi.yaml`?
-2. Does the implementation match the spec?
-3. Are there duplicate route registrations?
+2. Does every operation have request/response examples that pass `go run ./tools/openapi-lint`?
+3. Does the implementation match the spec?
+4. Are there duplicate route registrations?

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -34,55 +34,6 @@ paths:
               example:
                 status: "ok"
                 service: "stellarbill-backend"
-  /api/v1/plans:
-    get:
-      tags: [Plans]
-      summary: List billing plans
-      operationId: listPlans
-      parameters:
-        - name: cursor
-          in: query
-          schema:
-            type: string
-          description: Pagination cursor for the next page of results
-          example: "Y3Vyc29yX25leHRfcGFnZQ=="
-        - name: limit
-          in: query
-          schema:
-            type: integer
-            maximum: 100
-          description: Maximum number of items to return
-          example: 20
-      responses:
-        "200":
-          description: Plans list
-          headers:
-            Link:
-              $ref: "#/components/headers/Link"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlansResponse"
-              example:
-                plans:
-                  - id: "plan_basic"
-                    name: "Basic"
-                    amount: "1000"
-                    currency: "NGN"
-                    interval: "monthly"
-                    description: "Starter plan"
-                  - id: "plan_pro"
-                    name: "Pro"
-                    amount: "5000"
-                    currency: "NGN"
-                    interval: "monthly"
-                    description: "Professional plan"
-                pagination:
-                  has_more: false
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
   /api/subscriptions:
     get:
       tags: [Subscriptions]
@@ -183,6 +134,9 @@ paths:
           application/merge-patch+json:
             schema:
               $ref: "#/components/schemas/SubscriptionPatch"
+            example:
+              status: "paused"
+              next_billing: null
       responses:
         "200":
           description: Subscription updated
@@ -190,6 +144,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Subscription"
+              example:
+                id: "sub_123"
+                plan_id: "plan_basic"
+                customer: "customer_123"
+                status: "paused"
+                amount: "1000"
+                interval: "monthly"
+                next_billing: "2026-09-01T00:00:00Z"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -296,6 +258,68 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+          example:
+            error: "Unsupported Media Type"
+            message: "Content-Type must be application/merge-patch+json"
+            code: "unsupported_media_type"
+    BadRequest:
+      description: Validation or client error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            PaginationLimitExceeded:
+              value:
+                error: "Bad Request"
+                message: "Pagination limit cannot exceed 100 items."
+                code: "validation_error"
+            InvalidCursorFormat:
+              value:
+                error: "Bad Request"
+                message: "Invalid pagination cursor format provided."
+                code: "invalid_cursor"
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            TokenMissing:
+              value:
+                error: "Unauthorized"
+                message: "Authentication token is missing or invalid."
+                code: "auth_unauthorized"
+            TokenExpired:
+              value:
+                error: "Unauthorized"
+                message: "Authentication token has expired."
+                code: "auth_token_expired"
+    Forbidden:
+      description: Insufficient permissions
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            AccessDenied:
+              value:
+                error: "Forbidden"
+                message: "You do not have permission to access this resource."
+                code: "auth_forbidden"
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            ResourceNotFound:
+              value:
+                error: "Not Found"
+                message: "The requested subscription could not be found."
+                code: "resource_not_found"
   headers:
     Link:
       description: |
@@ -338,7 +362,9 @@ components:
         interval:
           type: string
         next_billing:
-          type: [string, 'null']
+          type: string
+          nullable: true
+          example: "2026-04-01T00:00:00Z"
     Error:
       type: object
       additionalProperties: false
@@ -478,62 +504,9 @@ components:
           type: string
           description: SHA-256 hex digest of the original request body, used to detect key reuse with a different payload.
           example: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  responses:
-    BadRequest:
-      description: Validation or client error
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
-          examples:
-            PaginationLimitExceeded:
-              value:
-                error: "Bad Request"
-                message: "Pagination limit cannot exceed 100 items."
-                code: "validation_error"
-            InvalidCursorFormat:
-              value:
-                error: "Bad Request"
-                message: "Invalid pagination cursor format provided."
-                code: "invalid_cursor"
-    Unauthorized:
-      description: Missing or invalid authentication
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
-          examples:
-            TokenMissing:
-              value:
-                error: "Unauthorized"
-                message: "Authentication token is missing or invalid."
-                code: "auth_unauthorized"
-            TokenExpired:
-              value:
-                error: "Unauthorized"
-                message: "Authentication token has expired."
-                code: "auth_token_expired"
-    Forbidden:
-      description: Insufficient permissions
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
-          examples:
-            AccessDenied:
-              value:
-                error: "Forbidden"
-                message: "You do not have permission to access this resource."
-                code: "auth_forbidden"
-    NotFound:
-      description: Resource not found
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
-          examples:
-            ResourceNotFound:
-              value:
-                error: "Not Found"
-                message: "The requested subscription could not be found."
-                code: "resource_not_found"
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT access token issued by the Stellabill identity provider.


### PR DESCRIPTION
## Overview

This PR ensures every OpenAPI operation has validated request/response examples and documents the `tools/openapi-lint` CI gate so missing or invalid examples fail before merge.

## Related Issue

Closes #693

## Changes

### 📄 OpenAPI Spec Examples

* **[MODIFY]** `openapi/openapi.yaml`
  * Backfill PATCH subscription request/response examples.
  * Merge duplicate `/api/v1/plans` path and `components.responses` keys so the document loads.
  * Convert OAS 3.1 `type: [string, 'null']` to OAS 3.0 `nullable: true`.
  * Add `components.securitySchemes.bearerAuth` referenced by authenticated operations.

* **[MODIFY]** `docs/OPENAPI_GUIDE.md`
  * Require request/response examples in the contributor checklist.
  * Document `go run ./tools/openapi-lint` for local and CI enforcement.

## Verification Results

```
go run ./tools/openapi-lint
✅ all operations in "openapi/openapi.yaml" have valid examples

go test ./tools/openapi-lint/ ./openapi/
✅ PASS
```

| Acceptance Criteria | Status |
| --- | --- |
| Every operation has at least one request/response example | ✅ Covered by openapi-lint |
| Examples validate against their schemas | ✅ Schema validation in lint tool |
| Lint fails CI when examples are missing/invalid | ✅ `go run ./tools/openapi-lint` in CI workflow |